### PR TITLE
[RefE2E] Initialize the linalg matmul accumulator buffer.

### DIFF
--- a/lib/E2E/TensorToMemref/LowerShapedResultsToMemref.cpp
+++ b/lib/E2E/TensorToMemref/LowerShapedResultsToMemref.cpp
@@ -221,6 +221,9 @@ public:
     if (failed(resultsOrFailure))
       return failure();
     auto results = *resultsOrFailure;
+    auto c0 =
+        rewriter.create<ConstantOp>(op.getLoc(), rewriter.getF32FloatAttr(0.0));
+    rewriter.create<linalg::FillOp>(op.getLoc(), results[0], c0);
     rewriter.create<linalg::MatmulOp>(op.getLoc(), operands, results);
     rewriter.replaceOp(op, results);
     return success();

--- a/test/E2E/lower-shaped-results-to-memref.mlir
+++ b/test/E2E/lower-shaped-results-to-memref.mlir
@@ -65,6 +65,8 @@ func @tcp_max(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
 // CHECK:           %[[LHS:.*]] = tcp.tensor_to_memref %arg0 : tensor<?x?xf32> -> memref<?x?xf32>
 // CHECK:           %[[RHS:.*]] = tcp.tensor_to_memref %arg1 : tensor<?x?xf32> -> memref<?x?xf32>
 // CHECK:           %[[RESULT:.*]] = tcp.alloc_memref %[[SHAPE]] : memref<?x?xf32>
+// CHECK:           %[[C0:.*]] = constant 0.000000e+00 : f32
+// CHECK:           linalg.fill(%2, %[[C0]]) : memref<?x?xf32>, f32
 // CHECK:           linalg.matmul ins(%[[LHS]], %[[RHS]] : memref<?x?xf32>, memref<?x?xf32>) outs(%[[RESULT]] : memref<?x?xf32>)
 // CHECK:           %[[RET:.*]] = tcp.memref_to_tensor %[[RESULT]] : memref<?x?xf32> -> tensor<?x?xf32>
 // CHECK:           return %[[RET]] : tensor<?x?xf32>

--- a/test/npcomp-run-mlir/matmul.mlir
+++ b/test/npcomp-run-mlir/matmul.mlir
@@ -5,6 +5,13 @@
 // RUN:   -shared-libs=%npcomp_runtime_shlib 2>&1 \
 // RUN:   | FileCheck %s
 
+// RUN: npcomp-run-mlir %s \
+// RUN:   -invoke matmul \
+// RUN:   -arg-value="dense<0.0> : tensor<2x3xf32>" \
+// RUN:   -arg-value="dense<0.0> : tensor<3x2xf32>" \
+// RUN:   -shared-libs=%npcomp_runtime_shlib 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=ZEROS
+
 // Basic correctness check:
 // [1 0 1] * [1 2] = [6  8]
 // [1 1 1]   [3 4]   [9 12]
@@ -13,6 +20,11 @@
 // CHECK: output #0: dense<[
 // CHECK-SAME:   [6.000000e+00, 8.000000e+00], [9.000000e+00, 1.200000e+01]
 // CHECK-SAME: ]> : tensor<2x2xf32>
+
+// Check with zeros as well. The result should be identically zeros.
+// If any uninitialized data sneaks in (even very small values that would be
+// rounding errors for the test case above), it will show up here.
+// ZEROS: output #0: dense<0.000000e+00> : tensor<2x2xf32>
 func @matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
   %0 = tcf.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
   return %0 : tensor<?x?xf32>


### PR DESCRIPTION
I was seeing some miscompiles due to the uninitialized data read here
before. Interestingly, this was masked in some of our previous test
cases, since the uninitialized data "always" was so small that it would
present as a rounding error for the 1.0-10.0 sized values that the
matmul was computing on.