### PR TITLE
[cmake] Updates for basic shared library support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,18 @@ endif()
 find_package(MLIR REQUIRED CONFIG)
 message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+#set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
+set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
+
+# Define the default arguments to use with 'lit', and an option for the user to
+# override.
+set(LIT_ARGS_DEFAULT "-sv")
+if (MSVC_IDE OR XCODE)
+  set(LIT_ARGS_DEFAULT "${LIT_ARGS_DEFAULT} --no-progress-bar")
+endif()
+set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" CACHE STRING "Default options for lit")
+
 list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 include(TableGen)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -29,6 +29,9 @@ if(NPCOMP_ENABLE_IREE)
   )
 endif()
 
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+
 add_mlir_library(NPCOMPInitAll
   InitAll.cpp
 
@@ -47,5 +50,7 @@ add_mlir_library(NPCOMPInitAll
   NPCOMPTCFPasses
   NPCOMPTypingPasses
 
+  ${dialect_libs}
+  ${conversion_libs}
   ${ALL_DEPENDS}
 )

--- a/lib/Dialect/Basicpy/IR/CMakeLists.txt
+++ b/lib/Dialect/Basicpy/IR/CMakeLists.txt
@@ -7,7 +7,8 @@ add_mlir_dialect_library(NPCOMPBasicpyDialect
 
   DEPENDS
   MLIRBasicpyOpsIncGen
-  NPCOMPTypingCPA
-)
 
-target_link_libraries(NPCOMPBasicpyDialect PUBLIC MLIRIR)
+  LINK_LIBS PUBLIC
+  NPCOMPTypingCPA
+  MLIRIR
+)

--- a/lib/Dialect/Numpy/IR/CMakeLists.txt
+++ b/lib/Dialect/Numpy/IR/CMakeLists.txt
@@ -6,8 +6,9 @@ add_mlir_dialect_library(NPCOMPNumpyDialect
   ${PROJECT_SOURCE_DIR}/include/npcomp/Dialect/Numpy
 
   DEPENDS
-  NPCOMPBasicpyDialect
   MLIRNumpyOpsIncGen
-)
 
-target_link_libraries(NPCOMPNumpyDialect PUBLIC MLIRIR)
+  LINK_LIBS PUBLIC
+  NPCOMPBasicpyDialect
+  MLIRIR
+)

--- a/lib/E2E/CMakeLists.txt
+++ b/lib/E2E/CMakeLists.txt
@@ -10,7 +10,6 @@ add_mlir_library(NPCOMPE2E
 
   DEPENDS
   NPCOMPE2EPassIncGen
-  MLIRLinalgOps
 
   LINK_COMPONENTS
   Core
@@ -22,3 +21,5 @@ add_mlir_library(NPCOMPE2E
   MLIRStandardToLLVM
   MLIRSCFToStandard
   )
+
+mlir_check_all_link_libraries(NPCOMPE2E)

--- a/lib/JITRuntime/CMakeLists.txt
+++ b/lib/JITRuntime/CMakeLists.txt
@@ -4,13 +4,13 @@ add_mlir_library(NPCOMPJITRuntime
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SRC_DIR}/include/npcomp/JITRuntime
 
-  DEPENDS
-  NPCOMPE2E
-  MLIRExecutionEngine
-
   LINK_COMPONENTS
   Core
 
   LINK_LIBS PUBLIC
   NPCOMPRuntime
+  NPCOMPE2E
+  MLIRExecutionEngine
   )
+
+mlir_check_all_link_libraries(NPCOMPE2E)

--- a/lib/Python/CMakeLists.txt
+++ b/lib/Python/CMakeLists.txt
@@ -40,7 +40,6 @@ target_link_libraries(NPCOMPPythonCommon
   MLIRSCF
 
   # Upstream depends
-  LLVMSupport
   MLIRDialect
   MLIREDSC
   MLIREDSCInterface
@@ -48,8 +47,8 @@ target_link_libraries(NPCOMPPythonCommon
   MLIRLLVMIR
   MLIRPass
   MLIRTransforms
-
-  ${ExtraInit_LIBADD}
 )
 
 npcomp_python_target_compile_options(NPCOMPPythonCommon)
+
+mlir_check_all_link_libraries(NPCOMPPythonCommon)

--- a/lib/runtime/CMakeLists.txt
+++ b/lib/runtime/CMakeLists.txt
@@ -17,6 +17,8 @@ add_mlir_library(NPCOMPRuntime
   EXCLUDE_FROM_LIBMLIR
 )
 
+mlir_check_all_link_libraries(NPCOMPRuntime)
+
 # The library that defines the symbols that the compiler emits references
 # to.
 # Note: is uses some of the same facilities that the user API depends on,
@@ -35,4 +37,3 @@ add_mlir_library(NPCOMPCompilerRuntimeShlib
 target_link_libraries(NPCOMPCompilerRuntimeShlib PRIVATE NPCOMPRuntime)
 set_target_properties(NPCOMPCompilerRuntimeShlib PROPERTIES LINK_FLAGS
     "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/unix_version.script")
-

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -135,7 +135,6 @@ target_link_libraries(${extension_target}
     ${dialect_libs}
 
     # Upstream depends
-    LLVMSupport
     MLIRAffineToStandard
     MLIRAffineTransforms
     MLIRDialect
@@ -152,3 +151,5 @@ target_link_libraries(${extension_target}
 )
 
 npcomp_python_target_compile_options(${extension_target})
+
+mlir_check_all_link_libraries(${extension_target})

--- a/tools/npcomp-opt/CMakeLists.txt
+++ b/tools/npcomp-opt/CMakeLists.txt
@@ -10,3 +10,5 @@ add_llvm_executable(npcomp-opt npcomp-opt.cpp)
 
 llvm_update_compile_flags(npcomp-opt)
 target_link_libraries(npcomp-opt PRIVATE ${LIBS})
+
+mlir_check_all_link_libraries(npcomp-opt)


### PR DESCRIPTION
Mostly this is CMake cleanup.  Several library dependencies are missing, which
is often revealed with shared library builds.