### PR TITLE
[RefBackend] Split out TCF->TCP conversion.

### DIFF
--- a/include/npcomp/RefBackend/RefBackend.h
+++ b/include/npcomp/RefBackend/RefBackend.h
@@ -54,6 +54,15 @@ struct RefBackendLoweringPipelineOptions
 void createRefBackendLoweringPipeline(
     OpPassManager &pm, const RefBackendLoweringPipelineOptions &options);
 
+// Helper pipeline that runs TCF->TCP lowering before invoking
+// RefBackendLoweringPipeline.
+// For now, just piggy-back on the same set of options since this is such a
+// thin wrapper.
+// Longer-term, the reference backend should fit into some sort of
+// "target interface" and this helper won't be needed.
+void createTCFRefBackendLoweringPipeline(
+    OpPassManager &pm, const RefBackendLoweringPipelineOptions &options);
+
 } // namespace NPCOMP
 } // namespace mlir
 

--- a/lib/RefBackend/JITHelpers/JITModule.cpp
+++ b/lib/RefBackend/JITHelpers/JITModule.cpp
@@ -32,7 +32,7 @@ void JITModule::buildBackendCompilationPipeline(PassManager &pm,
                                                 bool optimize) {
   NPCOMP::RefBackendLoweringPipelineOptions options;
   options.optimize = optimize;
-  NPCOMP::createRefBackendLoweringPipeline(pm, options);
+  NPCOMP::createTCFRefBackendLoweringPipeline(pm, options);
 }
 
 llvm::Expected<std::unique_ptr<JITModule>>

--- a/test/RefBackend/e2e-basic.mlir
+++ b/test/RefBackend/e2e-basic.mlir
@@ -1,5 +1,5 @@
-// RUN: npcomp-opt <%s -pass-pipeline=refback-lowering-pipeline | FileCheck %s --dump-input=fail
-// RUN: npcomp-opt <%s -pass-pipeline=refback-lowering-pipeline{optimize} | FileCheck %s --dump-input=fail
+// RUN: npcomp-opt <%s -pass-pipeline=tcf-refback-lowering-pipeline | FileCheck %s --dump-input=fail
+// RUN: npcomp-opt <%s -pass-pipeline=tcf-refback-lowering-pipeline{optimize} | FileCheck %s --dump-input=fail
 
 // This is the simplest case, which is easy to stare at for debugging
 // purposes.

--- a/test/RefBackend/e2e-constants.mlir
+++ b/test/RefBackend/e2e-constants.mlir
@@ -1,5 +1,5 @@
-// RUN: npcomp-opt <%s -pass-pipeline=refback-lowering-pipeline | FileCheck %s --dump-input=fail
-// RUN: npcomp-opt <%s -pass-pipeline=refback-lowering-pipeline{optimize} | FileCheck %s --dump-input=fail
+// RUN: npcomp-opt <%s -pass-pipeline=tcf-refback-lowering-pipeline | FileCheck %s --dump-input=fail
+// RUN: npcomp-opt <%s -pass-pipeline=tcf-refback-lowering-pipeline{optimize} | FileCheck %s --dump-input=fail
 
 // -----
 // CHECK-LABEL: func @global_add

--- a/test/RefBackend/e2e-mixed-ranks.mlir
+++ b/test/RefBackend/e2e-mixed-ranks.mlir
@@ -1,5 +1,5 @@
-// RUN: npcomp-opt <%s -pass-pipeline=refback-lowering-pipeline | FileCheck %s --dump-input=fail
-// RUN: npcomp-opt <%s -pass-pipeline=refback-lowering-pipeline{optimize} | FileCheck %s --dump-input=fail
+// RUN: npcomp-opt <%s -pass-pipeline=tcf-refback-lowering-pipeline | FileCheck %s --dump-input=fail
+// RUN: npcomp-opt <%s -pass-pipeline=tcf-refback-lowering-pipeline{optimize} | FileCheck %s --dump-input=fail
 
 // CHECK-LABEL: func @rank1
 func @rank1(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {


### PR DESCRIPTION
Now the reference backend is cleanly accepts "TCP"+scalar ops.

We introduce tcf-refback-lowering-pipeline which also does TCF->TCP
conversion for convenience until we have a "target interface".