### PR TITLE
Bump submodule versions.

### DIFF
--- a/include/npcomp/Conversion/Passes.h
+++ b/include/npcomp/Conversion/Passes.h
@@ -1,4 +1,4 @@
-//===- Common.h - Common definitions for all dialects -----------*- C++ -*-===//
+//===------------------------------------------------------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,23 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef NPCOMP_DIALECT_COMMON_H
-#define NPCOMP_DIALECT_COMMON_H
-
-#include "mlir/IR/Types.h"
+#ifndef NPCOMP_CONVERSION_PASSES_H
+#define NPCOMP_CONVERSION_PASSES_H
 
 namespace mlir {
 namespace NPCOMP {
 
-namespace TypeRanges {
-enum {
-  Basicpy = Type::FIRST_PRIVATE_EXPERIMENTAL_3_TYPE,
-  Numpy = Basicpy + 50,
-  Npcomprt = Numpy + 50,
-};
-}
+/// Registers all NPCOMP conversion passes.
+void registerConversionPasses();
 
 } // namespace NPCOMP
 } // namespace mlir
 
-#endif // NPCOMP_DIALECT_COMMON_H
+#endif // NPCOMP_CONVERSION_PASSES_H

--- a/include/npcomp/Dialect/ATen/ATen.td
+++ b/include/npcomp/Dialect/ATen/ATen.td
@@ -14,15 +14,37 @@ include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "npcomp/Dialect/ATen/ATenOpInterface.td"
 
-def aten_Dialect : Dialect {
+//===----------------------------------------------------------------------===//
+// Dialect definition
+//===----------------------------------------------------------------------===//
+
+/// The ATenDialect models 'A Tensor library' from Pytorch.  The intention
+/// is to provide an abstraction which is isomorphic with datastructures
+/// returned from the pytorch jit, enabling integration with Pytorch models.
+/// Most of the actual operation definitions in tablegen are themselves
+/// generated from C APIs exported by Pytorch.
+def ATen_Dialect : Dialect {
   let name = "aten";
   let cppNamespace = "aten";
 }
 
+//===----------------------------------------------------------------------===//
+// Dialect types
+//===----------------------------------------------------------------------===//
+
+def ATen_ListType : DialectType<ATen_Dialect,
+    CPred<"$_self.isa<::mlir::NPCOMP::aten::ATenListType>()">, "ATen List">,
+    BuildableType<"$_builder.getType<::mlir::NPCOMP::aten::ATenListType()"> {
+  let typeDescription = [{
+    A variadic list of arguments in ATen.
+  }];
+}
+
 // TODO: convert to "let results =" style
+// TODO: Rename prefix from "aten" to "ATen" for consistency.
 
 class aten_Op<string mnemonic, list<OpTrait> traits = [StatisticsOpInterface]> :
-    Op<aten_Dialect, mnemonic, traits>;
+    Op<ATen_Dialect, mnemonic, traits>;
 
 
 // Most ops are automatically generated from pytorch specs.

--- a/include/npcomp/Dialect/ATen/ATenDialect.h
+++ b/include/npcomp/Dialect/ATen/ATenDialect.h
@@ -25,27 +25,6 @@ namespace mlir {
 namespace NPCOMP {
 namespace aten {
 
-/// The ATenDialect models 'A Tensor library' from Pytorch.  The intention
-/// is to provide an abstraction which is isomorphic with datastructures
-/// returned from the pytorch jit, enabling integration with Pytorch models.
-/// Most of the actual operation definitions in tablegen are themselves
-/// generated from C APIs exported by Pytorch.
-class ATenDialect : public mlir::Dialect {
-public:
-  explicit ATenDialect(mlir::MLIRContext *ctx);
-  static StringRef getDialectNamespace() { return "aten"; }
-
-  /// Parse a type registered to this dialect. Overridding this method is
-  /// required for dialects that have custom types.
-  /// Technically this is only needed to be able to round-trip to textual IR.
-  mlir::Type parseType(DialectAsmParser &parser) const override;
-
-  /// Print a type registered to this dialect. Overridding this method is
-  /// only required for dialects that have custom types.
-  /// Technically this is only needed to be able to round-trip to textual IR.
-  void printType(mlir::Type type, DialectAsmPrinter &os) const override;
-};
-
 ////////////////////////////////////////////////////////////////////////////////
 /////////////////////// Custom Types for the Dialect ///////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -53,13 +32,6 @@ public:
 namespace detail {
 struct ATenListTypeStorage;
 }
-
-/// LLVM-style RTTI: one entry per subclass to allow dyn_cast/isa.
-enum ATenTypeKind {
-  // The enum starts at the range reserved for this dialect.
-  ATEN_TYPE = mlir::Type::FIRST_PRIVATE_EXPERIMENTAL_0_TYPE,
-  ATEN_LIST,
-};
 
 /// A variadic list of arguments in ATen
 class ATenListType : public mlir::Type::TypeBase<ATenListType, mlir::Type,
@@ -72,9 +44,6 @@ public:
 
   /// Get the unique instance of this Type from the context.
   static ATenListType get(mlir::Type elementType);
-
-  /// Support method to enable LLVM-style RTTI type casting.
-  static bool kindof(unsigned kind) { return kind == ATenTypeKind::ATEN_LIST; }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -123,6 +92,8 @@ namespace aten {
 // include TableGen generated Op definitions
 #define GET_OP_CLASSES
 #include "npcomp/Dialect/ATen/ATen.h.inc"
+
+#include "npcomp/Dialect/ATen/ATenDialect.h.inc"
 
 } // namespace aten
 } // namespace NPCOMP

--- a/include/npcomp/Dialect/Basicpy/IR/BasicpyDialect.h
+++ b/include/npcomp/Dialect/Basicpy/IR/BasicpyDialect.h
@@ -12,29 +12,11 @@
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/Types.h"
-#include "npcomp/Dialect/Common.h"
 #include "npcomp/Typing/Analysis/CPA/Interfaces.h"
 
 namespace mlir {
 namespace NPCOMP {
 namespace Basicpy {
-
-namespace BasicpyTypes {
-enum Kind {
-  // Dialect types.
-  BoolType = TypeRanges::Basicpy,
-  BytesType,
-  EllipsisType,
-  NoneType,
-  SlotObjectType,
-  StrType,
-  UnknownType,
-
-  // Dialect attributes.
-  SingletonAttr,
-  LAST_BASICPY_TYPE = SingletonAttr,
-};
-} // namespace BasicpyTypes
 
 namespace detail {
 struct SlotObjectTypeStorage;
@@ -45,51 +27,34 @@ struct SlotObjectTypeStorage;
 class BoolType : public Type::TypeBase<BoolType, Type, TypeStorage> {
 public:
   using Base::Base;
-  static bool kindof(unsigned kind) { return kind == BasicpyTypes::BoolType; }
-  static BoolType get(MLIRContext *context) {
-    return Base::get(context, BasicpyTypes::BoolType);
-  }
+  static BoolType get(MLIRContext *context) { return Base::get(context); }
 };
 
 /// The type of the Python `bytes` values.
 class BytesType : public Type::TypeBase<BytesType, Type, TypeStorage> {
 public:
   using Base::Base;
-  static bool kindof(unsigned kind) { return kind == BasicpyTypes::BytesType; }
-  static BytesType get(MLIRContext *context) {
-    return Base::get(context, BasicpyTypes::BytesType);
-  }
+  static BytesType get(MLIRContext *context) { return Base::get(context); }
 };
 
 /// The type of the Python `Ellipsis` value.
 class EllipsisType : public Type::TypeBase<EllipsisType, Type, TypeStorage> {
 public:
   using Base::Base;
-  static bool kindof(unsigned kind) {
-    return kind == BasicpyTypes::EllipsisType;
-  }
-  static EllipsisType get(MLIRContext *context) {
-    return Base::get(context, BasicpyTypes::EllipsisType);
-  }
+  static EllipsisType get(MLIRContext *context) { return Base::get(context); }
 };
 
 /// The type of the Python `None` value.
 class NoneType : public Type::TypeBase<NoneType, Type, TypeStorage> {
 public:
   using Base::Base;
-  static bool kindof(unsigned kind) { return kind == BasicpyTypes::NoneType; }
-  static NoneType get(MLIRContext *context) {
-    return Base::get(context, BasicpyTypes::NoneType);
-  }
+  static NoneType get(MLIRContext *context) { return Base::get(context); }
 };
 
 class SlotObjectType : public Type::TypeBase<SlotObjectType, Type,
                                              detail::SlotObjectTypeStorage> {
 public:
   using Base::Base;
-  static bool kindof(unsigned kind) {
-    return kind == BasicpyTypes::SlotObjectType;
-  }
   static SlotObjectType get(StringAttr className, ArrayRef<Type> slotTypes);
   StringAttr getClassName();
   unsigned getSlotCount();
@@ -106,10 +71,7 @@ public:
 class StrType : public Type::TypeBase<StrType, Type, TypeStorage> {
 public:
   using Base::Base;
-  static bool kindof(unsigned kind) { return kind == BasicpyTypes::StrType; }
-  static StrType get(MLIRContext *context) {
-    return Base::get(context, BasicpyTypes::StrType);
-  }
+  static StrType get(MLIRContext *context) { return Base::get(context); }
 };
 
 /// An unknown type that could be any supported python type.
@@ -117,12 +79,7 @@ class UnknownType : public Type::TypeBase<UnknownType, Type, TypeStorage,
                                           NPCOMPTypingTypeMapInterface::Trait> {
 public:
   using Base::Base;
-  static bool kindof(unsigned kind) {
-    return kind == BasicpyTypes::UnknownType;
-  }
-  static UnknownType get(MLIRContext *context) {
-    return Base::get(context, BasicpyTypes::UnknownType);
-  }
+  static UnknownType get(MLIRContext *context) { return Base::get(context); }
 
   Typing::CPA::TypeNode *mapToCPAType(Typing::CPA::Context &context);
 };

--- a/include/npcomp/Dialect/Basicpy/Transforms/Passes.h
+++ b/include/npcomp/Dialect/Basicpy/Transforms/Passes.h
@@ -20,6 +20,10 @@ namespace Basicpy {
 std::unique_ptr<OperationPass<FuncOp>> createFunctionTypeInferencePass();
 
 } // namespace Basicpy
+
+/// Registers all Basicpy transformation passes.
+void registerBasicpyPasses();
+
 } // namespace NPCOMP
 } // namespace mlir
 

--- a/include/npcomp/Dialect/Npcomprt/IR/NpcomprtDialect.h
+++ b/include/npcomp/Dialect/Npcomprt/IR/NpcomprtDialect.h
@@ -10,27 +10,16 @@
 #define NPCOMP_DIALECT_NPCOMPRT_IR_NPCOMPRTDIALECT_H
 
 #include "mlir/IR/Dialect.h"
-#include "npcomp/Dialect/Common.h"
 
 namespace mlir {
 namespace NPCOMP {
 namespace npcomprt {
 
-namespace NpcomprtTypes {
-enum Kind { TensorType = TypeRanges::Npcomprt };
-} // namespace NpcomprtTypes
-
 class TensorType : public Type::TypeBase<TensorType, Type, TypeStorage> {
 public:
   using Base::Base;
 
-  static TensorType get(MLIRContext *context) {
-    return Base::get(context, NpcomprtTypes::Kind::TensorType);
-  }
-
-  static bool kindof(unsigned kind) {
-    return kind == NpcomprtTypes::Kind::TensorType;
-  }
+  static TensorType get(MLIRContext *context) { return Base::get(context); }
 };
 
 #include "npcomp/Dialect/Npcomprt/IR/NpcomprtOpsDialect.h.inc"

--- a/include/npcomp/Dialect/Numpy/IR/NumpyDialect.h
+++ b/include/npcomp/Dialect/Numpy/IR/NumpyDialect.h
@@ -11,20 +11,11 @@
 
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/StandardTypes.h"
-#include "npcomp/Dialect/Common.h"
 #include "npcomp/Typing/Analysis/CPA/Interfaces.h"
 
 namespace mlir {
 namespace NPCOMP {
 namespace Numpy {
-
-namespace NumpyTypes {
-enum Kind {
-  AnyDtypeType = TypeRanges::Numpy,
-  NdArray,
-  LAST_NUMPY_TYPE = AnyDtypeType,
-};
-} // namespace NumpyTypes
 
 namespace detail {
 struct NdArrayTypeStorage;
@@ -35,13 +26,7 @@ class AnyDtypeType : public Type::TypeBase<AnyDtypeType, Type, TypeStorage> {
 public:
   using Base::Base;
 
-  static AnyDtypeType get(MLIRContext *context) {
-    return Base::get(context, NumpyTypes::Kind::AnyDtypeType);
-  }
-
-  static bool kindof(unsigned kind) {
-    return kind == NumpyTypes::Kind::AnyDtypeType;
-  }
+  static AnyDtypeType get(MLIRContext *context) { return Base::get(context); }
 };
 
 class NdArrayType
@@ -49,7 +34,6 @@ class NdArrayType
                             NPCOMPTypingTypeMapInterface::Trait> {
 public:
   using Base::Base;
-  static bool kindof(unsigned kind) { return kind == NumpyTypes::NdArray; }
 
   /// Constructs an NdArray with a dtype and no shape. Setting the dtype
   /// to !basicpy.UnknownType will print as ?.

--- a/include/npcomp/Dialect/Numpy/Transforms/Passes.h
+++ b/include/npcomp/Dialect/Numpy/Transforms/Passes.h
@@ -20,6 +20,10 @@ namespace Numpy {
 std::unique_ptr<OperationPass<ModuleOp>> createPublicFunctionsToTensorPass();
 
 } // namespace Numpy
+
+/// Registers all Numpy transformation passes.
+void registerNumpyPasses();
+
 } // namespace NPCOMP
 } // namespace mlir
 

--- a/include/npcomp/Dialect/TCF/Transforms/Passes.h
+++ b/include/npcomp/Dialect/TCF/Transforms/Passes.h
@@ -20,6 +20,10 @@ namespace tcf {
 std::unique_ptr<OperationPass<FuncOp>> createShapeRefinementPass();
 
 } // namespace tcf
+
+/// Registers all TCF transformation passes.
+void registerTCFPasses();
+
 } // namespace NPCOMP
 } // namespace mlir
 

--- a/include/npcomp/E2E/E2E.h
+++ b/include/npcomp/E2E/E2E.h
@@ -15,6 +15,9 @@
 namespace mlir {
 namespace NPCOMP {
 
+/// Registers all E2E passes.
+void registerE2EPasses();
+
 // Look in createE2ELoweringPipeline for more information about how these
 // passes fit together.
 //

--- a/include/npcomp/InitAll.h
+++ b/include/npcomp/InitAll.h
@@ -9,10 +9,12 @@
 #ifndef NPCOMP_INITALL_H
 #define NPCOMP_INITALL_H
 
+#include "mlir/IR/Dialect.h"
+
 namespace mlir {
 namespace NPCOMP {
 
-void registerAllDialects();
+void registerAllDialects(mlir::DialectRegistry &registry);
 void registerAllPasses();
 
 } // namespace NPCOMP

--- a/include/npcomp/Python/MlirInit.h
+++ b/include/npcomp/Python/MlirInit.h
@@ -17,11 +17,19 @@
 // here for parts of the code that are not RTTI-compatible.
 
 namespace mlir {
+
+class MLIRContext;
+
 namespace npcomp {
 namespace python {
 
 // One time initialization.
 bool npcompMlirInitialize();
+
+// Loads globally registered dialects into the MLIRContext.
+// This is temporary until there is an upstream story for handling dialect
+// registration in python-based systems.
+void loadGlobalDialectsIntoContext(MLIRContext *context);
 
 } // namespace python
 } // namespace npcomp

--- a/include/npcomp/Python/MlirIr.h
+++ b/include/npcomp/Python/MlirIr.h
@@ -109,6 +109,7 @@ struct PyAttribute {
 
 /// Wrapper around MLIRContext.
 struct PyContext : std::enable_shared_from_this<PyContext> {
+  PyContext();
   static void bind(py::module m);
   PyModuleOp parseAsm(const std::string &asm_text);
   MLIRContext context;

--- a/include/npcomp/Typing/Transforms/Passes.h
+++ b/include/npcomp/Typing/Transforms/Passes.h
@@ -20,6 +20,10 @@ namespace Typing {
 std::unique_ptr<OperationPass<FuncOp>> createCPAFunctionTypeInferencePass();
 
 } // namespace Typing
+
+/// Registers all typing passes.
+void registerTypingPasses();
+
 } // namespace NPCOMP
 } // namespace mlir
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -46,6 +46,7 @@ add_mlir_library(NPCOMPInitAll
   NPCOMPATenDialect
   NPCOMPBasicpyDialect
   NPCOMPBasicpyPasses
+  NPCOMPConversionPasses
   NPCOMPNumpyDialect
   NPCOMPNumpyPasses
   NPCOMPTCFPasses

--- a/lib/Conversion/BasicpyToStd/CMakeLists.txt
+++ b/lib/Conversion/BasicpyToStd/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_conversion_library(BasicpyToSTD
+add_mlir_conversion_library(NPCOMPBasicpyToSTD
   Passes.cpp
   PrimitiveOpsConversion.cpp
 

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -6,3 +6,19 @@ add_subdirectory(TCPToLinalg)
 if(NPCOMP_ENABLE_IREE)
 add_subdirectory(BasicpyToIREEVM)
 endif()
+
+add_mlir_library(NPCOMPConversionPasses
+  Passes.cpp
+
+  DEPENDS
+  NPCOMPConversionPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  NPCOMPBasicpyToSTD
+  NPCOMPNumpyToTCF
+  NPCOMPTCFToTCP
+  NPCOMPTCPToLinalg
+)

--- a/lib/Conversion/NumpyToTCF/CMakeLists.txt
+++ b/lib/Conversion/NumpyToTCF/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_mlir_conversion_library(BasicpyToIREEVM
+add_mlir_conversion_library(NPCOMPNumpyToTCF
   Passes.cpp
 
   DEPENDS

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "npcomp/Conversion/Passes.h"
+
+#include "npcomp/Conversion/BasicpyToStd/Passes.h"
+#include "npcomp/Conversion/NumpyToTCF/Passes.h"
+#include "npcomp/Conversion/TCFToTCP/TCFToTCP.h"
+#include "npcomp/Conversion/TCPToLinalg/TCPToLinalg.h"
+
+//===----------------------------------------------------------------------===//
+// Pass registration
+//===----------------------------------------------------------------------===//
+
+namespace {
+#define GEN_PASS_REGISTRATION
+#include "npcomp/Conversion/Passes.h.inc"
+} // end namespace
+
+void mlir::NPCOMP::registerConversionPasses() { ::registerPasses(); }

--- a/lib/Dialect/ATen/ATenDialect.cpp
+++ b/lib/Dialect/ATen/ATenDialect.cpp
@@ -46,7 +46,7 @@ private:
 } // namespace detail
 
 ATenListType ATenListType::get(mlir::Type elemType) {
-  return Base::get(elemType.getContext(), ATenTypeKind::ATEN_LIST, elemType);
+  return Base::get(elemType.getContext(), elemType);
 }
 
 mlir::Type ATenListType::getElementType() {
@@ -89,7 +89,7 @@ void ATenDialect::printType(mlir::Type type, DialectAsmPrinter &os) const {
   os << ">";
 }
 
-ATenDialect::ATenDialect(mlir::MLIRContext *ctx) : mlir::Dialect("aten", ctx) {
+void ATenDialect::initialize() {
   addTypes<ATenListType>();
   addOperations<
 #define GET_OP_LIST

--- a/lib/Dialect/Basicpy/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Basicpy/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_conversion_library(NPCOMPBasicpyPasses
+  Passes.cpp
   TypeInference.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/Basicpy/Transforms/Passes.cpp
+++ b/lib/Dialect/Basicpy/Transforms/Passes.cpp
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "npcomp/Dialect/Basicpy/Transforms/Passes.h"
+
+//===----------------------------------------------------------------------===//
+// Pass registration
+//===----------------------------------------------------------------------===//
+
+namespace {
+#define GEN_PASS_REGISTRATION
+#include "npcomp/Dialect/Basicpy/Transforms/Passes.h.inc"
+} // end namespace
+
+void mlir::NPCOMP::registerBasicpyPasses() { ::registerPasses(); }

--- a/lib/Dialect/Npcomprt/IR/NpcomprtDialect.cpp
+++ b/lib/Dialect/Npcomprt/IR/NpcomprtDialect.cpp
@@ -9,12 +9,12 @@
 #include "npcomp/Dialect/Npcomprt/IR/NpcomprtDialect.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "npcomp/Dialect/Npcomprt/IR/NpcomprtOps.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
 using namespace mlir::NPCOMP::npcomprt;
 
-NpcomprtDialect::NpcomprtDialect(MLIRContext *context)
-    : Dialect(getDialectNamespace(), context) {
+void NpcomprtDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "npcomp/Dialect/Npcomprt/IR/NpcomprtOps.cpp.inc"
@@ -36,11 +36,8 @@ Type NpcomprtDialect::parseType(DialectAsmParser &parser) const {
 }
 
 void NpcomprtDialect::printType(Type type, DialectAsmPrinter &os) const {
-  switch (type.getKind()) {
-  case NpcomprtTypes::Kind::TensorType:
-    os << "tensor";
-    return;
-  default:
-    llvm_unreachable("unexpected 'npcomprt' type kind");
-  }
+  TypeSwitch<Type>(type)
+      .Case<NPCOMP::npcomprt::TensorType>([&](Type) { os << "tensor"; })
+      .Default(
+          [&](Type) { llvm_unreachable("unexpected 'npcomprt' type kind"); });
 }

--- a/lib/Dialect/Numpy/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Numpy/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_conversion_library(NPCOMPNumpyPasses
+  Passes.cpp
   PublicFunctionToTensor.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/Numpy/Transforms/Passes.cpp
+++ b/lib/Dialect/Numpy/Transforms/Passes.cpp
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "npcomp/Dialect/Numpy/Transforms/Passes.h"
+
+//===----------------------------------------------------------------------===//
+// Pass registration
+//===----------------------------------------------------------------------===//
+
+namespace {
+#define GEN_PASS_REGISTRATION
+#include "npcomp/Dialect/Numpy/Transforms/Passes.h.inc"
+} // end namespace
+
+void mlir::NPCOMP::registerNumpyPasses() { ::registerPasses(); }

--- a/lib/Dialect/TCF/IR/TCFDialect.cpp
+++ b/lib/Dialect/TCF/IR/TCFDialect.cpp
@@ -12,8 +12,7 @@
 using namespace mlir;
 using namespace mlir::NPCOMP::tcf;
 
-TCFDialect::TCFDialect(MLIRContext *context)
-    : Dialect(getDialectNamespace(), context) {
+void TCFDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "npcomp/Dialect/TCF/IR/TCFOps.cpp.inc"

--- a/lib/Dialect/TCF/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TCF/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_conversion_library(NPCOMPTCFPasses
+  Passes.cpp
   ShapeRefinement.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/TCF/Transforms/Passes.cpp
+++ b/lib/Dialect/TCF/Transforms/Passes.cpp
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "npcomp/Dialect/TCF/Transforms/Passes.h"
+
+//===----------------------------------------------------------------------===//
+// Pass registration
+//===----------------------------------------------------------------------===//
+
+namespace {
+#define GEN_PASS_REGISTRATION
+#include "npcomp/Dialect/TCF/Transforms/Passes.h.inc"
+} // end namespace
+
+void mlir::NPCOMP::registerTCFPasses() { ::registerPasses(); }

--- a/lib/Dialect/TCP/IR/TCPDialect.cpp
+++ b/lib/Dialect/TCP/IR/TCPDialect.cpp
@@ -12,8 +12,7 @@
 using namespace mlir;
 using namespace mlir::NPCOMP::tcp;
 
-TCPDialect::TCPDialect(MLIRContext *context)
-    : Dialect(getDialectNamespace(), context) {
+void TCPDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "npcomp/Dialect/TCP/IR/TCPOps.cpp.inc"

--- a/lib/E2E/E2E.cpp
+++ b/lib/E2E/E2E.cpp
@@ -61,6 +61,27 @@ using namespace mlir;
 using namespace mlir::NPCOMP;
 
 //===----------------------------------------------------------------------===//
+// Pass registration
+//===----------------------------------------------------------------------===//
+
+namespace {
+#define GEN_PASS_REGISTRATION
+#include "npcomp/E2E/Passes.h.inc"
+} // end namespace
+
+void mlir::NPCOMP::registerE2EPasses() {
+  ::registerPasses();
+
+  mlir::PassPipelineRegistration<E2ELoweringPipelineOptions>(
+      "e2e-lowering-pipeline", "E2E lowering pipeline.",
+      mlir::NPCOMP::createE2ELoweringPipeline);
+  mlir::PassPipelineRegistration<>(
+      "lower-to-hybrid-tensor-memref-pipeline",
+      "Pipeline lowering to hybrid tensor/memref.",
+      mlir::NPCOMP::createLowerToHybridTensorMemRefPipeline);
+}
+
+//===----------------------------------------------------------------------===//
 // ResolveShapeOfOps
 //===----------------------------------------------------------------------===//
 

--- a/lib/Python/CMakeLists.txt
+++ b/lib/Python/CMakeLists.txt
@@ -42,7 +42,6 @@ target_link_libraries(NPCOMPPythonCommon
   # Upstream depends
   MLIRDialect
   MLIREDSC
-  MLIREDSCInterface
   MLIRIR
   MLIRLLVMIR
   MLIRPass

--- a/lib/Typing/Transforms/CMakeLists.txt
+++ b/lib/Typing/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_conversion_library(NPCOMPTypingPasses
+  Passes.cpp
   CPATypeInference.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Typing/Transforms/Passes.cpp
+++ b/lib/Typing/Transforms/Passes.cpp
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "npcomp/Typing/Transforms/Passes.h"
+
+//===----------------------------------------------------------------------===//
+// Pass registration
+//===----------------------------------------------------------------------===//
+
+namespace {
+#define GEN_PASS_REGISTRATION
+#include "npcomp/Typing/Transforms/Passes.h.inc"
+} // end namespace
+
+void mlir::NPCOMP::registerTypingPasses() { ::registerPasses(); }

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -140,7 +140,6 @@ target_link_libraries(${extension_target}
     MLIRAffineTransforms
     MLIRDialect
     MLIREDSC
-    MLIREDSCInterface
     MLIRIR
     MLIRSCFToStandard
     MLIRLLVMIR

--- a/test/E2E/lower-to-llvm-global.mlir
+++ b/test/E2E/lower-to-llvm-global.mlir
@@ -1,22 +1,50 @@
 // RUN: npcomp-opt -e2e-lower-to-llvm -split-input-file <%s | FileCheck %s --dump-input=fail
 
-// CHECK:         llvm.mlir.global internal constant @__npcomprt_global_data_buffer_g(dense<7.000000e+00> : tensor<3xf32>) : !llvm<"[3 x float]">
-// CHECK:         llvm.mlir.global internal constant @__npcomprt_global_extents_g(dense<3> : tensor<1xi32>) : !llvm<"[1 x i32]">
-// CHECK-LABEL:   llvm.mlir.global internal constant @g() : !llvm<"{ i32, i32*, i8* }"> {
-// CHECK:           %[[VAL_0:.*]] = llvm.mlir.undef : !llvm<"{ i32, i32*, i8* }">
+// CHECK-LABEL:   llvm.func @malloc(!llvm.i64) -> !llvm.ptr<i8>
+// CHECK:         llvm.func @__npcomp_compiler_rt_abort_if(!llvm.i1)
+// CHECK:         llvm.func @__npcomp_compiler_rt_get_extent(!llvm.ptr<i8>, !llvm.i32) -> !llvm.i64
+// CHECK:         llvm.func @__npcomp_compiler_rt_to_memref(!llvm.ptr<i8>) -> !llvm.struct<(i64, ptr<i8>)>
+// CHECK:         llvm.func @__npcomp_compiler_rt_from_memref(!llvm.i64, !llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:         llvm.func @__npcomp_compiler_rt_get_global(!llvm.ptr<struct<(i32, ptr<i32>, ptr<i8>)>>) -> !llvm.struct<(i64, ptr<i8>)>
+// CHECK:         llvm.mlir.global internal constant @__npcomprt_global_data_buffer_g(dense<7.000000e+00> : tensor<3xf32>) : !llvm.array<3 x float>
+// CHECK:         llvm.mlir.global internal constant @__npcomprt_global_extents_g(dense<3> : tensor<1xi32>) : !llvm.array<1 x i32>
+
+// CHECK-LABEL:   llvm.mlir.global internal constant @g() : !llvm.struct<(i32, ptr<i32>, ptr<i8>)> {
+// CHECK:           %[[VAL_0:.*]] = llvm.mlir.undef : !llvm.struct<(i32, ptr<i32>, ptr<i8>)>
 // CHECK:           %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : !llvm.i32
-// CHECK:           %[[VAL_2:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_0]][0 : i32] : !llvm<"{ i32, i32*, i8* }">
-// CHECK:           %[[VAL_3:.*]] = llvm.mlir.addressof @__npcomprt_global_extents_g : !llvm<"[1 x i32]*">
-// CHECK:           %[[VAL_4:.*]] = llvm.bitcast %[[VAL_3]] : !llvm<"[1 x i32]*"> to !llvm<"i32*">
-// CHECK:           %[[VAL_5:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_2]][1 : i32] : !llvm<"{ i32, i32*, i8* }">
-// CHECK:           %[[VAL_6:.*]] = llvm.mlir.addressof @__npcomprt_global_data_buffer_g : !llvm<"[3 x float]*">
-// CHECK:           %[[VAL_7:.*]] = llvm.bitcast %[[VAL_6]] : !llvm<"[3 x float]*"> to !llvm<"i8*">
-// CHECK:           %[[VAL_8:.*]] = llvm.insertvalue %[[VAL_7]], %[[VAL_5]][2 : i32] : !llvm<"{ i32, i32*, i8* }">
-// CHECK:           llvm.return %[[VAL_8]] : !llvm<"{ i32, i32*, i8* }">
+// CHECK:           %[[VAL_2:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_0]][0 : i32] : !llvm.struct<(i32, ptr<i32>, ptr<i8>)>
+// CHECK:           %[[VAL_3:.*]] = llvm.mlir.addressof @__npcomprt_global_extents_g : !llvm.ptr<array<1 x i32>>
+// CHECK:           %[[VAL_4:.*]] = llvm.bitcast %[[VAL_3]] : !llvm.ptr<array<1 x i32>> to !llvm.ptr<i32>
+// CHECK:           %[[VAL_5:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_2]][1 : i32] : !llvm.struct<(i32, ptr<i32>, ptr<i8>)>
+// CHECK:           %[[VAL_6:.*]] = llvm.mlir.addressof @__npcomprt_global_data_buffer_g : !llvm.ptr<array<3 x float>>
+// CHECK:           %[[VAL_7:.*]] = llvm.bitcast %[[VAL_6]] : !llvm.ptr<array<3 x float>> to !llvm.ptr<i8>
+// CHECK:           %[[VAL_8:.*]] = llvm.insertvalue %[[VAL_7]], %[[VAL_5]][2 : i32] : !llvm.struct<(i32, ptr<i32>, ptr<i8>)>
+// CHECK:           llvm.return %[[VAL_8]] : !llvm.struct<(i32, ptr<i32>, ptr<i8>)>
 // CHECK:         }
-// CHECK-LABEL:   llvm.func @calls_get_global() -> !llvm<"{ i64, i8* }"> {
-// CHECK:           %[[VAL_0:.*]] = llvm.mlir.addressof @g : !llvm<"{ i32, i32*, i8* }*">
-// CHECK:           %[[VAL_1:.*]] = llvm.call @__npcomp_compiler_rt_get_global(%[[VAL_0]]) : (!llvm<"{ i32, i32*, i8* }*">) -> !llvm<"{ i64, i8* }">
+
+// CHECK-LABEL:   llvm.func @calls_get_global() -> !llvm.struct<(i64, ptr<i8>)> {
+// CHECK:           %[[VAL_0:.*]] = llvm.mlir.addressof @g : !llvm.ptr<struct<(i32, ptr<i32>, ptr<i8>)>>
+// CHECK:           %[[VAL_1:.*]] = llvm.call @__npcomp_compiler_rt_get_global(%[[VAL_0]]) : (!llvm.ptr<struct<(i32, ptr<i32>, ptr<i8>)>>) -> !llvm.struct<(i64, ptr<i8>)>
+// CHECK:           %[[VAL_2:.*]] = llvm.mlir.constant(1 : index) : !llvm.i64
+// CHECK:           %[[VAL_3:.*]] = llvm.mlir.constant(2 : index) : !llvm.i64
+// CHECK:           %[[VAL_4:.*]] = llvm.mlir.constant(8 : index) : !llvm.i64
+// CHECK:           %[[VAL_5:.*]] = llvm.mlir.constant(8 : index) : !llvm.i64
+// CHECK:           %[[VAL_6:.*]] = llvm.mul %[[VAL_3]], %[[VAL_4]] : !llvm.i64
+// CHECK:           %[[VAL_7:.*]] = llvm.extractvalue %[[VAL_1]][0] : !llvm.struct<(i64, ptr<i8>)>
+// CHECK:           %[[VAL_8:.*]] = llvm.mul %[[VAL_3]], %[[VAL_7]] : !llvm.i64
+// CHECK:           %[[VAL_9:.*]] = llvm.add %[[VAL_8]], %[[VAL_2]] : !llvm.i64
+// CHECK:           %[[VAL_10:.*]] = llvm.mul %[[VAL_9]], %[[VAL_5]] : !llvm.i64
+// CHECK:           %[[VAL_11:.*]] = llvm.add %[[VAL_6]], %[[VAL_10]] : !llvm.i64
+// CHECK:           %[[VAL_12:.*]] = llvm.mlir.constant(false) : !llvm.i1
+// CHECK:           %[[VAL_13:.*]] = llvm.call @malloc(%[[VAL_11]]) : (!llvm.i64) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_14:.*]] = llvm.extractvalue %[[VAL_1]][1] : !llvm.struct<(i64, ptr<i8>)>
+// CHECK:           "llvm.intr.memcpy"(%[[VAL_13]], %[[VAL_14]], %[[VAL_11]], %[[VAL_12]]) : (!llvm.ptr<i8>, !llvm.ptr<i8>, !llvm.i64, !llvm.i1) -> ()
+// CHECK:           %[[VAL_15:.*]] = llvm.mlir.undef : !llvm.struct<(i64, ptr<i8>)>
+// CHECK:           %[[VAL_16:.*]] = llvm.extractvalue %[[VAL_1]][0] : !llvm.struct<(i64, ptr<i8>)>
+// CHECK:           %[[VAL_17:.*]] = llvm.insertvalue %[[VAL_16]], %[[VAL_15]][0] : !llvm.struct<(i64, ptr<i8>)>
+// CHECK:           %[[VAL_18:.*]] = llvm.insertvalue %[[VAL_13]], %[[VAL_17]][1] : !llvm.struct<(i64, ptr<i8>)>
+// CHECK:           llvm.return %[[VAL_18]] : !llvm.struct<(i64, ptr<i8>)>
+// CHECK:         }
 npcomprt.global @g dense<7.000000e+00> : tensor<3xf32>
 func @calls_get_global() -> memref<*xf32> {
   %0 = npcomprt.get_global @g : memref<*xf32>
@@ -26,7 +54,7 @@ func @calls_get_global() -> memref<*xf32> {
 // -----
 
 // For scalars, we have to fake-up a size-1 data buffer array to make LLVM translation happy.
-// CHECK: llvm.mlir.global internal constant @__npcomprt_global_data_buffer_g(dense<7.000000e+00> : tensor<f32>) : !llvm<"[1 x float]">     
-// CHECK: llvm.mlir.global internal constant @__npcomprt_global_extents_g(dense<0> : tensor<1xi32>) : !llvm<"[1 x i32]">
+// CHECK: llvm.mlir.global internal constant @__npcomprt_global_data_buffer_g(dense<7.000000e+00> : tensor<f32>) : !llvm.array<1 x float>
+// CHECK: llvm.mlir.global internal constant @__npcomprt_global_extents_g(dense<0> : tensor<1xi32>) : !llvm.array<1 x i32>
 npcomprt.global @g dense<7.0> : tensor<f32>
 

--- a/test/E2E/lower-to-llvm.mlir
+++ b/test/E2E/lower-to-llvm.mlir
@@ -1,47 +1,52 @@
 // RUN: npcomp-opt -e2e-lower-to-llvm -split-input-file <%s | FileCheck %s --dump-input=fail
 
 // CHECK-LABEL:   llvm.func @__npcomprt_wrapper_identity(
-// CHECK-SAME:                                            %[[VAL_0:.*]]: !llvm<"i8**">,
-// CHECK-SAME:                                            %[[VAL_1:.*]]: !llvm<"i8**">) {
+// CHECK-SAME:                                           %[[VAL_0:.*]]: !llvm.ptr<ptr<i8>>,
+// CHECK-SAME:                                           %[[VAL_1:.*]]: !llvm.ptr<ptr<i8>>) {
 // CHECK:           %[[VAL_2:.*]] = llvm.mlir.constant(0 : i32) : !llvm.i32
-// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm<"i8**">, !llvm.i32) -> !llvm<"i8*">
-// CHECK:           %[[VAL_4:.*]] = llvm.bitcast %[[VAL_3]] : !llvm<"i8*"> to !llvm<"i8**">
-// CHECK:           %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm<"i8**">
-// CHECK:           %[[VAL_6:.*]] = llvm.call @identity(%[[VAL_5]]) : (!llvm<"i8*">) -> !llvm<"i8*">
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<ptr<i8>>, !llvm.i32) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_4:.*]] = llvm.bitcast %[[VAL_3]] : !llvm.ptr<i8> to !llvm.ptr<ptr<i8>>
+// CHECK:           %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<ptr<i8>>
+// CHECK:           %[[VAL_6:.*]] = llvm.call @identity(%[[VAL_5]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_7:.*]] = llvm.mlir.constant(0 : i32) : !llvm.i32
-// CHECK:           %[[VAL_8:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_7]]] : (!llvm<"i8**">, !llvm.i32) -> !llvm<"i8*">
-// CHECK:           %[[VAL_9:.*]] = llvm.bitcast %[[VAL_8]] : !llvm<"i8*"> to !llvm<"i8**">
-// CHECK:           llvm.store %[[VAL_6]], %[[VAL_9]] : !llvm<"i8**">
+// CHECK:           %[[VAL_8:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_7]]] : (!llvm.ptr<ptr<i8>>, !llvm.i32) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = llvm.bitcast %[[VAL_8]] : !llvm.ptr<i8> to !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.store %[[VAL_6]], %[[VAL_9]] : !llvm.ptr<ptr<i8>>
 // CHECK:           llvm.return
 // CHECK:         }
-
+// CHECK:         llvm.func @__npcomp_compiler_rt_abort_if(!llvm.i1)
+// CHECK:         llvm.func @__npcomp_compiler_rt_get_extent(!llvm.ptr<i8>, !llvm.i32) -> !llvm.i64
+// CHECK:         llvm.func @__npcomp_compiler_rt_to_memref(!llvm.ptr<i8>) -> !llvm.struct<(i64, ptr<i8>)>
+// CHECK:         llvm.func @__npcomp_compiler_rt_from_memref(!llvm.i64, !llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:         llvm.func @__npcomp_compiler_rt_get_global(!llvm.ptr<struct<(i32, ptr<i32>, ptr<i8>)>>) -> !llvm.struct<(i64, ptr<i8>)>
 // CHECK:         llvm.mlir.global internal constant @__npcomp_internal_constant_identity("identity")
-// CHECK-LABEL:   llvm.mlir.global internal constant @__npcomp_func_descriptors() : !llvm<"[1 x { i32, i8*, i8*, i32, i32 }]"> {
-// CHECK:           %[[VAL_0:.*]] = llvm.mlir.undef : !llvm<"[1 x { i32, i8*, i8*, i32, i32 }]">
+
+// CHECK-LABEL:   llvm.mlir.global internal constant @__npcomp_func_descriptors() : !llvm.array<1 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>> {
+// CHECK:           %[[VAL_0:.*]] = llvm.mlir.undef : !llvm.array<1 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
 // CHECK:           %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : !llvm.i32
 // CHECK:           %[[VAL_2:.*]] = llvm.mlir.constant(8 : i32) : !llvm.i32
-// CHECK:           %[[VAL_3:.*]] = llvm.insertvalue %[[VAL_2]], %[[VAL_0]][0 : i32, 0 : i32] : !llvm<"[1 x { i32, i8*, i8*, i32, i32 }]">
-// CHECK:           %[[VAL_4:.*]] = llvm.mlir.addressof @__npcomp_internal_constant_identity : !llvm<"[8 x i8]*">
-// CHECK:           %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_4]]{{\[}}%[[VAL_1]], %[[VAL_1]]] : (!llvm<"[8 x i8]*">, !llvm.i32, !llvm.i32) -> !llvm<"i8*">
-// CHECK:           %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_5]], %[[VAL_3]][0 : i32, 1 : i32] : !llvm<"[1 x { i32, i8*, i8*, i32, i32 }]">
-// CHECK:           %[[VAL_7:.*]] = llvm.mlir.addressof @__npcomprt_wrapper_identity : !llvm<"void (i8**, i8**)*">
-// CHECK:           %[[VAL_8:.*]] = llvm.bitcast %[[VAL_7]] : !llvm<"void (i8**, i8**)*"> to !llvm<"i8*">
-// CHECK:           %[[VAL_9:.*]] = llvm.insertvalue %[[VAL_8]], %[[VAL_6]][0 : i32, 2 : i32] : !llvm<"[1 x { i32, i8*, i8*, i32, i32 }]">
+// CHECK:           %[[VAL_3:.*]] = llvm.insertvalue %[[VAL_2]], %[[VAL_0]][0 : i32, 0 : i32] : !llvm.array<1 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
+// CHECK:           %[[VAL_4:.*]] = llvm.mlir.addressof @__npcomp_internal_constant_identity : !llvm.ptr<array<8 x i8>>
+// CHECK:           %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_4]]{{\[}}%[[VAL_1]], %[[VAL_1]]] : (!llvm.ptr<array<8 x i8>>, !llvm.i32, !llvm.i32) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_5]], %[[VAL_3]][0 : i32, 1 : i32] : !llvm.array<1 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
+// CHECK:           %[[VAL_7:.*]] = llvm.mlir.addressof @__npcomprt_wrapper_identity : !llvm.ptr<func<void (ptr<ptr<i8>>, ptr<ptr<i8>>)>>
+// CHECK:           %[[VAL_8:.*]] = llvm.bitcast %[[VAL_7]] : !llvm.ptr<func<void (ptr<ptr<i8>>, ptr<ptr<i8>>)>> to !llvm.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = llvm.insertvalue %[[VAL_8]], %[[VAL_6]][0 : i32, 2 : i32] : !llvm.array<1 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
 // CHECK:           %[[VAL_10:.*]] = llvm.mlir.constant(1 : i32) : !llvm.i32
-// CHECK:           %[[VAL_11:.*]] = llvm.insertvalue %[[VAL_10]], %[[VAL_9]][0 : i32, 3 : i32] : !llvm<"[1 x { i32, i8*, i8*, i32, i32 }]">
+// CHECK:           %[[VAL_11:.*]] = llvm.insertvalue %[[VAL_10]], %[[VAL_9]][0 : i32, 3 : i32] : !llvm.array<1 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
 // CHECK:           %[[VAL_12:.*]] = llvm.mlir.constant(1 : i32) : !llvm.i32
-// CHECK:           %[[VAL_13:.*]] = llvm.insertvalue %[[VAL_12]], %[[VAL_11]][0 : i32, 4 : i32] : !llvm<"[1 x { i32, i8*, i8*, i32, i32 }]">
-// CHECK:           llvm.return %[[VAL_13]] : !llvm<"[1 x { i32, i8*, i8*, i32, i32 }]">
+// CHECK:           %[[VAL_13:.*]] = llvm.insertvalue %[[VAL_12]], %[[VAL_11]][0 : i32, 4 : i32] : !llvm.array<1 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
+// CHECK:           llvm.return %[[VAL_13]] : !llvm.array<1 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
 // CHECK:         }
 
-// CHECK-LABEL:   llvm.mlir.global external constant @_mlir___npcomp_module_descriptor() : !llvm<"{ i32, { i32, i8*, i8*, i32, i32 }* }"> {
-// CHECK:           %[[VAL_0:.*]] = llvm.mlir.undef : !llvm<"{ i32, { i32, i8*, i8*, i32, i32 }* }">
+// CHECK-LABEL:   llvm.mlir.global external constant @_mlir___npcomp_module_descriptor() : !llvm.struct<(i32, ptr<struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>)> {
+// CHECK:           %[[VAL_0:.*]] = llvm.mlir.undef : !llvm.struct<(i32, ptr<struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>)>
 // CHECK:           %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : !llvm.i32
-// CHECK:           %[[VAL_2:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_0]][0 : i32] : !llvm<"{ i32, { i32, i8*, i8*, i32, i32 }* }">
-// CHECK:           %[[VAL_3:.*]] = llvm.mlir.addressof @__npcomp_func_descriptors : !llvm<"[1 x { i32, i8*, i8*, i32, i32 }]*">
-// CHECK:           %[[VAL_4:.*]] = llvm.bitcast %[[VAL_3]] : !llvm<"[1 x { i32, i8*, i8*, i32, i32 }]*"> to !llvm<"{ i32, i8*, i8*, i32, i32 }*">
-// CHECK:           %[[VAL_5:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_2]][1 : i32] : !llvm<"{ i32, { i32, i8*, i8*, i32, i32 }* }">
-// CHECK:           llvm.return %[[VAL_5]] : !llvm<"{ i32, { i32, i8*, i8*, i32, i32 }* }">
+// CHECK:           %[[VAL_2:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_0]][0 : i32] : !llvm.struct<(i32, ptr<struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>)>
+// CHECK:           %[[VAL_3:.*]] = llvm.mlir.addressof @__npcomp_func_descriptors : !llvm.ptr<array<1 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>>
+// CHECK:           %[[VAL_4:.*]] = llvm.bitcast %[[VAL_3]] : !llvm.ptr<array<1 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>> to !llvm.ptr<struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
+// CHECK:           %[[VAL_5:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_2]][1 : i32] : !llvm.struct<(i32, ptr<struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>)>
+// CHECK:           llvm.return %[[VAL_5]] : !llvm.struct<(i32, ptr<struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>)>
 // CHECK:         }
 
 npcomprt.module_metadata {
@@ -49,9 +54,11 @@ npcomprt.module_metadata {
 }
 
 
-// CHECK-LABEL: llvm.func @identity(%arg0: !llvm<"i8*">) -> !llvm<"i8*">
+// CHECK-LABEL:   llvm.func @identity(
+// CHECK-SAME:                        %[[VAL_0:.*]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
+// CHECK:           llvm.return %[[VAL_0]] : !llvm.ptr<i8>
+// CHECK:         }
 func @identity(%arg0: !npcomprt.tensor) -> !npcomprt.tensor {
-// CHECK-NEXT: llvm.return %arg0 : !llvm<"i8*">
   return %arg0 : !npcomprt.tensor
 }
 
@@ -60,95 +67,110 @@ func @identity(%arg0: !npcomprt.tensor) -> !npcomprt.tensor {
 // Test input/output arg marshaling.
 
 // CHECK-LABEL:   llvm.func @__npcomprt_wrapper_inputs1results2(
-// CHECK-SAME:                                                   %[[VAL_0:.*]]: !llvm<"i8**">,
-// CHECK-SAME:                                                   %[[VAL_1:.*]]: !llvm<"i8**">) {
+// CHECK-SAME:                                                  %[[VAL_0:.*]]: !llvm.ptr<ptr<i8>>,
+// CHECK-SAME:                                                  %[[VAL_1:.*]]: !llvm.ptr<ptr<i8>>) {
 // CHECK:           %[[VAL_2:.*]] = llvm.mlir.constant(0 : i32) : !llvm.i32
-// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm<"i8**">, !llvm.i32) -> !llvm<"i8*">
-// CHECK:           %[[VAL_4:.*]] = llvm.bitcast %[[VAL_3]] : !llvm<"i8*"> to !llvm<"i8**">
-// CHECK:           %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm<"i8**">
-// CHECK:           %[[VAL_6:.*]] = llvm.call @inputs1results2(%[[VAL_5]]) : (!llvm<"i8*">) -> !llvm<"{ i8*, i8* }">
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<ptr<i8>>, !llvm.i32) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_4:.*]] = llvm.bitcast %[[VAL_3]] : !llvm.ptr<i8> to !llvm.ptr<ptr<i8>>
+// CHECK:           %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<ptr<i8>>
+// CHECK:           %[[VAL_6:.*]] = llvm.call @inputs1results2(%[[VAL_5]]) : (!llvm.ptr<i8>) -> !llvm.struct<(ptr<i8>, ptr<i8>)>
 // CHECK:           %[[VAL_7:.*]] = llvm.mlir.constant(0 : i32) : !llvm.i32
-// CHECK:           %[[VAL_8:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_7]]] : (!llvm<"i8**">, !llvm.i32) -> !llvm<"i8*">
-// CHECK:           %[[VAL_9:.*]] = llvm.bitcast %[[VAL_8]] : !llvm<"i8*"> to !llvm<"i8**">
-// CHECK:           %[[VAL_10:.*]] = llvm.extractvalue %[[VAL_6]][0 : i32] : !llvm<"{ i8*, i8* }">
-// CHECK:           llvm.store %[[VAL_10]], %[[VAL_9]] : !llvm<"i8**">
+// CHECK:           %[[VAL_8:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_7]]] : (!llvm.ptr<ptr<i8>>, !llvm.i32) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = llvm.bitcast %[[VAL_8]] : !llvm.ptr<i8> to !llvm.ptr<ptr<i8>>
+// CHECK:           %[[VAL_10:.*]] = llvm.extractvalue %[[VAL_6]][0 : i32] : !llvm.struct<(ptr<i8>, ptr<i8>)>
+// CHECK:           llvm.store %[[VAL_10]], %[[VAL_9]] : !llvm.ptr<ptr<i8>>
 // CHECK:           %[[VAL_11:.*]] = llvm.mlir.constant(1 : i32) : !llvm.i32
-// CHECK:           %[[VAL_12:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_11]]] : (!llvm<"i8**">, !llvm.i32) -> !llvm<"i8*">
-// CHECK:           %[[VAL_13:.*]] = llvm.bitcast %[[VAL_12]] : !llvm<"i8*"> to !llvm<"i8**">
-// CHECK:           %[[VAL_14:.*]] = llvm.extractvalue %[[VAL_6]][1 : i32] : !llvm<"{ i8*, i8* }">
-// CHECK:           llvm.store %[[VAL_14]], %[[VAL_13]] : !llvm<"i8**">
+// CHECK:           %[[VAL_12:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_11]]] : (!llvm.ptr<ptr<i8>>, !llvm.i32) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_13:.*]] = llvm.bitcast %[[VAL_12]] : !llvm.ptr<i8> to !llvm.ptr<ptr<i8>>
+// CHECK:           %[[VAL_14:.*]] = llvm.extractvalue %[[VAL_6]][1 : i32] : !llvm.struct<(ptr<i8>, ptr<i8>)>
+// CHECK:           llvm.store %[[VAL_14]], %[[VAL_13]] : !llvm.ptr<ptr<i8>>
 // CHECK:           llvm.return
 // CHECK:         }
 
 // CHECK-LABEL:   llvm.func @__npcomprt_wrapper_inputs1results1(
-// CHECK-SAME:                                                   %[[VAL_0:.*]]: !llvm<"i8**">,
-// CHECK-SAME:                                                   %[[VAL_1:.*]]: !llvm<"i8**">) {
+// CHECK-SAME:                                                  %[[VAL_0:.*]]: !llvm.ptr<ptr<i8>>,
+// CHECK-SAME:                                                  %[[VAL_1:.*]]: !llvm.ptr<ptr<i8>>) {
 // CHECK:           %[[VAL_2:.*]] = llvm.mlir.constant(0 : i32) : !llvm.i32
-// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm<"i8**">, !llvm.i32) -> !llvm<"i8*">
-// CHECK:           %[[VAL_4:.*]] = llvm.bitcast %[[VAL_3]] : !llvm<"i8*"> to !llvm<"i8**">
-// CHECK:           %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm<"i8**">
-// CHECK:           %[[VAL_6:.*]] = llvm.call @inputs1results1(%[[VAL_5]]) : (!llvm<"i8*">) -> !llvm<"i8*">
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<ptr<i8>>, !llvm.i32) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_4:.*]] = llvm.bitcast %[[VAL_3]] : !llvm.ptr<i8> to !llvm.ptr<ptr<i8>>
+// CHECK:           %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<ptr<i8>>
+// CHECK:           %[[VAL_6:.*]] = llvm.call @inputs1results1(%[[VAL_5]]) : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
 // CHECK:           %[[VAL_7:.*]] = llvm.mlir.constant(0 : i32) : !llvm.i32
-// CHECK:           %[[VAL_8:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_7]]] : (!llvm<"i8**">, !llvm.i32) -> !llvm<"i8*">
-// CHECK:           %[[VAL_9:.*]] = llvm.bitcast %[[VAL_8]] : !llvm<"i8*"> to !llvm<"i8**">
-// CHECK:           llvm.store %[[VAL_6]], %[[VAL_9]] : !llvm<"i8**">
+// CHECK:           %[[VAL_8:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_7]]] : (!llvm.ptr<ptr<i8>>, !llvm.i32) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = llvm.bitcast %[[VAL_8]] : !llvm.ptr<i8> to !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.store %[[VAL_6]], %[[VAL_9]] : !llvm.ptr<ptr<i8>>
 // CHECK:           llvm.return
 // CHECK:         }
 
 // CHECK-LABEL:   llvm.func @__npcomprt_wrapper_inputs1results0(
-// CHECK-SAME:                                                   %[[VAL_0:.*]]: !llvm<"i8**">,
-// CHECK-SAME:                                                   %[[VAL_1:.*]]: !llvm<"i8**">) {
+// CHECK-SAME:                                                  %[[VAL_0:.*]]: !llvm.ptr<ptr<i8>>,
+// CHECK-SAME:                                                  %[[VAL_1:.*]]: !llvm.ptr<ptr<i8>>) {
 // CHECK:           %[[VAL_2:.*]] = llvm.mlir.constant(0 : i32) : !llvm.i32
-// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm<"i8**">, !llvm.i32) -> !llvm<"i8*">
-// CHECK:           %[[VAL_4:.*]] = llvm.bitcast %[[VAL_3]] : !llvm<"i8*"> to !llvm<"i8**">
-// CHECK:           %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm<"i8**">
-// CHECK:           llvm.call @inputs1results0(%[[VAL_5]]) : (!llvm<"i8*">) -> ()
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<ptr<i8>>, !llvm.i32) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_4:.*]] = llvm.bitcast %[[VAL_3]] : !llvm.ptr<i8> to !llvm.ptr<ptr<i8>>
+// CHECK:           %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<ptr<i8>>
+// CHECK:           llvm.call @inputs1results0(%[[VAL_5]]) : (!llvm.ptr<i8>) -> ()
 // CHECK:           llvm.return
 // CHECK:         }
-
+// CHECK:         llvm.func @__npcomp_compiler_rt_abort_if(!llvm.i1)
+// CHECK:         llvm.func @__npcomp_compiler_rt_get_extent(!llvm.ptr<i8>, !llvm.i32) -> !llvm.i64
+// CHECK:         llvm.func @__npcomp_compiler_rt_to_memref(!llvm.ptr<i8>) -> !llvm.struct<(i64, ptr<i8>)>
+// CHECK:         llvm.func @__npcomp_compiler_rt_from_memref(!llvm.i64, !llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:         llvm.func @__npcomp_compiler_rt_get_global(!llvm.ptr<struct<(i32, ptr<i32>, ptr<i8>)>>) -> !llvm.struct<(i64, ptr<i8>)>
 // CHECK:         llvm.mlir.global internal constant @__npcomp_internal_constant_inputs1results0("inputs1results0")
 // CHECK:         llvm.mlir.global internal constant @__npcomp_internal_constant_inputs1results1("inputs1results1")
 // CHECK:         llvm.mlir.global internal constant @__npcomp_internal_constant_inputs1results2("inputs1results2")
-// CHECK-LABEL:   llvm.mlir.global internal constant @__npcomp_func_descriptors() : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]"> {
-// CHECK:           %[[VAL_0:.*]] = llvm.mlir.undef : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
+
+// CHECK-LABEL:   llvm.mlir.global internal constant @__npcomp_func_descriptors() : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>> {
+// CHECK:           %[[VAL_0:.*]] = llvm.mlir.undef : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
 // CHECK:           %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : !llvm.i32
 // CHECK:           %[[VAL_2:.*]] = llvm.mlir.constant(15 : i32) : !llvm.i32
-// CHECK:           %[[VAL_3:.*]] = llvm.insertvalue %[[VAL_2]], %[[VAL_0]][0 : i32, 0 : i32] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
-// CHECK:           %[[VAL_4:.*]] = llvm.mlir.addressof @__npcomp_internal_constant_inputs1results0 : !llvm<"[15 x i8]*">
-// CHECK:           %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_4]]{{\[}}%[[VAL_1]], %[[VAL_1]]] : (!llvm<"[15 x i8]*">, !llvm.i32, !llvm.i32) -> !llvm<"i8*">
-// CHECK:           %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_5]], %[[VAL_3]][0 : i32, 1 : i32] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
-// CHECK:           %[[VAL_7:.*]] = llvm.mlir.addressof @__npcomprt_wrapper_inputs1results0 : !llvm<"void (i8**, i8**)*">
-// CHECK:           %[[VAL_8:.*]] = llvm.bitcast %[[VAL_7]] : !llvm<"void (i8**, i8**)*"> to !llvm<"i8*">
-// CHECK:           %[[VAL_9:.*]] = llvm.insertvalue %[[VAL_8]], %[[VAL_6]][0 : i32, 2 : i32] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
+// CHECK:           %[[VAL_3:.*]] = llvm.insertvalue %[[VAL_2]], %[[VAL_0]][0 : i32, 0 : i32] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
+// CHECK:           %[[VAL_4:.*]] = llvm.mlir.addressof @__npcomp_internal_constant_inputs1results0 : !llvm.ptr<array<15 x i8>>
+// CHECK:           %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_4]]{{\[}}%[[VAL_1]], %[[VAL_1]]] : (!llvm.ptr<array<15 x i8>>, !llvm.i32, !llvm.i32) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_5]], %[[VAL_3]][0 : i32, 1 : i32] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
+// CHECK:           %[[VAL_7:.*]] = llvm.mlir.addressof @__npcomprt_wrapper_inputs1results0 : !llvm.ptr<func<void (ptr<ptr<i8>>, ptr<ptr<i8>>)>>
+// CHECK:           %[[VAL_8:.*]] = llvm.bitcast %[[VAL_7]] : !llvm.ptr<func<void (ptr<ptr<i8>>, ptr<ptr<i8>>)>> to !llvm.ptr<i8>
+// CHECK:           %[[VAL_9:.*]] = llvm.insertvalue %[[VAL_8]], %[[VAL_6]][0 : i32, 2 : i32] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
 // CHECK:           %[[VAL_10:.*]] = llvm.mlir.constant(1 : i32) : !llvm.i32
-// CHECK:           %[[VAL_11:.*]] = llvm.insertvalue %[[VAL_10]], %[[VAL_9]][0 : i32, 3 : i32] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
+// CHECK:           %[[VAL_11:.*]] = llvm.insertvalue %[[VAL_10]], %[[VAL_9]][0 : i32, 3 : i32] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
 // CHECK:           %[[VAL_12:.*]] = llvm.mlir.constant(0 : i32) : !llvm.i32
-// CHECK:           %[[VAL_13:.*]] = llvm.insertvalue %[[VAL_12]], %[[VAL_11]][0 : i32, 4 : i32] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
+// CHECK:           %[[VAL_13:.*]] = llvm.insertvalue %[[VAL_12]], %[[VAL_11]][0 : i32, 4 : i32] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
 // CHECK:           %[[VAL_14:.*]] = llvm.mlir.constant(15 : i32) : !llvm.i32
-// CHECK:           %[[VAL_15:.*]] = llvm.insertvalue %[[VAL_14]], %[[VAL_13]][1 : i32, 0 : i32] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
-// CHECK:           %[[VAL_16:.*]] = llvm.mlir.addressof @__npcomp_internal_constant_inputs1results1 : !llvm<"[15 x i8]*">
-// CHECK:           %[[VAL_17:.*]] = llvm.getelementptr %[[VAL_16]]{{\[}}%[[VAL_1]], %[[VAL_1]]] : (!llvm<"[15 x i8]*">, !llvm.i32, !llvm.i32) -> !llvm<"i8*">
-// CHECK:           %[[VAL_18:.*]] = llvm.insertvalue %[[VAL_17]], %[[VAL_15]][1 : i32, 1 : i32] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
-// CHECK:           %[[VAL_19:.*]] = llvm.mlir.addressof @__npcomprt_wrapper_inputs1results1 : !llvm<"void (i8**, i8**)*">
-// CHECK:           %[[VAL_20:.*]] = llvm.bitcast %[[VAL_19]] : !llvm<"void (i8**, i8**)*"> to !llvm<"i8*">
-// CHECK:           %[[VAL_21:.*]] = llvm.insertvalue %[[VAL_20]], %[[VAL_18]][1 : i32, 2 : i32] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
+// CHECK:           %[[VAL_15:.*]] = llvm.insertvalue %[[VAL_14]], %[[VAL_13]][1 : i32, 0 : i32] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
+// CHECK:           %[[VAL_16:.*]] = llvm.mlir.addressof @__npcomp_internal_constant_inputs1results1 : !llvm.ptr<array<15 x i8>>
+// CHECK:           %[[VAL_17:.*]] = llvm.getelementptr %[[VAL_16]]{{\[}}%[[VAL_1]], %[[VAL_1]]] : (!llvm.ptr<array<15 x i8>>, !llvm.i32, !llvm.i32) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_18:.*]] = llvm.insertvalue %[[VAL_17]], %[[VAL_15]][1 : i32, 1 : i32] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
+// CHECK:           %[[VAL_19:.*]] = llvm.mlir.addressof @__npcomprt_wrapper_inputs1results1 : !llvm.ptr<func<void (ptr<ptr<i8>>, ptr<ptr<i8>>)>>
+// CHECK:           %[[VAL_20:.*]] = llvm.bitcast %[[VAL_19]] : !llvm.ptr<func<void (ptr<ptr<i8>>, ptr<ptr<i8>>)>> to !llvm.ptr<i8>
+// CHECK:           %[[VAL_21:.*]] = llvm.insertvalue %[[VAL_20]], %[[VAL_18]][1 : i32, 2 : i32] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
 // CHECK:           %[[VAL_22:.*]] = llvm.mlir.constant(1 : i32) : !llvm.i32
-// CHECK:           %[[VAL_23:.*]] = llvm.insertvalue %[[VAL_22]], %[[VAL_21]][1 : i32, 3 : i32] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
+// CHECK:           %[[VAL_23:.*]] = llvm.insertvalue %[[VAL_22]], %[[VAL_21]][1 : i32, 3 : i32] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
 // CHECK:           %[[VAL_24:.*]] = llvm.mlir.constant(1 : i32) : !llvm.i32
-// CHECK:           %[[VAL_25:.*]] = llvm.insertvalue %[[VAL_24]], %[[VAL_23]][1 : i32, 4 : i32] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
+// CHECK:           %[[VAL_25:.*]] = llvm.insertvalue %[[VAL_24]], %[[VAL_23]][1 : i32, 4 : i32] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
 // CHECK:           %[[VAL_26:.*]] = llvm.mlir.constant(15 : i32) : !llvm.i32
-// CHECK:           %[[VAL_27:.*]] = llvm.insertvalue %[[VAL_26]], %[[VAL_25]][2 : i32, 0 : i32] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
-// CHECK:           %[[VAL_28:.*]] = llvm.mlir.addressof @__npcomp_internal_constant_inputs1results2 : !llvm<"[15 x i8]*">
-// CHECK:           %[[VAL_29:.*]] = llvm.getelementptr %[[VAL_28]]{{\[}}%[[VAL_1]], %[[VAL_1]]] : (!llvm<"[15 x i8]*">, !llvm.i32, !llvm.i32) -> !llvm<"i8*">
-// CHECK:           %[[VAL_30:.*]] = llvm.insertvalue %[[VAL_29]], %[[VAL_27]][2 : i32, 1 : i32] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
-// CHECK:           %[[VAL_31:.*]] = llvm.mlir.addressof @__npcomprt_wrapper_inputs1results2 : !llvm<"void (i8**, i8**)*">
-// CHECK:           %[[VAL_32:.*]] = llvm.bitcast %[[VAL_31]] : !llvm<"void (i8**, i8**)*"> to !llvm<"i8*">
-// CHECK:           %[[VAL_33:.*]] = llvm.insertvalue %[[VAL_32]], %[[VAL_30]][2 : i32, 2 : i32] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
+// CHECK:           %[[VAL_27:.*]] = llvm.insertvalue %[[VAL_26]], %[[VAL_25]][2 : i32, 0 : i32] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
+// CHECK:           %[[VAL_28:.*]] = llvm.mlir.addressof @__npcomp_internal_constant_inputs1results2 : !llvm.ptr<array<15 x i8>>
+// CHECK:           %[[VAL_29:.*]] = llvm.getelementptr %[[VAL_28]]{{\[}}%[[VAL_1]], %[[VAL_1]]] : (!llvm.ptr<array<15 x i8>>, !llvm.i32, !llvm.i32) -> !llvm.ptr<i8>
+// CHECK:           %[[VAL_30:.*]] = llvm.insertvalue %[[VAL_29]], %[[VAL_27]][2 : i32, 1 : i32] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
+// CHECK:           %[[VAL_31:.*]] = llvm.mlir.addressof @__npcomprt_wrapper_inputs1results2 : !llvm.ptr<func<void (ptr<ptr<i8>>, ptr<ptr<i8>>)>>
+// CHECK:           %[[VAL_32:.*]] = llvm.bitcast %[[VAL_31]] : !llvm.ptr<func<void (ptr<ptr<i8>>, ptr<ptr<i8>>)>> to !llvm.ptr<i8>
+// CHECK:           %[[VAL_33:.*]] = llvm.insertvalue %[[VAL_32]], %[[VAL_30]][2 : i32, 2 : i32] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
 // CHECK:           %[[VAL_34:.*]] = llvm.mlir.constant(1 : i32) : !llvm.i32
-// CHECK:           %[[VAL_35:.*]] = llvm.insertvalue %[[VAL_34]], %[[VAL_33]][2 : i32, 3 : i32] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
+// CHECK:           %[[VAL_35:.*]] = llvm.insertvalue %[[VAL_34]], %[[VAL_33]][2 : i32, 3 : i32] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
 // CHECK:           %[[VAL_36:.*]] = llvm.mlir.constant(2 : i32) : !llvm.i32
-// CHECK:           %[[VAL_37:.*]] = llvm.insertvalue %[[VAL_36]], %[[VAL_35]][2 : i32, 4 : i32] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
-// CHECK:           llvm.return %[[VAL_37]] : !llvm<"[3 x { i32, i8*, i8*, i32, i32 }]">
+// CHECK:           %[[VAL_37:.*]] = llvm.insertvalue %[[VAL_36]], %[[VAL_35]][2 : i32, 4 : i32] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
+// CHECK:           llvm.return %[[VAL_37]] : !llvm.array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
+// CHECK:         }
+
+// CHECK-LABEL:   llvm.mlir.global external constant @_mlir___npcomp_module_descriptor() : !llvm.struct<(i32, ptr<struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>)> {
+// CHECK:           %[[VAL_0:.*]] = llvm.mlir.undef : !llvm.struct<(i32, ptr<struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>)>
+// CHECK:           %[[VAL_1:.*]] = llvm.mlir.constant(3 : i32) : !llvm.i32
+// CHECK:           %[[VAL_2:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_0]][0 : i32] : !llvm.struct<(i32, ptr<struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>)>
+// CHECK:           %[[VAL_3:.*]] = llvm.mlir.addressof @__npcomp_func_descriptors : !llvm.ptr<array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>>
+// CHECK:           %[[VAL_4:.*]] = llvm.bitcast %[[VAL_3]] : !llvm.ptr<array<3 x struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>> to !llvm.ptr<struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>
+// CHECK:           %[[VAL_5:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_2]][1 : i32] : !llvm.struct<(i32, ptr<struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>)>
+// CHECK:           llvm.return %[[VAL_5]] : !llvm.struct<(i32, ptr<struct<(i32, ptr<i8>, ptr<i8>, i32, i32)>>)>
 // CHECK:         }
 
 npcomprt.module_metadata {
@@ -160,7 +182,7 @@ npcomprt.module_metadata {
 
 
 // CHECK-LABEL:   llvm.func @inputs1results0(
-// CHECK-SAME:                               %[[VAL_0:.*]]: !llvm<"i8*">) {
+// CHECK-SAME:                               %[[VAL_0:.*]]: !llvm.ptr<i8>) {
 // CHECK:           llvm.return
 // CHECK:         }
 func @inputs1results0(%arg0: !npcomprt.tensor) {
@@ -168,19 +190,19 @@ func @inputs1results0(%arg0: !npcomprt.tensor) {
 }
 
 // CHECK-LABEL:   llvm.func @inputs1results1(
-// CHECK-SAME:                               %[[VAL_0:.*]]: !llvm<"i8*">) -> !llvm<"i8*"> {
-// CHECK:           llvm.return %[[VAL_0]] : !llvm<"i8*">
+// CHECK-SAME:                               %[[VAL_0:.*]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
+// CHECK:           llvm.return %[[VAL_0]] : !llvm.ptr<i8>
 // CHECK:         }
 func @inputs1results1(%arg0: !npcomprt.tensor) -> !npcomprt.tensor {
   return %arg0 : !npcomprt.tensor
 }
 
 // CHECK-LABEL:   llvm.func @inputs1results2(
-// CHECK-SAME:                               %[[VAL_0:.*]]: !llvm<"i8*">) -> !llvm<"{ i8*, i8* }"> {
-// CHECK:           %[[VAL_1:.*]] = llvm.mlir.undef : !llvm<"{ i8*, i8* }">
-// CHECK:           %[[VAL_2:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_1]][0] : !llvm<"{ i8*, i8* }">
-// CHECK:           %[[VAL_3:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_2]][1] : !llvm<"{ i8*, i8* }">
-// CHECK:           llvm.return %[[VAL_3]] : !llvm<"{ i8*, i8* }">
+// CHECK-SAME:                               %[[VAL_0:.*]]: !llvm.ptr<i8>) -> !llvm.struct<(ptr<i8>, ptr<i8>)> {
+// CHECK:           %[[VAL_1:.*]] = llvm.mlir.undef : !llvm.struct<(ptr<i8>, ptr<i8>)>
+// CHECK:           %[[VAL_2:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_1]][0] : !llvm.struct<(ptr<i8>, ptr<i8>)>
+// CHECK:           %[[VAL_3:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_2]][1] : !llvm.struct<(ptr<i8>, ptr<i8>)>
+// CHECK:           llvm.return %[[VAL_3]] : !llvm.struct<(ptr<i8>, ptr<i8>)>
 // CHECK:         }
 func @inputs1results2(%arg0: !npcomprt.tensor) -> (!npcomprt.tensor, !npcomprt.tensor) {
   return %arg0, %arg0 : !npcomprt.tensor, !npcomprt.tensor
@@ -191,22 +213,28 @@ func @inputs1results2(%arg0: !npcomprt.tensor) -> (!npcomprt.tensor, !npcomprt.t
 
 // Test emission of compiler runtime functions.
 
-// CHECK: llvm.func @__npcomp_compiler_rt_abort_if(!llvm.i1)
-// CHECK: llvm.func @__npcomp_compiler_rt_get_extent(!llvm<"i8*">, !llvm.i32) -> !llvm.i64
+// CHECK-LABEL:   llvm.func @__npcomp_compiler_rt_abort_if(!llvm.i1)
+// CHECK:         llvm.func @__npcomp_compiler_rt_get_extent(!llvm.ptr<i8>, !llvm.i32) -> !llvm.i64
+// CHECK:         llvm.func @__npcomp_compiler_rt_to_memref(!llvm.ptr<i8>) -> !llvm.struct<(i64, ptr<i8>)>
+// CHECK:         llvm.func @__npcomp_compiler_rt_from_memref(!llvm.i64, !llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:         llvm.func @__npcomp_compiler_rt_get_global(!llvm.ptr<struct<(i32, ptr<i32>, ptr<i8>)>>) -> !llvm.struct<(i64, ptr<i8>)>
 
-// CHECK-LABEL: llvm.func @calls_abort_if(
-// CHECK-SAME:      %[[PRED:.*]]: !llvm.i1)
+// CHECK-LABEL:   llvm.func @calls_abort_if(
+// CHECK-SAME:                              %[[VAL_0:.*]]: !llvm.i1) {
+// CHECK:           llvm.call @__npcomp_compiler_rt_abort_if(%[[VAL_0]]) : (!llvm.i1) -> ()
+// CHECK:           llvm.return
+// CHECK:         }
 func @calls_abort_if(%arg0: i1) {
-  // CHECK: llvm.call @__npcomp_compiler_rt_abort_if(%arg0) : (!llvm.i1) -> ()
   npcomprt.abort_if %arg0
   return
 }
 
 // CHECK-LABEL:   llvm.func @calls_get_extent(
-// CHECK-SAME:                                %[[TENSOR:.*]]: !llvm<"i8*">) -> !llvm.i64 {
-// CHECK:           %[[C1:.*]] = llvm.mlir.constant(1 : i32) : !llvm.i32
-// CHECK:           %[[EXTENT:.*]] = llvm.call @__npcomp_compiler_rt_get_extent(%[[TENSOR]], %[[C1]])
-// CHECK:           llvm.return %[[EXTENT]] : !llvm.i64
+// CHECK-SAME:                                %[[VAL_0:.*]]: !llvm.ptr<i8>) -> !llvm.i64 {
+// CHECK:           %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : !llvm.i32
+// CHECK:           %[[VAL_2:.*]] = llvm.call @__npcomp_compiler_rt_get_extent(%[[VAL_0]], %[[VAL_1]]) : (!llvm.ptr<i8>, !llvm.i32) -> !llvm.i64
+// CHECK:           llvm.return %[[VAL_2]] : !llvm.i64
+// CHECK:         }
 func @calls_get_extent(%arg0: !npcomprt.tensor) -> index {
   %c1 = constant 1 : i32
   %0 = npcomprt.get_extent %arg0, %c1
@@ -214,8 +242,8 @@ func @calls_get_extent(%arg0: !npcomprt.tensor) -> index {
 }
 
 // CHECK-LABEL:   llvm.func @calls_to_memref(
-// CHECK-SAME:                               %[[VAL_0:.*]]: !llvm<"i8*">) {
-// CHECK:           %[[VAL_1:.*]] = llvm.call @__npcomp_compiler_rt_to_memref(%[[VAL_0]]) : (!llvm<"i8*">) -> !llvm<"{ i64, i8* }">
+// CHECK-SAME:                               %[[VAL_0:.*]]: !llvm.ptr<i8>) {
+// CHECK:           %[[VAL_1:.*]] = llvm.call @__npcomp_compiler_rt_to_memref(%[[VAL_0]]) : (!llvm.ptr<i8>) -> !llvm.struct<(i64, ptr<i8>)>
 // CHECK:           llvm.return
 // CHECK:         }
 func @calls_to_memref(%arg0: !npcomprt.tensor) {
@@ -225,14 +253,14 @@ func @calls_to_memref(%arg0: !npcomprt.tensor) {
 
 // CHECK-LABEL:   llvm.func @calls_from_memref(
 // CHECK-SAME:                                 %[[VAL_0:.*]]: !llvm.i64,
-// CHECK-SAME:                                 %[[VAL_1:.*]]: !llvm<"i8*">) -> !llvm<"i8*"> {
-// CHECK:           %[[VAL_2:.*]] = llvm.mlir.undef : !llvm<"{ i64, i8* }">
-// CHECK:           %[[VAL_3:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_2]][0] : !llvm<"{ i64, i8* }">
-// CHECK:           %[[VAL_4:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_3]][1] : !llvm<"{ i64, i8* }">
-// CHECK:           %[[VAL_5:.*]] = llvm.extractvalue %[[VAL_4]][0 : i32] : !llvm<"{ i64, i8* }">
-// CHECK:           %[[VAL_6:.*]] = llvm.extractvalue %[[VAL_4]][1 : i32] : !llvm<"{ i64, i8* }">
-// CHECK:           %[[VAL_7:.*]] = llvm.call @__npcomp_compiler_rt_from_memref(%[[VAL_5]], %[[VAL_6]]) : (!llvm.i64, !llvm<"i8*">) -> !llvm<"i8*">                                                               
-// CHECK:           llvm.return %[[VAL_7]] : !llvm<"i8*">
+// CHECK-SAME:                                 %[[VAL_1:.*]]: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
+// CHECK:           %[[VAL_2:.*]] = llvm.mlir.undef : !llvm.struct<(i64, ptr<i8>)>
+// CHECK:           %[[VAL_3:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_2]][0] : !llvm.struct<(i64, ptr<i8>)>
+// CHECK:           %[[VAL_4:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_3]][1] : !llvm.struct<(i64, ptr<i8>)>
+// CHECK:           %[[VAL_5:.*]] = llvm.extractvalue %[[VAL_4]][0 : i32] : !llvm.struct<(i64, ptr<i8>)>
+// CHECK:           %[[VAL_6:.*]] = llvm.extractvalue %[[VAL_4]][1 : i32] : !llvm.struct<(i64, ptr<i8>)>
+// CHECK:           %[[VAL_7:.*]] = llvm.call @__npcomp_compiler_rt_from_memref(%[[VAL_5]], %[[VAL_6]]) : (!llvm.i64, !llvm.ptr<i8>) -> !llvm.ptr<i8>
+// CHECK:           llvm.return %[[VAL_7]] : !llvm.ptr<i8>
 // CHECK:         }
 func @calls_from_memref(%arg0: memref<*xf32>) -> !npcomprt.tensor {
   %0 = npcomprt.from_memref %arg0 : memref<*xf32>


### PR DESCRIPTION
* llvm-project: b5924a8e27536d19dd5c4d302db29fb6163d5faa
* mhlo: 848ca244d20f045b7921da55a98a04d95ef94f0e
* Multiple breakages that need to be fixed.

Fixes:
* Refactor dialect registration
* Remove all kindof methods (Casting functionality has been added upstream and is implicitly
available, see https://llvm.discourse.group/t/removing-kinds-from-attributes-and-types/1547.)
* Update dialect registration to comply with https://reviews.llvm.org/D85495.
* Remove type kinds and update some changed dialect signatures.
* Upgrade ATen dialect to match upstream needs.
  * Move dialect registration to tablegen.
  * Register the ListType in tablegen.
  * Change dialect initialization signature.
* Use TypeSwitch in MlirIr location printer.
* Remove global registry depends from npcomp-opt.
* Change LowerToLLVM to pass an MLIRContext vs an LLVMDialect for type creation.
* Remove dep on MLIREDSCInterface that is removed upstream.
* Thread through the DialectRegistry for opt and python-like tools.
* Modernize pass registration (This was forced because the GEN_PASS_REGISTRATION code now generates inline functions vs literal pass registration statements)

Co-authored-by: Marius Brehler <marius.brehler@iml.fraunhofer.de>