### PR TITLE
Add public API for constructing a module/function to capture PyTorch …

### DIFF
--- a/frontends/pytorch/csrc/c10_dispatch/CMakeLists.txt
+++ b/frontends/pytorch/csrc/c10_dispatch/CMakeLists.txt
@@ -9,14 +9,15 @@ include_directories(
 link_directories("${TORCH_INSTALL_PREFIX}/lib")
 add_library(npcomp_torch_c10_dispatch_bindings
   acap_dispatch.cpp
+  module_builder.cpp
   python_bindings.cpp
 )
 
 get_property(mlir_libs GLOBAL PROPERTY MLIR_ALL_LIBS)
 target_link_libraries(npcomp_torch_c10_dispatch_bindings
-  NPCOMPATenDialect
+  NPCOMPCAPIRegistration
   ${TORCH_LIBRARIES}
-  ${mlir_libs}
   ${PYTHON_LIBRARIES}
+  ${mlir_libs}
   torch_python
   )

--- a/frontends/pytorch/csrc/c10_dispatch/acap_dispatch.h
+++ b/frontends/pytorch/csrc/c10_dispatch/acap_dispatch.h
@@ -11,10 +11,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef NPCOMP_FRONTENDS_PYTORCH_CSRC_C10_DISPATCH_ACAP_DISPATCH_H
+#define NPCOMP_FRONTENDS_PYTORCH_CSRC_C10_DISPATCH_ACAP_DISPATCH_H
+
 #include <list>
 #include <memory>
 
 #include <pybind11/pybind11.h>
+
+#include "mlir-c/IR.h"
 
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <c10/core/impl/LocalDispatchKeySet.h>
@@ -24,7 +29,10 @@ namespace torch_mlir {
 /// Main entry point for managing device capture.
 class AcapController : public std::enable_shared_from_this<AcapController> {
 public:
-  AcapController() = default;
+  AcapController(MlirOperation funcOp) : funcOp(funcOp) {
+    // TODO: Remove once used (suppresses warning).
+    (void)this->funcOp;
+  }
 
   // Enter and exit the context manager.
   pybind11::object contextEnter();
@@ -54,7 +62,11 @@ private:
   };
   // Gets the thread local stack of active acap controllers.
   static std::list<Activation> &getThreadLocalActiveStack();
+
+  MlirOperation funcOp;
   std::vector<std::string> captureLog;
 };
 
 } // namespace torch_mlir
+
+#endif // NPCOMP_FRONTENDS_PYTORCH_CSRC_C10_DISPATCH_ACAP_DISPATCH_H

--- a/frontends/pytorch/csrc/c10_dispatch/module_builder.cpp
+++ b/frontends/pytorch/csrc/c10_dispatch/module_builder.cpp
@@ -1,0 +1,119 @@
+//===- module_builder.cpp -------------------------------------------------===//
+//
+// This file is licensed under a pytorch-style license
+// See frontends/pytorch/LICENSE for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include "module_builder.h"
+
+#include "mlir-c/Registration.h"
+#include "mlir-c/StandardAttributes.h"
+#include "mlir-c/StandardTypes.h"
+#include "npcomp-c/Registration.h"
+
+namespace py = pybind11;
+using namespace torch_mlir;
+
+namespace {
+/// Accumulates into a python string from a method that accepts an
+/// MlirStringCallback.
+/// TODO: Remove this once the MLIR Python objects are exposed directly.
+struct PyPrintAccumulator {
+  py::list parts;
+
+  void *getUserData() { return this; }
+
+  MlirStringCallback getCallback() {
+    return [](const char *part, intptr_t size, void *userData) {
+      PyPrintAccumulator *printAccum =
+          static_cast<PyPrintAccumulator *>(userData);
+      py::str pyPart(part, size); // Decodes as UTF-8 by default.
+      printAccum->parts.append(std::move(pyPart));
+    };
+  }
+
+  py::str join() {
+    py::str delim("", 0);
+    return delim.attr("join")(parts);
+  }
+};
+} // namespace
+
+ModuleBuilder::ModuleBuilder()
+    // TODO: Once the MLIR C/Python capsule API is in place, these should be
+    // derived from Python level objects (which will provide better lifetime
+    // semantics and interop). Until then, they are just scoped to this instance
+    // and must not escape.
+    : context(mlirContextCreate()), unknownLoc(mlirLocationUnknownGet(context)),
+      module(mlirModuleCreateEmpty(unknownLoc)) {
+  // TODO: Rework this once dialect registration C-APIs are in place.
+  // https://reviews.llvm.org/D88162
+  mlirRegisterAllDialects(context);
+  npcompRegisterAllDialects(context);
+}
+
+ModuleBuilder::~ModuleBuilder() {
+  mlirModuleDestroy(module);
+  mlirContextDestroy(context);
+}
+
+py::str ModuleBuilder::getAsm() {
+  MlirOperation operation = mlirModuleGetOperation(module);
+  PyPrintAccumulator printAccum;
+  mlirOperationPrint(operation, printAccum.getCallback(),
+                     printAccum.getUserData());
+  return printAccum.join();
+}
+
+std::shared_ptr<AcapController>
+ModuleBuilder::startCaptureFunction(std::string &name) {
+  // TODO: Populate input/result types.
+  llvm::SmallVector<MlirType, 4> inputTypes;
+  llvm::SmallVector<MlirType, 4> resultTypes;
+  MlirOperation funcOp = createFunction(name, inputTypes, resultTypes);
+  return std::make_shared<AcapController>(funcOp);
+}
+
+// TODO: Implement an mlir-c API for creating a function and avoid the danger
+// of getting the below wrong.
+MlirOperation
+ModuleBuilder::createFunction(std::string &name,
+                              llvm::SmallVectorImpl<MlirType> &inputTypes,
+                              llvm::SmallVectorImpl<MlirType> &resultTypes) {
+  MlirOperation moduleOp = mlirModuleGetOperation(module);
+  MlirBlock moduleBlock =
+      mlirRegionGetFirstBlock(mlirOperationGetRegion(moduleOp, 0));
+
+  llvm::SmallVector<MlirNamedAttribute, 4> funcAttrs;
+  funcAttrs.push_back(mlirNamedAttributeGet(
+      "type", mlirTypeAttrGet(mlirFunctionTypeGet(
+                  context, inputTypes.size(), inputTypes.data(),
+                  resultTypes.size(), resultTypes.data()))));
+  funcAttrs.push_back(mlirNamedAttributeGet(
+      "sym_name", mlirStringAttrGet(context, name.size(), name.data())));
+
+  // TODO: Extract current traceback and use it for location.
+  MlirOperationState state = mlirOperationStateGet("func", unknownLoc);
+  mlirOperationStateAddAttributes(&state, funcAttrs.size(), funcAttrs.data());
+  {
+    // Don't access these once ownership transferred.
+    MlirRegion bodyRegion = mlirRegionCreate();
+    MlirBlock entryBlock =
+        mlirBlockCreate(inputTypes.size(), inputTypes.data());
+    mlirRegionInsertOwnedBlockAfter(bodyRegion, {nullptr}, entryBlock);
+    mlirOperationStateAddOwnedRegions(&state, 1, &bodyRegion);
+  }
+
+  MlirOperation funcOp = mlirOperationCreate(&state);
+  mlirBlockInsertOwnedOperationAfter(moduleBlock, {nullptr}, funcOp);
+  return funcOp;
+}
+
+void ModuleBuilder::bind(py::module &m) {
+  py::class_<ModuleBuilder>(m, "ModuleBuilder")
+      .def(py::init<>())
+      .def("__str__", &ModuleBuilder::getAsm)
+      .def("capture_function", &ModuleBuilder::startCaptureFunction,
+           py::keep_alive<0, 1>());
+}

--- a/frontends/pytorch/csrc/c10_dispatch/module_builder.h
+++ b/frontends/pytorch/csrc/c10_dispatch/module_builder.h
@@ -1,0 +1,50 @@
+//===- module_builder.h -----------------------------------------*- C++ -*-===//
+//
+// This file is licensed under a pytorch-style license
+// See frontends/pytorch/LICENSE for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef NPCOMP_FRONTENDS_PYTORCH_CSRC_C10_DISPATCH_MODULE_BUILDER_H
+#define NPCOMP_FRONTENDS_PYTORCH_CSRC_C10_DISPATCH_MODULE_BUILDER_H
+
+#include <pybind11/pybind11.h>
+
+#include "acap_dispatch.h"
+
+#include "mlir-c/IR.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace torch_mlir {
+
+/// Main entry-point for constructing an MLIR module from some combination
+/// of PyTorch programs/execution.
+class ModuleBuilder {
+public:
+  ModuleBuilder();
+  ~ModuleBuilder();
+
+  /// Creates Python bindings for the class.
+  static void bind(pybind11::module &m);
+
+  // TODO: Remove this once the MLIR Python objects are exposed directly.
+  pybind11::str getAsm();
+
+  // Starts a device-capture based function.
+  // TODO: Add inputs.
+  std::shared_ptr<AcapController> startCaptureFunction(std::string &name);
+
+private:
+  // Creates a new top-level function and returns its operation.
+  MlirOperation createFunction(std::string &name,
+                               llvm::SmallVectorImpl<MlirType> &inputTypes,
+                               llvm::SmallVectorImpl<MlirType> &resultTypes);
+
+  MlirContext context;
+  MlirLocation unknownLoc;
+  MlirModule module;
+};
+
+} // namespace torch_mlir
+
+#endif // NPCOMP_FRONTENDS_PYTORCH_CSRC_C10_DISPATCH_MODULE_BUILDER_H

--- a/frontends/pytorch/csrc/c10_dispatch/python_bindings.cpp
+++ b/frontends/pytorch/csrc/c10_dispatch/python_bindings.cpp
@@ -11,6 +11,7 @@
 
 #include "../init_python_bindings.h"
 #include "acap_dispatch.h"
+#include "module_builder.h"
 
 using namespace torch_mlir;
 namespace py = pybind11;
@@ -127,11 +128,12 @@ py::list GetRegisteredOps() {
 void InitModuleBindings(py::module &m) {
   py::class_<AcapController, std::shared_ptr<AcapController>>(m,
                                                               "AcapController")
-      .def(py::init<>())
       .def("__enter__", &AcapController::contextEnter)
       .def("__exit__", &AcapController::contextExit)
       .def("get_debug_log", &AcapController::getDebugLog);
   m.def("get_registered_ops", &GetRegisteredOps, kGetRegisteredOpsDocstring);
+
+  ModuleBuilder::bind(m);
 }
 
 } // namespace

--- a/frontends/pytorch/csrc/init_python_bindings.cpp
+++ b/frontends/pytorch/csrc/init_python_bindings.cpp
@@ -153,9 +153,7 @@ void InitBindings(py::module &m) {
 #if defined(NPCOMP_ENABLE_TORCH_TYPE_DISPATCH)
   InitTypeDispatchBindings(m);
 #else
-  auto c10_m = m.def_submodule(
-      "c10", "Experimental support for c10 dispatch integration");
-  InitC10DispatchBindings(c10_m);
+  InitC10DispatchBindings(m);
 #endif
 }
 

--- a/frontends/pytorch/csrc/type_dispatch/python_bindings.cpp
+++ b/frontends/pytorch/csrc/type_dispatch/python_bindings.cpp
@@ -134,4 +134,4 @@ void InitModuleBindings(py::module &m) {
 
 void InitTypeDispatchBindings(py::module &m) { InitModuleBindings(m); }
 
-} // namespace
+} // namespace torch_mlir

--- a/frontends/pytorch/test/c10_dispatch/get_registered_ops.py
+++ b/frontends/pytorch/test/c10_dispatch/get_registered_ops.py
@@ -8,4 +8,4 @@ import _torch_mlir
 # This check is just for a built-in op that is unlikely to change (and is
 # otherwise insignificant).
 # CHECK: {'name': ('aten::mul', 'Tensor'), 'is_vararg': False, 'is_varret': False, 'is_mutable': False, 'arguments': [{'name': 'self', 'type': 'Tensor', 'pytype': 'Tensor'}, {'name': 'other', 'type': 'Tensor', 'pytype': 'Tensor'}], 'returns': [{'name': '', 'type': 'Tensor', 'pytype': 'Tensor'}]}
-print('\n\n'.join([repr(r) for r in _torch_mlir.c10.get_registered_ops()]))
+print('\n\n'.join([repr(r) for r in _torch_mlir.get_registered_ops()]))

--- a/frontends/pytorch/test/c10_dispatch/module_builder.py
+++ b/frontends/pytorch/test/c10_dispatch/module_builder.py
@@ -9,16 +9,15 @@ import _torch_mlir as m
 t0 = torch.randn((4,4))
 t1 = torch.randn((4,4))
 
-with m.c10.AcapController() as c:
+mb = m.ModuleBuilder()
+with mb.capture_function("foobar") as c:
   result = t0 + t1
 
-result = result * t0
-
-# NOTE: Ops involved with printing throw RuntimeError about calling a kernel
-# from an unboxed API.
-print(result)
+# CHECK: module {
+# CHECK:   func @foobar() {
+# CHECK:   }
+# CHECK: }
+print(mb)
 
 # CHECK: CAPTURE: aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> (Tensor)
-# CHECK-NOT: CAPTURE: aten::mul
-log = c.get_debug_log()
-for line in log: print(line)
+for line in c.get_debug_log(): print(line)

--- a/include/npcomp-c/Registration.h
+++ b/include/npcomp-c/Registration.h
@@ -1,0 +1,28 @@
+/*===-- npcomp-c/Registration.h - Registration functions  ---------*- C -*-===*\
+|*                                                                            *|
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM          *|
+|* Exceptions.                                                                *|
+|* See https://llvm.org/LICENSE.txt for license information.                  *|
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception                    *|
+|*                                                                            *|
+\*===----------------------------------------------------------------------===*/
+
+#ifndef NPCOMP_C_REGISTRATION_H
+#define NPCOMP_C_REGISTRATION_H
+
+#include "mlir-c/IR.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Registers all NPComp dialects with a context.
+ * This is needed before creating IR for these Dialects.
+ */
+void npcompRegisterAllDialects(MlirContext context);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NPCOMP_C_REGISTRATION_H

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_mlir_library(NPCOMPCAPIRegistration
+  Registration.cpp
+
+  EXCLUDE_FROM_LIBMLIR
+
+  LINK_LIBS PUBLIC
+  NPCOMPInitAll
+  )

--- a/lib/CAPI/Registration.cpp
+++ b/lib/CAPI/Registration.cpp
@@ -1,0 +1,18 @@
+//===- Registration.cpp - C Interface for MLIR Registration ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "npcomp-c/Registration.h"
+
+#include "mlir/CAPI/IR.h"
+#include "npcomp/InitAll.h"
+
+void npcompRegisterAllDialects(MlirContext context) {
+  mlir::NPCOMP::registerAllDialects(unwrap(context)->getDialectRegistry());
+  // TODO: Don't eagerly load once D88162 is in and clients can do this.
+  unwrap(context)->getDialectRegistry().loadAll(unwrap(context));
+}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(CAPI)
 add_subdirectory(Conversion)
 add_subdirectory(Dialect)
 add_subdirectory(E2E)


### PR DESCRIPTION
…ops.

* Uses the MLIR-C API since that will save us a lot of grief down the road (i.e. will give PyTorch and libMLIR/libNPCOMP the ability to skew version-wise).
* Quite a few TODOs and not yet populating the function in any way.