### PR TITLE
[RefE2E] Add support for matmul.

### DIFF
--- a/include/npcomp/Dialect/TCF/IR/TCFOps.td
+++ b/include/npcomp/Dialect/TCF/IR/TCFOps.td
@@ -29,43 +29,26 @@ Add two tensors.
   let results = (outs AnyTensor:$result);
 }
 
-def TCF_BatchMatmulOp : TCF_Op<"batch_matmul"> {
-  let summary = "Performs a batch of matrix multiplications.";
+// TODO: Generalize this op appropriately and add more verification.
+// For example, an unranked operand probably should be allowed and verified
+// dynamically in TCF->TCP lowering if needed.
+def TCF_MatmulOp : TCF_Op<"matmul"> {
+  let summary = "Performs a matrix multiplication";
   let description = [{
-This op, in its simplest case, performs a matrix multiplication between the two operands.
-Let the input shapes of the operands have shape:
-- `lhs`: `[BLHS..., LHSROWS, LHSCOLS]`
-- `rhs`: `[BRHS..., RHSROWS, RHSCOLS]`
-Then `result` will have shape `[broadcast(BLHS, BRHS),LHSROWS,RHSCOLS]`.
+    Performs a matrix multiplication.
 
-This op encounters an error if `LHSCOLS != RHSROWS` or if
-`broadcast(BLHS, BRHS)` is not possible.
+    The tensors have dimensions:
+    - lhs: [M, K]
+    - rhs: [K, N]
+    - result: [M, N]
 
+    If the `K` dimension mismatches between the operands, this op aborts the
+    program.
   }];
-  let arguments = (ins AnyTensor:$lhs, AnyTensor:$rhs);
-  let results = (outs AnyTensor:$result);
-}
+  let arguments = (ins 2DTensorOf<[F32]>:$lhs, 2DTensorOf<[F32]>:$rhs);
+  let results = (outs 2DTensorOf<[F32]>:$result);
 
-// TODO: represent more general convolutions (via more parameters and also more ops)
-// torch.nn.functional has a good summary of frontend needs: https://pytorch.org/docs/stable/nn.functional.html#conv2d
-// TODO: describe error conditions
-def TCF_Conv2DOp : TCF_Op<"conv_2d"> {
-  let summary = "Perform a 2D convolution.";
-  let description = [{
-This op performs a 2D convolution in the sense typical in deep learning
-contexts.
-
-The inputs have the following rank structure:
-- `input`: `[BATCH, Zin, IN0, IN1]`
-- `kernel`: `[Zout, Zin, K0, K1]`
-  }];
-  let arguments = (ins
-    AnyTensor:$input,
-    AnyTensor:$kernel
-  );
-  let results = (outs
-    AnyTensor:$result
-  );
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` functional-type(operands, results)";
 }
 
 #endif // #ifndef TCF_OPS

--- a/include/npcomp/Dialect/TCP/IR/TCPOps.td
+++ b/include/npcomp/Dialect/TCP/IR/TCPOps.td
@@ -20,9 +20,7 @@ class TCP_Op<string mnemonic, list<OpTrait> traits = []>
     : Op<TCP_Dialect, mnemonic, traits> {
 }
 
-// TODO: clarify allowed tensor element types.
-// TODO: HasParent is too restrictive? can't have an island with loop.for with
-// further ops inside it?
+// TODO: Clarify allowed tensor element types.
 def TCP_AddOp
     : TCP_Op<"add", []> {
   let summary = "Adds two tensors.";
@@ -31,6 +29,33 @@ Adds two tensors.
   }];
   let arguments = (ins AnyRankedTensor:$lhs, AnyRankedTensor:$rhs);
   let results = (outs AnyRankedTensor:$result);
+}
+
+// TODO: Generalize this op appropriately and add more verification.
+// For example, should we have a single primitive that does multidimensional
+// contractions? + batching as well in the same op? In fact, if we want to
+// get really general, we can include convolution as well; matmul is the 1x1
+// image and 1x1 kernel special case.
+// It still lowers trivially into linalg.generic even with such generalization
+// -- the main question is what transforms we want to do at the TCP level that
+// would be affected by those design choices.
+def TCP_MatmulOp : TCP_Op<"matmul"> {
+  let summary = "Performs a matrix multiplication";
+  let description = [{
+    Performs a matrix multiplication.
+
+    The tensors have dimensions:
+    - lhs: [M, K]
+    - rhs: [K, N]
+    - result: [M, N]
+
+    If the `K` dimension mismatches between operands, this op has
+    undefined behavior.
+  }];
+  let arguments = (ins 2DTensorOf<[F32]>:$lhs, 2DTensorOf<[F32]>:$rhs);
+  let results = (outs 2DTensorOf<[F32]>:$result);
+
+  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` functional-type(operands, results)";
 }
 
 def TCP_BroadcastToOp : TCP_Op<"broadcast_to"> {

--- a/lib/Conversion/TCFToTCP/TCFToTCP.cpp
+++ b/lib/Conversion/TCFToTCP/TCFToTCP.cpp
@@ -10,6 +10,7 @@
 
 #include "../PassDetail.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Dialect/Traits.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "npcomp/Dialect/TCF/IR/TCFOps.h"
@@ -75,6 +76,35 @@ public:
 } // namespace
 
 namespace {
+class ConvertMatmul : public OpRewritePattern<tcf::MatmulOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(tcf::MatmulOp op,
+                                PatternRewriter &rewriter) const override {
+    // Create the constraints, and the assuming region.
+    Value lhsK = rewriter.create<DimOp>(op.getLoc(), op.lhs(), 1);
+    Value rhsK = rewriter.create<DimOp>(op.getLoc(), op.rhs(), 0);
+    Value matchingK =
+        rewriter.create<CmpIOp>(op.getLoc(), CmpIPredicate::eq, lhsK, rhsK);
+    Value witness = rewriter.create<shape::CstrRequireOp>(
+        op.getLoc(), matchingK, "mismatching contracting dimension for matmul");
+    auto assuming = rewriter.create<shape::AssumingOp>(
+        op.getLoc(), ArrayRef<Type>{op.getType()}, witness);
+
+    // Build the region body.
+    rewriter.createBlock(&assuming.doRegion());
+    Value matmul = rewriter.create<tcp::MatmulOp>(op.getLoc(), op.getType(),
+                                                  op.lhs(), op.rhs());
+    rewriter.create<shape::AssumingYieldOp>(op.getLoc(), matmul);
+
+    // Finally, replace with the results of the shape.assuming
+    rewriter.replaceOp(op, assuming.getResults());
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class ConvertTCFToTCP : public ConvertTCFToTCPBase<ConvertTCFToTCP> {
 public:
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -87,6 +117,7 @@ public:
 
     OwningRewritePatternList patterns;
     patterns.insert<ConvertAdd>(context);
+    patterns.insert<ConvertMatmul>(context);
     (void)applyPatternsAndFoldGreedily(module, patterns);
   }
 };

--- a/test/Conversion/TCFToTCP/basic.mlir
+++ b/test/Conversion/TCFToTCP/basic.mlir
@@ -19,3 +19,23 @@ func @tcf_add(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
   %0 = "tcf.add"(%arg0, %arg1) : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
   return %0 : tensor<?xf32>
 }
+
+// CHECK-LABEL:   func @tcf_matmul(
+// CHECK-SAME:                     %[[LHS:.*]]: tensor<?x?xf32>,
+// CHECK-SAME:                     %[[RHS:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
+// CHECK:           %[[C1:.*]] = constant 1 : index
+// CHECK:           %[[C0:.*]] = constant 0 : index
+// CHECK:           %[[LHSK:.*]] = dim %[[LHS]], %[[C1]] : tensor<?x?xf32>
+// CHECK:           %[[RHSK:.*]] = dim %[[RHS]], %[[C0]] : tensor<?x?xf32>
+// CHECK:           %[[KEQUAL:.*]] = cmpi "eq", %[[LHSK]], %[[RHSK]] : index
+// CHECK:           %[[WITNESS:.*]] = shape.cstr_require %[[KEQUAL]], "{{.*}}"
+// CHECK:           %[[RET:.*]] = shape.assuming %[[WITNESS]] -> (tensor<?x?xf32>) {
+// CHECK:             %[[MATMUL:.*]] = tcp.matmul %[[LHS]], %[[RHS]] : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:             shape.assuming_yield %[[MATMUL]] : tensor<?x?xf32>
+// CHECK:           }
+// CHECK:           return %[[RET:.*]] : tensor<?x?xf32>
+// CHECK:         }
+func @tcf_matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcf.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}

--- a/test/Dialect/TCF/ops.mlir
+++ b/test/Dialect/TCF/ops.mlir
@@ -5,3 +5,9 @@ func @f(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) {
   %0 = "tcf.add"(%arg0, %arg1) : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
   return
 }
+
+func @matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  // CHECK: tcf.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  %0 = tcf.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}

--- a/test/Dialect/TCP/ops.mlir
+++ b/test/Dialect/TCP/ops.mlir
@@ -10,6 +10,12 @@ func @f(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>, %arg2: i32) {
   return
 }
 
+func @matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  // CHECK: tcp.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  %0 = tcp.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
 // CHECK-LABEL:      func @g
 // CHECK-NEXT:   %[[RET:.*]] = tcp.shaped_results %arg1 {
 // CHECK-NEXT:     %[[VAL:.*]] =

--- a/test/E2E/lower-shape-constraints.mlir
+++ b/test/E2E/lower-shape-constraints.mlir
@@ -47,3 +47,12 @@ func @assuming(%arg0: tensor<?xindex>, %arg1: tensor<?xindex>) -> tensor<2xf32> 
   // CHECK: return %[[CST]]
   return %0 : tensor<2xf32>
 }
+
+// CHECK-LABEL: func @cstr_require
+func @cstr_require(%arg0: i1) -> !shape.witness {
+  // CHECK: %[[RET:.*]] = shape.const_witness true
+  // CHECK: assert %arg0, "msg"
+  // CHECK: return %[[RET]]
+  %witness = shape.cstr_require %arg0, "msg"
+  return %witness : !shape.witness
+}

--- a/test/E2E/lower-to-llvm.mlir
+++ b/test/E2E/lower-to-llvm.mlir
@@ -211,7 +211,7 @@ func @inputs1results2(%arg0: !npcomprt.tensor) -> (!npcomprt.tensor, !npcomprt.t
 
 // Test emission of compiler runtime functions.
 
-// CHECK:         llvm.mlir.global internal constant @[[STRSYM:.*]]("msg")
+// CHECK:         llvm.mlir.global internal constant @[[STRSYM:.*]]("msg\00")
 // CHECK:         llvm.func @__npcomp_compiler_rt_abort_if(!llvm.i1, !llvm.ptr<i8>)
 // CHECK:         llvm.func @__npcomp_compiler_rt_to_memref(!llvm.ptr<i8>) -> !llvm.struct<(i64, ptr<i8>)>
 // CHECK:         llvm.func @__npcomp_compiler_rt_from_memref(!llvm.i64, !llvm.ptr<i8>) -> !llvm.ptr<i8>
@@ -219,9 +219,9 @@ func @inputs1results2(%arg0: !npcomprt.tensor) -> (!npcomprt.tensor, !npcomprt.t
 
 // CHECK-LABEL:   llvm.func @calls_abort_if(
 // CHECK-SAME:                              %[[VAL_0:.*]]: !llvm.i1) {
-// CHECK:         %[[VAL_0:.*]] = llvm.mlir.addressof @[[STRSYM]] : !llvm.ptr<array<3 x i8>>
+// CHECK:         %[[VAL_0:.*]] = llvm.mlir.addressof @[[STRSYM]] : !llvm.ptr<array<4 x i8>>
 // CHECK:         %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : !llvm.i32
-// CHECK:         %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]], %[[VAL_1]]] : (!llvm.ptr<array<3 x i8>>, !llvm.i32, !llvm.i32) -> !llvm.ptr<i8>
+// CHECK:         %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]], %[[VAL_1]]] : (!llvm.ptr<array<4 x i8>>, !llvm.i32, !llvm.i32) -> !llvm.ptr<i8>
 // CHECK:         llvm.call @__npcomp_compiler_rt_abort_if(%[[VAL_3:.*]], %[[VAL_2]]) : (!llvm.i1, !llvm.ptr<i8>) -> ()
 // CHECK:         llvm.return
 

--- a/test/npcomp-run-mlir/invalid-matmul.mlir
+++ b/test/npcomp-run-mlir/invalid-matmul.mlir
@@ -1,0 +1,17 @@
+// RUN: not npcomp-run-mlir %s \
+// RUN:   -invoke matmul \
+// RUN:   -arg-value="dense<[[1.0, 0.0, 1.0], [1.0, 1.0, 1.0]]> : tensor<2x3xf32>" \
+// RUN:   -arg-value="dense<[[1.0, 2.0], [3.0, 4.0]]> : tensor<2x2xf32>" \
+// RUN:   -shared-libs=%npcomp_runtime_shlib 2>&1 \
+// RUN:   | FileCheck %s
+
+// Invalid: contracting dimensions don't match.
+// [1 0 1] * [1 2] = [6  8]
+// [1 1 1]   [3 4]   [9 12]
+
+// CHECK: NPCOMP: aborting: mismatching contracting dimension for matmul
+func @matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcf.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+

--- a/test/npcomp-run-mlir/matmul.mlir
+++ b/test/npcomp-run-mlir/matmul.mlir
@@ -1,0 +1,20 @@
+// RUN: npcomp-run-mlir %s \
+// RUN:   -invoke matmul \
+// RUN:   -arg-value="dense<[[1.0, 0.0, 1.0], [1.0, 1.0, 1.0]]> : tensor<2x3xf32>" \
+// RUN:   -arg-value="dense<[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]> : tensor<3x2xf32>" \
+// RUN:   -shared-libs=%npcomp_runtime_shlib 2>&1 \
+// RUN:   | FileCheck %s
+
+// Basic correctness check:
+// [1 0 1] * [1 2] = [6  8]
+// [1 1 1]   [3 4]   [9 12]
+//           [5 6]
+
+// CHECK: output #0: dense<[
+// CHECK-SAME:   [6.000000e+00, 8.000000e+00], [9.000000e+00, 1.200000e+01]
+// CHECK-SAME: ]> : tensor<2x2xf32>
+func @matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcf.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+

--- a/tools/run_lit.sh
+++ b/tools/run_lit.sh
@@ -7,7 +7,7 @@ set -e
 td="$(realpath $(dirname $0)/..)"
 build_dir="$td/build"
 install_mlir="$td/install-mlir"
-build_mlir="$td/build-mlir"
+build_mlir="$td/external/llvm-project/build"
 
 lit_exe="$build_mlir/bin/llvm-lit"
 if ! [ -f "$lit_exe" ]; then
@@ -33,5 +33,5 @@ done
 
 set -x
 cd $build_dir
-ninja npcomp-opt npcomp-run-mlir NPCOMPCompilerRuntimeShlib
+ninja npcomp-opt npcomp-run-mlir NPCOMPCompilerRuntimeShlib NPCOMPNativePyExt
 cd test && python3 "$lit_exe" ${lit_args[@]}


### PR DESCRIPTION
(also, a couple miscellaneous commits in this PR and an integrate (pending upstream submission of a patch))

I'm pretty happy with how this turned out. It looks pretty much like it
should -- one change at each layer. This particular op bottoms out on
linalg which takes care of the rest.

- Add tcf.matmul
- Add tcp.matmul
- Add TCF->TCP lowering
- Add tcp.matmul shape transfer function (BypassShapes.cpp)
- Add tcp.matmul -> linalg.matmul lowering (LowerShapedResultsToMemref.cpp)
- Add support to LowerShapeConstraints for lowering the new
shape.cstr_require

This matmul op is pretty limited in its capabilities. There is no
batching and no multidimensional contraction. Certainly more design work
will be needed to find the right abstractions that aren't too general
but also help to canonicalize many cases from frontends. This is mainly
to show that adding a new op needn't be very "scary" once we have the
e2e infra in place.

Also,
- this clears out some exploratory cruft from the TCF dialect now that
this is starting to become real.
