### PR TITLE
Update docker, instructions and some fixes for the pytorch 1.3 build.

### DIFF
--- a/build_tools/install_mlir.sh
+++ b/build_tools/install_mlir.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
+# Usage (for in-tree build/ directory):
+#   ./build_tools/install_mlir.sh
+# Usage (for aribtrary build/ directory):
+#   BUILD_DIR=/build ./build_tools/install_mlir.sh
 set -e
 td="$(realpath $(dirname $0)/..)"
+build_dir="$(realpath "${BUILD_DIR:-$td/build}")"
 
 # Find LLVM source (assumes it is adjacent to this directory).
 LLVM_SRC_DIR="$(realpath "${LLVM_SRC_DIR:-$td/external/llvm-project}")"
@@ -10,10 +15,10 @@ if ! [ -f "$LLVM_SRC_DIR/llvm/CMakeLists.txt" ]; then
   exit 1
 fi
 echo "Using LLVM source dir: $LLVM_SRC_DIR"
-
+echo "Build directory: $build_dir"
 # Setup directories.
-build_mlir="$td/build-mlir"
-install_mlir="$td/install-mlir"
+build_mlir="$build_dir/build-mlir"
+install_mlir="$build_dir/install-mlir"
 echo "Building MLIR in $build_mlir"
 echo "Install MLIR to $install_mlir"
 mkdir -p "$build_mlir"

--- a/docker/pytorch-1.3/Dockerfile
+++ b/docker/pytorch-1.3/Dockerfile
@@ -40,5 +40,5 @@ RUN conda install -c gaiar nnpack
 # Additional env for building npcomp.
 ENV CC=clang-10
 ENV CXX=clang++-10
-ENV CPPFLAGS "-I/opt/conda/include"
+ENV CXXFLAGS "-I/opt/conda/include"
 ENV LDFLAGS "-fuse-ld=/usr/bin/ld.lld-10 -L/opt/conda/lib"

--- a/docker/pytorch-1.3/Dockerfile
+++ b/docker/pytorch-1.3/Dockerfile
@@ -19,7 +19,6 @@ RUN /opt/conda/bin/conda install matplotlib pybind11
 #torchvision
 
 ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:/opt/conda/lib"
-
 # Rebuild pytorch
 
 WORKDIR /opt/pytorch/pytorch
@@ -34,3 +33,12 @@ RUN TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0 7.5+PTX" \
 
 WORKDIR /workspace
 
+# Additional packages for building npcomp
+RUN apt-get install clang-10 lld-10 --assume-yes
+RUN conda install -c gaiar nnpack
+
+# Additional env for building npcomp.
+ENV CC=clang-10
+ENV CXX=clang++-10
+ENV CPPFLAGS "-I/opt/conda/include"
+ENV LDFLAGS "-fuse-ld=/usr/bin/ld.lld-10 -L/opt/conda/lib"

--- a/docker/pytorch-1.3/Dockerfile
+++ b/docker/pytorch-1.3/Dockerfile
@@ -37,7 +37,8 @@ WORKDIR /workspace
 RUN apt-get install clang-10 lld-10 --assume-yes
 RUN conda install -c gaiar nnpack
 
-# Additional env for building npcomp.
+# Additional env for building npcomp and running tests.
+ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-10.1/compat/lib.real"
 ENV CC=clang-10
 ENV CXX=clang++-10
 ENV CXXFLAGS "-I/opt/conda/include"

--- a/frontends/pytorch/csrc/type_dispatch/python_bindings.cpp
+++ b/frontends/pytorch/csrc/type_dispatch/python_bindings.cpp
@@ -18,6 +18,8 @@
 // In this case t2_cpu contains the result of the computation, and t2_mlir
 // contains the mlir description of the computation.
 
+#include <pybind11/pybind11.h>
+
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
@@ -36,7 +38,7 @@
 #include "npcomp/Dialect/ATen/ATenPasses.h"
 #include "npcomp/Dialect/ATen/LivenessReport.h"
 
-#include "torch/csrc/jit/pybind.h"
+namespace py = pybind11;
 
 // Then ATen headers with workarounds
 #include "ATen/ArrayRef.h"

--- a/frontends/pytorch/lib/aten_ops.cpp
+++ b/frontends/pytorch/lib/aten_ops.cpp
@@ -19,7 +19,7 @@
 #include <ATen/ATen.h>
 #include <torch/torch.h>
 
-#include "nnpack.h"
+#include <nnpack.h>
 #include <ATen/CPUType.h>
 
 namespace {

--- a/lib/JITRuntime/JITModule.cpp
+++ b/lib/JITRuntime/JITModule.cpp
@@ -52,7 +52,7 @@ JITModule::fromCompiledModule(mlir::ModuleOp module,
     return expectedAddress.takeError();
   ret->descriptor =
       reinterpret_cast<npcomprt::ModuleDescriptor *>(*expectedAddress);
-  return ret;
+  return std::move(ret);
 }
 
 // Converter for bridging to npcomprt llvm-lookalike data structures.


### PR DESCRIPTION
* Includes pybind11 directly (for some reason using the pytorch helper header for this depends on a source file not in the image).
* Installs nnpack into the image.
* Installs new-clang and LLD and configures environment to use it (otherwise, link time is terrible).
* Fixes a gcc compile error (in the off chance you build with default gcc compiler).
* Tests are failing based on some dialect registration stuff that must not have been factored correctly. Will followup with a fix.