### PR TITLE
[RefE2E] Add support for "max".

### DIFF
--- a/include/npcomp/Dialect/TCF/IR/TCFOps.td
+++ b/include/npcomp/Dialect/TCF/IR/TCFOps.td
@@ -18,17 +18,29 @@ class TCF_Op<string mnemonic, list<OpTrait> traits = []>
 // TODO: investigate effects framework for defining error semantics
 // TODO: define in a general way across the dialect what "encounters an error" means.
 
-// TODO: verify same dtype?
-// TODO: what are the allowable dtypes?
-def TCF_AddOp : TCF_Op<"add"> {
-  let summary = "Add two tensors.";
-  let description = [{
-Add two tensors.
-  }];
+class BinaryArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
+  TCF_Op<mnemonic, traits> {
   let arguments = (ins AnyTensor:$lhs, AnyTensor:$rhs);
   let results = (outs AnyTensor:$result);
-
   let assemblyFormat = "$lhs `,` $rhs attr-dict `:` functional-type(operands, results)";
+}
+
+def TCF_AddOp : BinaryArithmeticOp<"add"> {
+  let summary = "Addition of two tensors.";
+  let description = [{
+    Addition of two tensors.
+
+    Numpy-style broadcasting is allowed.
+  }];
+}
+
+def TCF_MaxOp : BinaryArithmeticOp<"max"> {
+  let summary = "Maximum of two tensors.";
+  let description = [{
+    Maximum of two tensors.
+
+    Numpy-style broadcasting is allowed.
+  }];
 }
 
 // TODO: Generalize this op appropriately and add more verification.

--- a/include/npcomp/Dialect/TCP/IR/TCPOps.td
+++ b/include/npcomp/Dialect/TCP/IR/TCPOps.td
@@ -21,16 +21,25 @@ class TCP_Op<string mnemonic, list<OpTrait> traits = []>
 }
 
 // TODO: Clarify allowed tensor element types.
-def TCP_AddOp
-    : TCP_Op<"add", []> {
-  let summary = "Adds two tensors.";
-  let description = [{
-Adds two tensors.
-  }];
+class BinaryArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
+  TCP_Op<mnemonic, traits> {
   let arguments = (ins AnyRankedTensor:$lhs, AnyRankedTensor:$rhs);
   let results = (outs AnyRankedTensor:$result);
-
   let assemblyFormat = "$lhs `,` $rhs attr-dict `:` functional-type(operands, results)";
+}
+
+def TCP_AddOp : BinaryArithmeticOp<"add"> {
+  let summary = "Addition of two tensors";
+  let description = [{
+    Addition of two tensors.
+  }];
+}
+
+def TCP_MaxOp : BinaryArithmeticOp<"max"> {
+  let summary = "Maximum of two tensors";
+  let description = [{
+    Maximum of two tensors.
+  }];
 }
 
 // TODO: Generalize this op appropriately and add more verification.

--- a/lib/E2E/BypassShapes.cpp
+++ b/lib/E2E/BypassShapes.cpp
@@ -24,7 +24,8 @@ static SmallVector<Value, 6> bypassResultShapes(Operation &op) {
     return {broadcastTo.shape()};
   }
 
-  if (auto add = dyn_cast<tcp::AddOp>(op)) {
+  // Binary elementwise ops.
+  if (isa<tcp::AddOp, tcp::MaxOp>(op)) {
     return {builder.create<shape::ShapeOfOp>(op.getLoc(), op.getOperand(0))};
   }
 

--- a/test/Dialect/TCF/ops.mlir
+++ b/test/Dialect/TCF/ops.mlir
@@ -1,11 +1,15 @@
 // RUN: npcomp-opt <%s | FileCheck %s --dump-input=fail
 
-func @f(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) {
+// CHECK-LABEL: func @binary_elementwise
+func @binary_elementwise(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) {
   // CHECK: tcf.add %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  // CHECK: tcf.max %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
   %0 = tcf.add %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  %1 = tcf.max %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
   return
 }
 
+// CHECK-LABEL: func @matmul
 func @matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
   // CHECK: tcf.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
   %0 = tcf.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>

--- a/test/Dialect/TCP/ops.mlir
+++ b/test/Dialect/TCP/ops.mlir
@@ -3,27 +3,37 @@
 // CHECK-LABEL: tcp.global @foo dense<0.0{{.*}}> : tensor<10xf32>
 tcp.global @foo dense<0.0> : tensor<10xf32>
 
-func @f(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>, %arg2: i32) {
-  // CHECK: tcp.add
-  %0 = tcp.add %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
-  %1 = tcp.get_global_memref @foo : memref<10xf32>
+// CHECK-LABEL: func @global
+func @global() {
+  // CHECK: tcp.get_global_memref @foo : memref<10xf32>
+  %0 = tcp.get_global_memref @foo : memref<10xf32>
   return
 }
 
+// CHECK-LABEL: func @binary_elementwise
+func @binary_elementwise(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>, %arg2: i32) {
+  // CHECK: tcp.add %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  // CHECK: tcp.max %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  %0 = tcp.add %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  %1 = tcp.max %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  return
+}
+
+// CHECK-LABEL: func @matmul
 func @matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
   // CHECK: tcp.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
   %0 = tcp.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
   return %0 : tensor<?x?xf32>
 }
 
-// CHECK-LABEL:      func @g
+// CHECK-LABEL:      func @shaped_results
 // CHECK-NEXT:   %[[RET:.*]] = tcp.shaped_results %arg1 {
 // CHECK-NEXT:     %[[VAL:.*]] =
 // CHECK-NEXT:     tcp.yield %[[VAL]] : tensor<?x?xf32>
 // CHECK-NEXT:   } : tensor<?xindex> -> tensor<?x?xf32>
 // CHECK-NEXT:   return %[[RET]] : tensor<?x?xf32>
 // CHECK-NEXT: }
-func @g(%arg0: tensor<?x?xf32>, %arg1: tensor<?xindex>) -> tensor<?x?xf32> {
+func @shaped_results(%arg0: tensor<?x?xf32>, %arg1: tensor<?xindex>) -> tensor<?x?xf32> {
   %add = tcp.shaped_results %arg1 {
     %0 = tcp.add %arg0, %arg0 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
     tcp.yield %0 : tensor<?x?xf32>

--- a/test/E2E/bypass-shapes.mlir
+++ b/test/E2E/bypass-shapes.mlir
@@ -19,6 +19,18 @@ func @tcp_add(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
   return %0 : tensor<?xf32>
 }
 
+// TODO: Don't create too many duplicate tests for binary elementwise ops.
+// CHECK-LABEL:   func @tcp_max(
+// CHECK-SAME:                  %[[LHS:.*]]: tensor<?xf32>,
+// CHECK-SAME:                  %[[RHS:.*]]: tensor<?xf32>) -> tensor<?xf32> {
+// CHECK:           %[[LHSSHAPE:.*]] = shape.shape_of %[[LHS]]
+// CHECK:           %[[RET:.*]] = tcp.shaped_results %[[LHSSHAPE]]
+// CHECK:           return %[[RET:.*]] : tensor<?xf32>
+// CHECK:         }
+func @tcp_max(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+  %0 = tcp.max %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
 
 // CHECK-LABEL:   func @tcp_matmul(
 // CHECK-SAME:                 %[[LHS:.*]]: tensor<?x?xf32>,

--- a/test/E2E/lower-shaped-results-to-memref.mlir
+++ b/test/E2E/lower-shaped-results-to-memref.mlir
@@ -41,6 +41,22 @@ func @tcp_add(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
 }
 
 // -----
+// Check just the linalg body. The code is otherwise shared with tcp.add.
+// CHECK-LABEL: func @tcp_max
+// CHECK:           ^bb0(%[[LHS:.*]]: f32, %[[RHS:.*]]: f32, %[[DST:.*]]: f32):
+// CHECK:             %[[GREATER:.*]] = cmpf "ogt", %[[LHS]], %[[RHS]] : f32
+// CHECK:             %[[MAX:.*]] = select %[[GREATER]], %[[LHS]], %[[RHS]] : f32
+// CHECK:             linalg.yield %[[MAX]] : f32
+func @tcp_max(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+  %0 = shape.shape_of %arg0 : tensor<?xf32> -> tensor<?xindex>
+  %1 = tcp.shaped_results %0 {
+    %2 = tcp.max %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+    tcp.yield %2 : tensor<?xf32>
+  } : tensor<?xindex> -> tensor<?xf32>
+  return %1 : tensor<?xf32>
+}
+
+// -----
 
 // CHECK-LABEL:   func @tcp_matmul(
 // CHECK-SAME:                     %arg0: tensor<?x?xf32>,

--- a/test/npcomp-run-mlir/binary-elementwise.mlir
+++ b/test/npcomp-run-mlir/binary-elementwise.mlir
@@ -1,0 +1,16 @@
+// RUN: npcomp-run-mlir %s \
+// RUN:   -invoke max \
+// RUN:   -arg-value="dense<[1.0]> : tensor<1xf32>" \
+// RUN:   -arg-value="dense<[3.0]> : tensor<1xf32>" \
+// RUN:   -shared-libs=%npcomp_runtime_shlib 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=MAX
+
+// These ops share a lot of code paths. So we don't test the exact
+// broadcasting behavior and error checking for all of them.
+
+// MAX: output #0: dense<3.000000e+00> : tensor<1xf32>
+func @max(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+  %0 =  tcf.max %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+


### PR DESCRIPTION
This cleans up the lowering pipeline to easily allow extending to
multiple binary ops. It looks fairly repetitive at multiple levels, but
I don't want to prematurely generalize. I think that in principle we
could derive a large swatch of TCF + TCP from a single linalg-style
specification. Another direction is to use an OpInterface (something
like "buildLinalgGenericBody"). I'm keeping my eye on it.

In a subsequent commit, I'll mechanically add a set of binary ops
modeled off of the std arithmetic ops.