### PR TITLE
Implement torch.kernel_call capture.

### DIFF
--- a/frontends/pytorch/csrc/c10_dispatch/acap_dispatch.cpp
+++ b/frontends/pytorch/csrc/c10_dispatch/acap_dispatch.cpp
@@ -7,14 +7,22 @@
 
 #include "acap_dispatch.h"
 
+#include "mlir-c/StandardAttributes.h"
 #include "npcomp/Python/PybindUtils.h"
 
+#include <ATen/core/function_schema.h>
+#include <ATen/core/ivalue.h>
+#include <ATen/core/stack.h>
 #include <c10/core/DispatchKey.h>
 #include <torch/library.h>
 
 using namespace torch_mlir;
 
 namespace py = pybind11;
+
+using c10::FunctionSchema;
+using c10::OperatorHandle;
+using c10::Stack;
 
 // TODO: Private use dispatch keys are not made for real uses. Allocate a proper
 // dispatch key in upstream PyTorch (DispatchKey.h) prior to maturity. Note
@@ -47,6 +55,42 @@ void AcapController::contextExit(py::object exc_type, py::object exc_val,
                            "Mismatched context manager __exit__");
   }
   stack.pop_front();
+
+  if (!hasReturned) {
+    returns({});
+  }
+}
+
+void AcapController::returns(std::vector<at::Tensor> tensors) {
+  verifyHasNotReturned();
+
+  llvm::SmallVector<MlirType, 4> returnsTypes;
+  llvm::SmallVector<MlirValue, 4> returnsValues;
+  for (auto &tensor : tensors) {
+    MlirValue v = funcBuilder->lookupTensor(tensor);
+    // TODO: Add mlirValueIsNull()
+    if (!v.ptr) {
+      // Exclude recursive dispatch in order to print tensor.
+      c10::impl::ExcludeDispatchKeyGuard exclusion(kAcapDispatchKey);
+      std::stringstream msg;
+      msg << "Cannot return a tensor that is not from the capture context: ";
+      msg << tensor;
+      throw std::invalid_argument(msg.str());
+    }
+
+    returnsTypes.push_back(mlirValueGetType(v));
+    returnsValues.push_back(v);
+  }
+
+  // TODO: Get location from traceback.
+  MlirLocation loc = mlirLocationUnknownGet(funcBuilder->getContext());
+  OperationStateHolder s("std.return", loc);
+  mlirOperationStateAddOperands(&s.state, returnsValues.size(),
+                                returnsValues.data());
+  funcBuilder->getEntryBlockBuilder().insertBeforeTerminator(
+      s.createOperation());
+  funcBuilder->rewriteFuncReturnTypes(returnsTypes);
+  hasReturned = true;
 }
 
 std::vector<std::string> AcapController::getDebugLog() {
@@ -62,21 +106,168 @@ std::shared_ptr<AcapController> AcapController::getCurrent() {
   return stack.front().controller;
 }
 
-void AcapController::fallbackKernel(const c10::OperatorHandle &opHandle,
-                                    c10::Stack *stack) {
+void AcapController::verifyHasNotReturned() {
+  if (hasReturned) {
+    throw std::runtime_error(
+        "Function has already returned. Cannot trace more operations.");
+  }
+}
+
+/* static */
+void AcapController::fallbackKernel(const OperatorHandle &opHandle,
+                                    Stack *stack) {
+  auto current = getCurrent();
+  if (!current) {
+    current->redispatch(opHandle, stack);
+    return;
+  }
+  current->fallbackKernelImpl(opHandle, stack);
+}
+
+void AcapController::redispatch(const c10::OperatorHandle &opHandle,
+                                c10::Stack *stack) {
+  // Exclude recursive dispatch to this kernel.
+  c10::impl::ExcludeDispatchKeyGuard exclusion(kAcapDispatchKey);
+  // Passthrough.
+  auto &dispatcher = c10::Dispatcher::singleton();
+  dispatcher.callBoxed(opHandle, stack);
+}
+
+void AcapController::fallbackKernelImpl(const OperatorHandle &opHandle,
+                                        Stack *stack) {
+  verifyHasNotReturned();
   // Exclude recursive dispatch to this kernel.
   c10::impl::ExcludeDispatchKeyGuard exclusion(kAcapDispatchKey);
 
-  auto current = getCurrent();
-  if (current) {
-    // Capture the dispatch.
-    std::stringstream sout;
-    sout << "CAPTURE: " << opHandle.schema() << "\n";
-    current->captureLog.push_back(sout.str());
+  const FunctionSchema &schema = opHandle.schema();
+
+  // Check for unsupported.
+  if (schema.is_vararg() || schema.is_varret()) {
+    throw std::invalid_argument(
+        "Cannot capture ops with variable arguments or returns");
   }
 
-  auto &dispatcher = c10::Dispatcher::singleton();
-  dispatcher.callBoxed(opHandle, stack);
+  // TODO: Extract actual location from stack.
+  MlirContext context = funcBuilder->getContext();
+  MlirLocation loc = mlirLocationUnknownGet(context);
+  OperationStateHolder stateHolder("torch.kernel_call", loc);
+
+  // Add the kernel_name attribute.
+  auto kernelName = schema.name();
+  MlirNamedAttribute kernelNameAttr = mlirNamedAttributeGet(
+      "kernel_name",
+      mlirStringAttrGet(context, kernelName.size(), kernelName.data()));
+  mlirOperationStateAddAttributes(&stateHolder.state, 1, &kernelNameAttr);
+
+  // Map arguments to operands.
+  // This must be accumulated into the OperationState prior to re-dispatch
+  // since the stack is modified at that point.
+  size_t argCount = schema.arguments().size();
+  assert(stack->size() >= argCount && "stack too short");
+  llvm::SmallVector<MlirValue, 4> operands;
+  for (auto argIt = stack->end() - argCount; argIt != stack->end(); ++argIt) {
+    MlirValue mlirValue = mapIValueToMlirValue(loc, *argIt);
+    // TODO: Add upstream mlirValueIsNull
+    if (!mlirValue.ptr) {
+      std::stringstream out;
+      out << "Unsupported capture value passed to kernel (" << argIt->tagKind()
+          << "): " << *argIt;
+      throw std::invalid_argument(out.str());
+    }
+    operands.push_back(mlirValue);
+  }
+  mlirOperationStateAddOperands(&stateHolder.state, operands.size(),
+                                operands.data());
+
+  // Invoke the original kernel.
+  redispatch(opHandle, stack);
+
+  // Map returns to results.
+  size_t returnCount = schema.returns().size();
+  assert(stack->size() >= returnCount && "stack too short");
+  llvm::SmallVector<MlirType, 4> resultTypes;
+  llvm::SmallVector<std::pair<size_t, at::Tensor>, 4> resultIndexToTensorMap;
+  for (auto returnIt = stack->end() - returnCount; returnIt != stack->end();
+       ++returnIt) {
+    size_t resultIndex = resultTypes.size();
+    MlirType resultType = mapIValueToMlirType(loc, *returnIt);
+    if (mlirTypeIsNull(resultType)) {
+      std::stringstream out;
+      out << "Unsupported capture value returned from kernel ("
+          << returnIt->tagKind() << "): " << *returnIt;
+      throw std::invalid_argument(out.str());
+    }
+    resultTypes.push_back(resultType);
+    if (returnIt->isTensor()) {
+      resultIndexToTensorMap.emplace_back(resultIndex, returnIt->toTensor());
+    }
+  }
+  mlirOperationStateAddResults(&stateHolder.state, resultTypes.size(),
+                               resultTypes.data());
+
+  // Create operation.
+  MlirOperation op = stateHolder.createOperation();
+  funcBuilder->getEntryBlockBuilder().insertBeforeTerminator(op);
+
+  // Map result tensors.
+  for (auto &it : resultIndexToTensorMap) {
+    MlirValue result = mlirOperationGetResult(op, it.first);
+    funcBuilder->mapTensor(it.second, result);
+  }
+
+  // Add to debug log.
+  std::stringstream sout;
+  sout << "CAPTURE: " << opHandle.schema() << "\n";
+  captureLog.push_back(sout.str());
+}
+
+MlirValue AcapController::mapIValueToMlirValue(MlirLocation loc,
+                                               c10::IValue &ival) {
+  if (ival.isScalar()) {
+    return funcBuilder->getScalarConstant(loc, ival.toScalar());
+  }
+  if (ival.isTensor()) {
+    // Is it an already mapped tensor?
+    MlirValue mappedValue = funcBuilder->lookupTensor(ival.toTensor());
+    // TODO: Add mlirValueIsNull()
+    if (mappedValue.ptr) {
+      return mappedValue;
+    }
+
+    throw std::invalid_argument(
+        "TODO: implement tensor import for non-arg tensors");
+  }
+  return {nullptr};
+  // TODO: Implement mappings for the whole set (relevant to this use case):
+  // _(None)
+  // _(Tensor)
+  // _(Double)
+  // _(Int)
+  // _(Bool)
+  // _(Tuple)
+  // _(String)
+  // _(Blob)
+  // _(GenericList)
+  // _(GenericDict)
+  // _(Future)
+  // _(Device)
+  // _(Object)
+  // _(PyObject)
+  // _(Uninitialized)
+  // _(Capsule)
+  // _(RRef)
+  // _(Generator)
+}
+
+MlirType AcapController::mapIValueToMlirType(MlirLocation loc,
+                                             c10::IValue &ival) {
+  if (ival.isScalar()) {
+    return typeMapper.mapScalarType(ival.toScalar().type());
+  }
+  if (ival.isTensor()) {
+    return typeMapper.forwardTensorToType(ival.toTensor());
+  }
+  return {nullptr};
 }
 
 TORCH_LIBRARY_IMPL(_, ACAP_DISPATCH_KEY, m) {

--- a/frontends/pytorch/csrc/c10_dispatch/func_builder.h
+++ b/frontends/pytorch/csrc/c10_dispatch/func_builder.h
@@ -16,6 +16,33 @@
 
 namespace torch_mlir {
 
+/// Wraps an MlirOperationState, deallocating it on destruction unless if
+/// it has been consumed.
+class OperationStateHolder {
+public:
+  OperationStateHolder(const char *name, MlirLocation loc)
+      : state(mlirOperationStateGet(name, loc)) {}
+  OperationStateHolder(const OperationStateHolder &) = delete;
+  OperationStateHolder(OperationStateHolder &&other) = delete;
+  ~OperationStateHolder() {
+    if (owned) {
+      // TODO: Upstream a mlirOperationStateDestroy() function.
+      mlirOperationDestroy(createOperation());
+    }
+  }
+
+  MlirOperation createOperation() {
+    assert(owned && "cannot createOperation on unowned state");
+    owned = false;
+    return mlirOperationCreate(&state);
+  }
+
+  MlirOperationState state;
+
+private:
+  bool owned = true;
+};
+
 /// Maps various runtime types to MlirType.
 class TypeMapper {
 public:
@@ -47,6 +74,11 @@ public:
   MlirOperation getTerminator() { return terminator; }
   bool getIsReturnTerminator() { return isReturn; }
 
+  /// Inserts an owned operation before the terminator.
+  void insertBeforeTerminator(MlirOperation op) {
+    mlirBlockInsertOwnedOperationBefore(block, terminator, op);
+  }
+
 private:
   MlirBlock block;
   MlirOperation terminator;
@@ -65,10 +97,16 @@ public:
                  llvm::StringRef name,
                  llvm::SmallVectorImpl<MlirType> &inputTypes);
 
+  MlirContext getContext() { return context; }
   MlirOperation getFuncOp() { return funcOp; }
 
   /// Gets the function's entry block.
   MlirBlock getEntryBlock() { return entryBlock.getBlock(); }
+  BlockBuilder &getEntryBlockBuilder() { return entryBlock; }
+
+  /// Rewrites the function's signature to return the given types. It is
+  /// assumed that a compatible terminator has been added.
+  void rewriteFuncReturnTypes(llvm::SmallVectorImpl<MlirType> &resultTypes);
 
   /// Maps a live Tensor to an MlirValue.
   void mapTensor(at::Tensor tensor, MlirValue value) {
@@ -79,12 +117,20 @@ public:
   /// value if not found.
   MlirValue lookupTensor(at::Tensor tensor);
 
+  /// Gets a scalar constant value.
+  MlirValue getScalarConstant(MlirLocation loc, at::Scalar s);
+
 private:
   FuncBuilder(MlirContext context, MlirOperation funcOp,
               BlockBuilder entryBlock)
       : context(context), funcOp(funcOp), entryBlock(std::move(entryBlock)) {
     (void)this->context;
   }
+
+  /// Inserts a constant op into the function, returning its first result.
+  /// The function maintains a constant area at the top where these are
+  /// inserted.
+  MlirValue insertConstantOp(MlirOperation op);
 
   MlirContext context;
 
@@ -94,10 +140,15 @@ private:
   /// Block builder for the entry block.
   BlockBuilder entryBlock;
 
+  /// Previously inserted constant op or null.
+  MlirOperation prevConstantOp = {nullptr};
+
   /// Maps tensors to MlirValue. Unfortunately, this needs to be a linear scan
   /// because the impl pointer for the Tensor is not accessible. To make this
   /// slightly better, we add to the back and lookup in reverse under the idea
   /// that tensors may be mapped and accessed in proximity.
+  /// TODO: Tensors referenced via an IValue support hash code lookup and
+  /// identity checks. Switch to this instead of a linear scan.
   llvm::SmallVector<std::pair<at::Tensor, MlirValue>, 16> tensorValueMap;
 };
 

--- a/frontends/pytorch/csrc/c10_dispatch/module_builder.cpp
+++ b/frontends/pytorch/csrc/c10_dispatch/module_builder.cpp
@@ -93,7 +93,7 @@ ModuleBuilder::startCaptureFunction(std::string &name,
     funcBuilder->mapTensor(it.value(),
                            mlirBlockGetArgument(entryBlock, it.index()));
   }
-  return std::make_shared<AcapController>(std::move(funcBuilder));
+  return std::make_shared<AcapController>(typeMapper, std::move(funcBuilder));
 }
 
 MlirBlock ModuleBuilder::getBodyBlock() {

--- a/frontends/pytorch/csrc/c10_dispatch/python_bindings.cpp
+++ b/frontends/pytorch/csrc/c10_dispatch/python_bindings.cpp
@@ -130,6 +130,7 @@ void InitModuleBindings(py::module &m) {
                                                               "AcapController")
       .def("__enter__", &AcapController::contextEnter)
       .def("__exit__", &AcapController::contextExit)
+      .def("returns", &AcapController::returns)
       .def("get_debug_log", &AcapController::getDebugLog);
   m.def("get_registered_ops", &GetRegisteredOps, kGetRegisteredOpsDocstring);
 

--- a/frontends/pytorch/test/c10_dispatch/module_builder.py
+++ b/frontends/pytorch/test/c10_dispatch/module_builder.py
@@ -8,19 +8,22 @@
 import torch
 import _torch_mlir as m
 
-t0 = torch.randn((4,4))
-t1 = torch.randn((4,4))
+t0 = torch.randn((1,4))
+t1 = torch.randn((4,1))
 
 mb = m.ModuleBuilder()
-with mb.capture_function("foobar", [t0, t1]) as c:
+with mb.capture_function("foobar", [t0, t1]) as f:
   result = t0 + t1
+  f.returns([result])
 
 # CHECK: module {
-# CHECK:   func @foobar(%arg0: !numpy.ndarray<[4,4]:f32>, %arg1: !numpy.ndarray<[4,4]:f32>) {
-# CHECK:     return
+# CHECK:   func @foobar(%arg0: !numpy.ndarray<[1,4]:f32>, %arg1: !numpy.ndarray<[4,1]:f32>) {
+# CHECK:     %c1_i64 = constant 1 : i64
+# CHECK:     %0 = torch.kernel_call "aten::add" %arg0, %arg1, %c1_i64 : (!numpy.ndarray<[1,4]:f32>, !numpy.ndarray<[4,1]:f32>, i64) -> !numpy.ndarray<[4,4]:f32>
+# CHECK:     return %0 : !numpy.ndarray<[4,4]:f32>
 # CHECK:   }
 # CHECK: }
 print(mb)
 
 # CHECK: CAPTURE: aten::add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> (Tensor)
-for line in c.get_debug_log(): print(line)
+for line in f.get_debug_log(): print(line)

--- a/include/npcomp/Dialect/Torch/IR/TorchBase.td
+++ b/include/npcomp/Dialect/Torch/IR/TorchBase.td
@@ -89,6 +89,9 @@ def AnyScalar : AnyTypeOf<[
     Basicpy_BoolType,
     Basicpy_StrType,
     Basicpy_NoneType,
+    // Allow signless integers for ease of conversions. In general, this
+    // dialect uses signed integers.
+    AnySignlessInteger,
   ], "Any primitive type suitable to be passed as a Torch Scalar">;
 
 def AnyTorchType : AnyTypeOf<[

--- a/include/npcomp/Dialect/Torch/IR/TorchOps.td
+++ b/include/npcomp/Dialect/Torch/IR/TorchOps.td
@@ -21,9 +21,6 @@ def Torch_KernelCall : Torch_Op<"kernel_call"> {
     Torch kernel calls are matched by the runtime based on signature, including
     the fully qualified kernel name (i.e. "namespace::name") and the tuple of
     argument types. This op models such an invocation.
-
-    Caveat: When interacting with the PyTorch boxed interpreter stack, the
-    arguments follow a convention that the top of stack is the first argument.
   }];
 
   let arguments = (ins


### PR DESCRIPTION
* Had to stop short of modifying the function return signature because of a missing C-API upstream.
* Committing here is good enough for a test and will resolve the various TODOs about upstream APIs next.