### PR TITLE
Explicitly load aten and std dialects when constructing a context.

### DIFF
--- a/docker/pytorch-1.3/Dockerfile
+++ b/docker/pytorch-1.3/Dockerfile
@@ -37,6 +37,9 @@ WORKDIR /workspace
 RUN apt-get install clang-10 lld-10 --assume-yes
 RUN conda install -c gaiar nnpack
 
+# Make it possible to symbolize stack traces in crashes.
+RUN ln -s /usr/bin/llvm-symbolizer-10 /usr/bin/llvm-symbolizer
+
 # Additional env for building npcomp and running tests.
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/cuda-10.1/compat/lib.real"
 ENV CC=clang-10

--- a/frontends/pytorch/csrc/type_dispatch/mlir_gen.cpp
+++ b/frontends/pytorch/csrc/type_dispatch/mlir_gen.cpp
@@ -17,6 +17,8 @@
 
 #include "llvm/Support/Debug.h"
 
+#include "npcomp/Dialect/ATen/ATenDialect.h"
+
 #include "ATen/ArrayRef.h"
 namespace at {
 template <typename T> using ArrayRef = c10::ArrayRef<T>;
@@ -32,6 +34,11 @@ template <typename T> using ArrayRef = c10::ArrayRef<T>;
 #define DEBUG_TYPE "torch_mlir"
 
 namespace torch_mlir {
+
+MLIRGen::MLIRGen(mlir::MLIRContext &context) : context(context) {
+  context.getOrLoadDialect<mlir::NPCOMP::aten::ATenDialect>();
+  context.getOrLoadDialect<mlir::StandardOpsDialect>();
+}
 
 std::tuple<mlir::OwningModuleRef, std::vector<at::Tensor>>
 MLIRGen::genModule(std::vector<ir::Value> &v) {

--- a/frontends/pytorch/csrc/type_dispatch/mlir_gen.h
+++ b/frontends/pytorch/csrc/type_dispatch/mlir_gen.h
@@ -17,7 +17,7 @@ namespace torch_mlir {
 class MLIRGen {
 
 public:
-  MLIRGen(mlir::MLIRContext &context) : context(context){};
+  MLIRGen(mlir::MLIRContext &context);
 
   // Generate an MLIR model that computes the given outputs.
   std::tuple<mlir::OwningModuleRef, std::vector<at::Tensor>>


### PR DESCRIPTION
* This gets the pytorch frontend broadly working and what is left appears to be legitimate failures in 9 tests.
* Errors noted in #46