### PR TITLE
Refactor namespace handling

### DIFF
--- a/include/npcomp/Dialect/ATen/ATen.td
+++ b/include/npcomp/Dialect/ATen/ATen.td
@@ -25,7 +25,7 @@ include "npcomp/Dialect/ATen/ATenOpInterface.td"
 /// generated from C APIs exported by Pytorch.
 def ATen_Dialect : Dialect {
   let name = "aten";
-  let cppNamespace = "aten";
+  let cppNamespace = "::mlir::NPCOMP::aten";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/npcomp/Dialect/ATen/ATenDialect.h
+++ b/include/npcomp/Dialect/ATen/ATenDialect.h
@@ -86,17 +86,10 @@ uint64_t getTensorVolume(const Type ty) {
 
 #include "npcomp/Dialect/ATen/ATenOpInterfaces.h"
 
-namespace mlir {
-namespace NPCOMP {
-namespace aten {
 // include TableGen generated Op definitions
 #define GET_OP_CLASSES
 #include "npcomp/Dialect/ATen/ATen.h.inc"
 
 #include "npcomp/Dialect/ATen/ATenDialect.h.inc"
-
-} // namespace aten
-} // namespace NPCOMP
-} // namespace mlir
 
 #endif

--- a/include/npcomp/Dialect/Basicpy/IR/BasicpyDialect.h
+++ b/include/npcomp/Dialect/Basicpy/IR/BasicpyDialect.h
@@ -84,10 +84,10 @@ public:
   Typing::CPA::TypeNode *mapToCPAType(Typing::CPA::Context &context);
 };
 
-#include "npcomp/Dialect/Basicpy/IR/BasicpyOpsDialect.h.inc"
-
 } // namespace Basicpy
 } // namespace NPCOMP
 } // namespace mlir
+
+#include "npcomp/Dialect/Basicpy/IR/BasicpyOpsDialect.h.inc"
 
 #endif // NPCOMP_DIALECT_BASICPY_IR_BASICPY_DIALECT_H

--- a/include/npcomp/Dialect/Basicpy/IR/BasicpyDialect.td
+++ b/include/npcomp/Dialect/Basicpy/IR/BasicpyDialect.td
@@ -21,7 +21,7 @@ def Basicpy_Dialect : Dialect {
   let description = [{
     Core types and ops 
   }];
-  let cppNamespace = "Basicpy";
+  let cppNamespace = "::mlir::NPCOMP::Basicpy";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/npcomp/Dialect/Basicpy/IR/BasicpyOps.h
+++ b/include/npcomp/Dialect/Basicpy/IR/BasicpyOps.h
@@ -22,15 +22,7 @@
 
 #include "npcomp/Dialect/Basicpy/IR/BasicpyOpsEnums.h.inc"
 
-namespace mlir {
-namespace NPCOMP {
-namespace Basicpy {
-
 #define GET_OP_CLASSES
 #include "npcomp/Dialect/Basicpy/IR/BasicpyOps.h.inc"
-
-} // namespace Basicpy
-} // namespace NPCOMP
-} // namespace mlir
 
 #endif // NPCOMP_DIALECT_BASICPY_IR_BASICPY_OPS_H

--- a/include/npcomp/Dialect/Npcomprt/IR/NpcomprtDialect.h
+++ b/include/npcomp/Dialect/Npcomprt/IR/NpcomprtDialect.h
@@ -22,10 +22,10 @@ public:
   static TensorType get(MLIRContext *context) { return Base::get(context); }
 };
 
-#include "npcomp/Dialect/Npcomprt/IR/NpcomprtOpsDialect.h.inc"
-
 } // namespace npcomprt
 } // namespace NPCOMP
 } // namespace mlir
+
+#include "npcomp/Dialect/Npcomprt/IR/NpcomprtOpsDialect.h.inc"
 
 #endif // NPCOMP_DIALECT_NPCOMPRT_IR_NPCOMPRTDIALECT_H

--- a/include/npcomp/Dialect/Npcomprt/IR/NpcomprtOps.h
+++ b/include/npcomp/Dialect/Npcomprt/IR/NpcomprtOps.h
@@ -14,15 +14,7 @@
 #include "mlir/IR/StandardTypes.h"
 #include "mlir/IR/SymbolTable.h"
 
-namespace mlir {
-namespace NPCOMP {
-namespace npcomprt {
-
 #define GET_OP_CLASSES
 #include "npcomp/Dialect/Npcomprt/IR/NpcomprtOps.h.inc"
-
-} // namespace npcomprt
-} // namespace NPCOMP
-} // namespace mlir
 
 #endif // NPCOMP_DIALECT_NPCOMPRT_IR_NPCOMPRTOPS_H

--- a/include/npcomp/Dialect/Numpy/IR/NumpyDialect.h
+++ b/include/npcomp/Dialect/Numpy/IR/NumpyDialect.h
@@ -56,10 +56,10 @@ public:
   Typing::CPA::TypeNode *mapToCPAType(Typing::CPA::Context &context);
 };
 
-#include "npcomp/Dialect/Numpy/IR/NumpyOpsDialect.h.inc"
-
 } // namespace Numpy
 } // namespace NPCOMP
 } // namespace mlir
+
+#include "npcomp/Dialect/Numpy/IR/NumpyOpsDialect.h.inc"
 
 #endif // NPCOMP_DIALECT_NUMPY_IR_NUMPY_DIALECT_H

--- a/include/npcomp/Dialect/Numpy/IR/NumpyDialect.td
+++ b/include/npcomp/Dialect/Numpy/IR/NumpyDialect.td
@@ -22,7 +22,7 @@ def Numpy_Dialect : Dialect {
   let description = [{
     Dialect of types and core numpy ops and abstractions.
   }];
-  let cppNamespace = "Numpy";
+  let cppNamespace = "::mlir::NPCOMP::Numpy";
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/npcomp/Dialect/Numpy/IR/NumpyOps.h
+++ b/include/npcomp/Dialect/Numpy/IR/NumpyOps.h
@@ -18,15 +18,7 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "npcomp/Typing/Analysis/CPA/Interfaces.h"
 
-namespace mlir {
-namespace NPCOMP {
-namespace Numpy {
-
 #define GET_OP_CLASSES
 #include "npcomp/Dialect/Numpy/IR/NumpyOps.h.inc"
-
-} // namespace Numpy
-} // namespace NPCOMP
-} // namespace mlir
 
 #endif // NPCOMP_DIALECT_NUMPY_IR_NUMPY_OPS_H

--- a/include/npcomp/Dialect/TCF/IR/TCFDialect.h
+++ b/include/npcomp/Dialect/TCF/IR/TCFDialect.h
@@ -11,14 +11,6 @@
 
 #include "mlir/IR/Dialect.h"
 
-namespace mlir {
-namespace NPCOMP {
-namespace tcf {
-
 #include "npcomp/Dialect/TCF/IR/TCFOpsDialect.h.inc"
-
-} // namespace tcf
-} // namespace NPCOMP
-} // namespace mlir
 
 #endif // NPCOMP_DIALECT_TCF_IR_TCFDIALECT_H

--- a/include/npcomp/Dialect/TCF/IR/TCFOps.h
+++ b/include/npcomp/Dialect/TCF/IR/TCFOps.h
@@ -13,15 +13,7 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/StandardTypes.h"
 
-namespace mlir {
-namespace NPCOMP {
-namespace tcf {
-
 #define GET_OP_CLASSES
 #include "npcomp/Dialect/TCF/IR/TCFOps.h.inc"
-
-} // namespace tcf
-} // namespace NPCOMP
-} // namespace mlir
 
 #endif // NPCOMP_DIALECT_TCF_IR_TCFOPS_H

--- a/include/npcomp/Dialect/TCP/IR/TCPDialect.h
+++ b/include/npcomp/Dialect/TCP/IR/TCPDialect.h
@@ -11,14 +11,6 @@
 
 #include "mlir/IR/Dialect.h"
 
-namespace mlir {
-namespace NPCOMP {
-namespace tcp {
-
 #include "npcomp/Dialect/TCP/IR/TCPOpsDialect.h.inc"
-
-} // namespace tcp
-} // namespace NPCOMP
-} // namespace mlir
 
 #endif // NPCOMP_DIALECT_TCP_IR_TCPDIALECT_H

--- a/include/npcomp/Dialect/TCP/IR/TCPOps.h
+++ b/include/npcomp/Dialect/TCP/IR/TCPOps.h
@@ -16,15 +16,7 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
-namespace mlir {
-namespace NPCOMP {
-namespace tcp {
-
 #define GET_OP_CLASSES
 #include "npcomp/Dialect/TCP/IR/TCPOps.h.inc"
-
-} // namespace tcp
-} // namespace NPCOMP
-} // namespace mlir
 
 #endif // NPCOMP_DIALECT_TCP_IR_TCPOPS_H

--- a/lib/Dialect/ATen/ATenDialect.cpp
+++ b/lib/Dialect/ATen/ATenDialect.cpp
@@ -10,6 +10,8 @@
 #include "mlir/IR/DialectImplementation.h"
 
 using namespace mlir;
+using namespace mlir::NPCOMP;
+using namespace mlir::NPCOMP::aten;
 
 namespace mlir {
 namespace NPCOMP {
@@ -89,6 +91,10 @@ void ATenDialect::printType(mlir::Type type, DialectAsmPrinter &os) const {
   os << ">";
 }
 
+} // namespace aten
+} // namespace NPCOMP
+} // namespace mlir
+
 void ATenDialect::initialize() {
   addTypes<ATenListType>();
   addOperations<
@@ -100,7 +106,4 @@ void ATenDialect::initialize() {
 #define GET_OP_CLASSES
 #include "npcomp/Dialect/ATen/ATen.cpp.inc"
 
-} // namespace aten
 #include "npcomp/Dialect/ATen/ATenOpInterfaces.cpp.inc"
-} // namespace NPCOMP
-} // namespace mlir

--- a/lib/Dialect/Basicpy/IR/BasicpyOps.cpp
+++ b/lib/Dialect/Basicpy/IR/BasicpyOps.cpp
@@ -287,8 +287,9 @@ void UnknownCastOp::getCanonicalizationPatterns(
   patterns.insert<ElideIdentityUnknownCast>(context);
 }
 
-#define GET_OP_CLASSES
-#include "npcomp/Dialect/Basicpy/IR/BasicpyOps.cpp.inc"
 } // namespace Basicpy
 } // namespace NPCOMP
 } // namespace mlir
+
+#define GET_OP_CLASSES
+#include "npcomp/Dialect/Basicpy/IR/BasicpyOps.cpp.inc"

--- a/lib/Dialect/Npcomprt/IR/NpcomprtOps.cpp
+++ b/lib/Dialect/Npcomprt/IR/NpcomprtOps.cpp
@@ -98,11 +98,5 @@ static LogicalResult verify(FuncMetadataOp op) {
   return success();
 }
 
-namespace mlir {
-namespace NPCOMP {
-namespace npcomprt {
 #define GET_OP_CLASSES
 #include "npcomp/Dialect/Npcomprt/IR/NpcomprtOps.cpp.inc"
-} // namespace npcomprt
-} // namespace NPCOMP
-} // namespace mlir

--- a/lib/Dialect/Numpy/IR/NumpyOps.cpp
+++ b/lib/Dialect/Numpy/IR/NumpyOps.cpp
@@ -86,11 +86,5 @@ void CopyToTensorOp::getCanonicalizationPatterns(
   patterns.insert<ElideCreateRedundantArrayFromTensor>(context);
 }
 
-namespace mlir {
-namespace NPCOMP {
-namespace Numpy {
 #define GET_OP_CLASSES
 #include "npcomp/Dialect/Numpy/IR/NumpyOps.cpp.inc"
-} // namespace Numpy
-} // namespace NPCOMP
-} // namespace mlir

--- a/lib/Dialect/TCF/IR/TCFOps.cpp
+++ b/lib/Dialect/TCF/IR/TCFOps.cpp
@@ -11,11 +11,5 @@
 using namespace mlir;
 using namespace mlir::NPCOMP::tcf;
 
-namespace mlir {
-namespace NPCOMP {
-namespace tcf {
 #define GET_OP_CLASSES
 #include "npcomp/Dialect/TCF/IR/TCFOps.cpp.inc"
-} // namespace tcf
-} // namespace NPCOMP
-} // namespace mlir

--- a/lib/Dialect/TCP/IR/TCPOps.cpp
+++ b/lib/Dialect/TCP/IR/TCPOps.cpp
@@ -58,11 +58,5 @@ static LogicalResult verifyGetGlobalMemrefOp(GetGlobalMemrefOp op) {
   return success();
 }
 
-namespace mlir {
-namespace NPCOMP {
-namespace tcp {
 #define GET_OP_CLASSES
 #include "npcomp/Dialect/TCP/IR/TCPOps.cpp.inc"
-} // namespace tcp
-} // namespace NPCOMP
-} // namespace mlir


### PR DESCRIPTION
This refactors the namespace handling that has changed upstream. Furthermore, this 
*  bumps LLVM to llvm/llvm-project@7d1ed69 and
*  bumps MLIR-HLO to tensorflow/mlir-hlo@1880f87.
