### PR TITLE
Misc fixes to enable building/testing on manylinux2014 images.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,9 +106,12 @@ endif()
 # Python Configuration
 #-------------------------------------------------------------------------------
 
+set(NPCOMP_PYTHON_BINDINGS_VERSION_LOCKED 1 CACHE BOOL
+       "Links to specific python libraries, resolving all symbols.")
+
 # TODO(laurenzo): Rationalize with how this is done elsewhere
 find_package(PythonInterp REQUIRED)
-find_package(PythonLibs REQUIRED)
+find_package(PythonLibs)
 message(STATUS "Found python include dirs: ${PYTHON_INCLUDE_DIRS}")
 message(STATUS "Found ppython libraries: ${PYTHON_LIBRARIES}")
 find_package(pybind11 CONFIG REQUIRED)
@@ -125,6 +128,6 @@ add_custom_target(check-npcomp)
 
 add_subdirectory(include/npcomp)
 add_subdirectory(lib)
-add_subdirectory(python)
 add_subdirectory(tools)
+add_subdirectory(python)
 add_subdirectory(test)

--- a/lib/runtime/CMakeLists.txt
+++ b/lib/runtime/CMakeLists.txt
@@ -11,6 +11,9 @@ set(LLVM_OPTIONAL_SOURCES
 add_mlir_library(NPCOMPRuntime
   Runtime.cpp
 
+  LINK_LIBS
+  MLIRExecutionEngine
+
   EXCLUDE_FROM_LIBMLIR
 )
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -73,8 +73,13 @@ include(NpcompPython)
 # symbols, which is better for development.
 # TODO(laurenzo): Windows requires linking against the PYTHON_LIBRARIES
 # TODO(laurenzo): OSX requires allowing undefined (-undefined dynamic_lookup)
-set(NPCOMP_PYEXT_LINK_MODE SHARED)
-set(NPCOMP_PYEXT_LIBADD ${PYTHON_LIBRARIES})
+if(NPCOMP_PYTHON_BINDINGS_VERSION_LOCKED)
+  set(NPCOMP_PYEXT_LINK_MODE SHARED)
+  set(NPCOMP_PYEXT_LIBADD ${PYTHON_LIBRARIES})
+else()
+  set(NPCOMP_PYEXT_LINK_MODE MODULE)
+  set(NPCOMP_PYEXT_LIBADD)
+endif()
 
 if(NPCOMP_ENABLE_IREE)
   list(APPEND NPCOMP_PYEXT_LIBADD NPCOMPBackendIREEPythonModule)
@@ -86,10 +91,6 @@ if(NPCOMP_ENABLE_REFJIT)
   )
 endif()
 
-# TODO(laurenzo): Add a config setting to control this.
-# set(NPCOMP_PYEXT_LINK_MODE MODULE)
-# set(NPCOMP_PYEXT_LIBADD "")
-
 # When building the extension, distinguish between those sources that use
 # pybind (and need rtti/exceptions) and those that only use LLVM/MLIR.
 # Some of the low-level components do not support mixing RTTI modes and are
@@ -100,9 +101,6 @@ set(extension_llvm_sources
 set(extension_pybind_sources
   NpcompModule.cpp
 )
-set_source_files_properties(
-  ${extension_pybind_sources}
-  PROPERTIES COMPILE_FLAGS "${extension_cflags}")
 add_library(${extension_target} ${NPCOMP_PYEXT_LINK_MODE}
   ${extension_pybind_sources}
   ${extension_llvm_sources}
@@ -128,13 +126,13 @@ set_target_properties(${extension_target} PROPERTIES LINK_FLAGS
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
-# llvm_update_compile_flags(${extension_target})
 target_link_libraries(${extension_target}
   PRIVATE
-    ${dialect_libs}
-    ${conversion_libs}
-    NPCOMPInitAll
     NPCOMPPythonCommon
+    NPCOMPInitAll
+
+    ${conversion_libs}
+    ${dialect_libs}
 
     # Upstream depends
     LLVMSupport

--- a/tools/npcomp-opt/CMakeLists.txt
+++ b/tools/npcomp-opt/CMakeLists.txt
@@ -1,10 +1,10 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 set(LIBS
-        ${dialect_libs}
-        ${conversion_libs}
         MLIROptLib
         NPCOMPInitAll
+        ${conversion_libs}
+        ${dialect_libs}
 )
 add_llvm_executable(npcomp-opt npcomp-opt.cpp)
 

--- a/tools/npcomp-run-mlir/CMakeLists.txt
+++ b/tools/npcomp-run-mlir/CMakeLists.txt
@@ -11,8 +11,6 @@ llvm_update_compile_flags(npcomp-run-mlir)
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 target_link_libraries(npcomp-run-mlir PRIVATE
-  ${dialect_libs}
-  ${conversion_libs}
   MLIRAnalysis
   MLIREDSC
   MLIRExecutionEngine
@@ -24,6 +22,8 @@ target_link_libraries(npcomp-run-mlir PRIVATE
   MLIRSupport
   NPCOMPInitAll
   NPCOMPJITRuntime
+  ${conversion_libs}
+  ${dialect_libs}
   )
 add_dependencies(npcomp-run-mlir
   NPCOMPCompilerRuntimeShlib


### PR DESCRIPTION
* Since the manylinux images do not hard-link against python libs (resolving them at runtime), the module must be built without resolving undefined references.
* For some reason, builds on this platform are stricter, exposing dependency ordering issues.
* The CMake bits to build the extension are still somewhat of a mess. I have better versions both upstream and in IREE and will be reconciling. For now, don't look too closely.