### PR TITLE
Register dialects in conversion and ATen lowering passes

### DIFF
--- a/lib/Conversion/NumpyToTCF/Passes.cpp
+++ b/lib/Conversion/NumpyToTCF/Passes.cpp
@@ -11,6 +11,7 @@
 #include "../PassDetail.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "npcomp/Dialect/Numpy/IR/NumpyOps.h"
+#include "npcomp/Dialect/TCF/IR/TCFDialect.h"
 #include "npcomp/Dialect/TCF/IR/TCFOps.h"
 
 using namespace mlir;
@@ -43,7 +44,11 @@ private:
 
 namespace {
 class ConvertNumpyToTCF : public ConvertNumpyToTCFBase<ConvertNumpyToTCF> {
-  void runOnOperation() {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<NPCOMP::tcf::TCFDialect>();
+  }
+
+  void runOnOperation() override {
     FuncOp func = getOperation();
     MLIRContext *context = &getContext();
 

--- a/lib/Conversion/TCFToTCP/TCFToTCP.cpp
+++ b/lib/Conversion/TCFToTCP/TCFToTCP.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Traits.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "npcomp/Dialect/TCF/IR/TCFOps.h"
+#include "npcomp/Dialect/TCP/IR/TCPDialect.h"
 #include "npcomp/Dialect/TCP/IR/TCPOps.h"
 
 using namespace mlir;
@@ -68,7 +69,11 @@ public:
 namespace {
 class ConvertTCFToTCP : public ConvertTCFToTCPBase<ConvertTCFToTCP> {
 public:
-  void runOnOperation() {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<shape::ShapeDialect,tcp::TCPDialect>();
+  }
+
+  void runOnOperation() override {
     ModuleOp module = getOperation();
     MLIRContext *context = &getContext();
 

--- a/lib/Conversion/TCPToLinalg/TCPToLinalg.cpp
+++ b/lib/Conversion/TCPToLinalg/TCPToLinalg.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "npcomp/Dialect/TCF/IR/TCFDialect.h"
 #include "npcomp/Dialect/TCP/IR/TCPOps.h"
 
 using namespace mlir;
@@ -57,6 +58,10 @@ public:
 namespace {
 class ConvertTCPToLinalg : public ConvertTCPToLinalgBase<ConvertTCPToLinalg> {
 public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<linalg::LinalgDialect>();
+  }
+
   void runOnOperation() override {
     ModuleOp module = getOperation();
     MLIRContext *context = &getContext();

--- a/lib/Dialect/ATen/ATenLoweringPass.cpp
+++ b/lib/Dialect/ATen/ATenLoweringPass.cpp
@@ -891,6 +891,10 @@ MemRefType convertTensorType(TensorType tensor) {
 struct ATenLoweringPass
     : public PassWrapper<ATenLoweringPass, OperationPass<ModuleOp>> {
 
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<LLVM::LLVMDialect, StandardOpsDialect>();
+  }
+
   void runOnOperation() override {
     LLVMTypeConverter typeConverter(getOperation().getContext());
     typeConverter.addConversion([&](Type type) {


### PR DESCRIPTION
This is a first step to register the dialects within the passes. It can be tested with 

```
--- a/tools/npcomp-opt/npcomp-opt.cpp
+++ b/tools/npcomp-opt/npcomp-opt.cpp
@@ -90,7 +90,8 @@ int main(int argc, char **argv) {

   if (failed(MlirOptMain(output->os(), std::move(file), passPipeline, registry,
                          splitInputFile, verifyDiagnostics, verifyPasses,
-                         allowUnregisteredDialects))) {
+                         allowUnregisteredDialects,
+                         /*preloadDialectsInContext=*/false))) {
```

and fixes some of the tests.