### PR TITLE
Update test configuration to import mlir from LLVM install location.

### DIFF
--- a/frontends/pytorch/test/acap_regression/test_export_ResA.py
+++ b/frontends/pytorch/test/acap_regression/test_export_ResA.py
@@ -13,7 +13,7 @@ import npcomp.frontends.pytorch as torch_mlir
 
 import inspect
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 class ResA(nn.Module):
     def __init__(self, channels):

--- a/frontends/pytorch/test/acap_regression/test_export_add3.py
+++ b/frontends/pytorch/test/acap_regression/test_export_add3.py
@@ -5,7 +5,7 @@
 import torch
 import npcomp.frontends.pytorch as torch_mlir
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 t0 = torch.randn((1,2,3,4), device=dev)

--- a/frontends/pytorch/test/acap_regression/test_export_batchnorm.py
+++ b/frontends/pytorch/test/acap_regression/test_export_batchnorm.py
@@ -5,7 +5,7 @@
 import torch
 import npcomp.frontends.pytorch as torch_mlir
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 

--- a/frontends/pytorch/test/acap_regression/test_export_conv2d_back.py
+++ b/frontends/pytorch/test/acap_regression/test_export_conv2d_back.py
@@ -5,7 +5,7 @@
 import torch
 import npcomp.frontends.pytorch as torch_mlir
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 

--- a/frontends/pytorch/test/acap_regression/test_export_multi_out.py
+++ b/frontends/pytorch/test/acap_regression/test_export_multi_out.py
@@ -5,7 +5,7 @@
 import torch
 import npcomp.frontends.pytorch as torch_mlir
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 

--- a/frontends/pytorch/test/acap_regression/test_export_resnet18.py
+++ b/frontends/pytorch/test/acap_regression/test_export_resnet18.py
@@ -6,7 +6,7 @@ import torch
 import npcomp.frontends.pytorch as torch_mlir
 import torchvision.models as models
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 

--- a/frontends/pytorch/test/acap_regression/test_export_vgg11.py
+++ b/frontends/pytorch/test/acap_regression/test_export_vgg11.py
@@ -6,7 +6,7 @@ import torch
 import npcomp.frontends.pytorch as torch_mlir
 import torchvision.models as models
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 

--- a/frontends/pytorch/test/acap_regression/test_jit_add2.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_add2.py
@@ -6,7 +6,7 @@ import torch
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 t0 = torch.randn((4,4), device=dev)

--- a/frontends/pytorch/test/acap_regression/test_jit_add3.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_add3.py
@@ -6,7 +6,7 @@ import torch
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 t0 = torch.randn((1,2,3,4), device=dev)

--- a/frontends/pytorch/test/acap_regression/test_jit_add_views.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_add_views.py
@@ -6,7 +6,7 @@ import torch
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 t0 = torch.randn((4,16,4), device=dev)

--- a/frontends/pytorch/test/acap_regression/test_jit_as_stride.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_as_stride.py
@@ -6,7 +6,7 @@ import torch
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 

--- a/frontends/pytorch/test/acap_regression/test_jit_conv2d.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_conv2d.py
@@ -6,7 +6,7 @@ import torch
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 model = torch.nn.Conv2d(2,16,7,stride=[2,2], padding=[3,3],
                         dilation=1, groups=1, bias=True)

--- a/frontends/pytorch/test/acap_regression/test_jit_conv2d_back.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_conv2d_back.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 

--- a/frontends/pytorch/test/acap_regression/test_jit_lenet_back.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_lenet_back.py
@@ -10,7 +10,7 @@ import torch.optim as optim
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 class Net(nn.Module):
     def __init__(self):

--- a/frontends/pytorch/test/acap_regression/test_jit_lenet_fwd.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_lenet_fwd.py
@@ -14,7 +14,7 @@ from torch.optim.lr_scheduler import StepLR
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 class Net(nn.Module):
     def __init__(self):

--- a/frontends/pytorch/test/acap_regression/test_jit_linear.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_linear.py
@@ -6,7 +6,7 @@ import torch
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 

--- a/frontends/pytorch/test/acap_regression/test_jit_logsoftmax.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_logsoftmax.py
@@ -6,7 +6,7 @@ import torch
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 model = torch.nn.LogSoftmax(dim=0)
 tensor = torch.ones(1,2,3,4)

--- a/frontends/pytorch/test/acap_regression/test_jit_maxpool.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_maxpool.py
@@ -6,7 +6,7 @@ import torch
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 model = torch.nn.MaxPool2d(kernel_size=(3,3), stride=(2,2), padding=(1,1),
                            dilation=1, return_indices=False, ceil_mode=False)

--- a/frontends/pytorch/test/acap_regression/test_jit_mlp_back.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_mlp_back.py
@@ -14,7 +14,7 @@ from torch.optim.lr_scheduler import StepLR
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 class Net(nn.Module):
     def __init__(self):
@@ -28,20 +28,20 @@ class Net(nn.Module):
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
         return F.log_softmax(self.fc3(x), dim=1)
-    
+
 def main():
     device = torch_mlir.mlir_device()
     model = Net()
     tensor = torch.randn((64, 1, 28, 28),requires_grad=True)
     # CHECK: PASS! fwd check
     fwd_path = test.check_ref(model, tensor)
-    
+
     target = torch.ones((64), dtype=torch.long)
     loss = F.nll_loss
-        
+
     # CHECK: PASS! back check
     test.check_back(fwd_path, target, loss)
-    
+
     # CHECK: PASS! fc1_weight_grad check
     test.compare(model.fc1.weight.grad, fwd_path[0].fc1.weight.grad, "fc1_weight_grad")
 

--- a/frontends/pytorch/test/acap_regression/test_jit_mm.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_mm.py
@@ -6,7 +6,7 @@ import torch
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 

--- a/frontends/pytorch/test/acap_regression/test_jit_mul2.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_mul2.py
@@ -6,7 +6,7 @@ import torch
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 t0 = torch.randn((4,4), device=dev)

--- a/frontends/pytorch/test/acap_regression/test_jit_nllloss.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_nllloss.py
@@ -6,7 +6,7 @@ import torch
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 model = torch.nn.LogSoftmax(dim=1)
 tensor = torch.randn(3,5,requires_grad=True)

--- a/frontends/pytorch/test/acap_regression/test_jit_relu.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_relu.py
@@ -6,7 +6,7 @@ import torch
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 model = torch.nn.ReLU()
 tensor = torch.randn(10)

--- a/frontends/pytorch/test/acap_regression/test_jit_t.py
+++ b/frontends/pytorch/test/acap_regression/test_jit_t.py
@@ -6,7 +6,7 @@ import torch
 import npcomp.frontends.pytorch as torch_mlir
 import npcomp.frontends.pytorch.test as test
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 

--- a/frontends/pytorch/test/acap_regression/test_op_report_conv2d.py
+++ b/frontends/pytorch/test/acap_regression/test_op_report_conv2d.py
@@ -5,7 +5,7 @@
 import torch
 import npcomp.frontends.pytorch as torch_mlir
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 dev = torch_mlir.mlir_device()
 

--- a/frontends/pytorch/test/acap_regression/test_op_report_vgg_style_lenet.py
+++ b/frontends/pytorch/test/acap_regression/test_op_report_vgg_style_lenet.py
@@ -2,7 +2,6 @@
 # This file is licensed under a pytorch-style license
 # See frontends/pytorch/LICENSE for license information.
 
-from __future__ import print_function
 import argparse
 import torch
 import torch.nn as nn
@@ -14,7 +13,7 @@ from torch.optim.lr_scheduler import StepLR
 import npcomp.frontends.pytorch as torch_mlir
 import json
 
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 class Net(nn.Module):
     def __init__(self):

--- a/frontends/pytorch/test/c10_dispatch/get_registered_ops.py
+++ b/frontends/pytorch/test/c10_dispatch/get_registered_ops.py
@@ -1,7 +1,7 @@
 # -*- Python -*-
 # This file is licensed under a pytorch-style license
 # See frontends/pytorch/LICENSE for license information.
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 import _torch_mlir
 

--- a/frontends/pytorch/test/c10_dispatch/module_builder.py
+++ b/frontends/pytorch/test/c10_dispatch/module_builder.py
@@ -1,7 +1,7 @@
 # -*- Python -*-
 # This file is licensed under a pytorch-style license
 # See frontends/pytorch/LICENSE for license information.
-# RUN: python %s | FileCheck %s
+# RUN: %PYTHON %s | FileCheck %s
 
 # TODO: Once stabilized, expand tests to include all argument dtypes.
 

--- a/frontends/pytorch/test/extension_coexistence.py
+++ b/frontends/pytorch/test/extension_coexistence.py
@@ -1,0 +1,18 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See frontends/pytorch/LICENSE for license information.
+
+# Some checks that we can import the various extensions and libraries and
+# not have symbol collisions or other goings on.
+# RUN: %PYTHON %s
+
+import sys
+
+print(f"PYTHONPATH={sys.path}")
+
+import mlir
+import npcomp
+import _npcomp
+import _torch_mlir
+
+print("Extensions all loaded")

--- a/frontends/pytorch/test/lit.cfg.py
+++ b/frontends/pytorch/test/lit.cfg.py
@@ -21,7 +21,6 @@ from lit.llvm.subst import FindTool
 config.name = 'FRONTENDS_PYTORCH'
 
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
-config.environment['PYTHONPATH'] = os.path.join(config.npcomp_obj_root, "python")
 if 'TEST_SRC_PATH' in os.environ:
    config.environment['TEST_SRC_PATH'] = os.environ['TEST_SRC_PATH']
 
@@ -39,6 +38,7 @@ config.test_exec_root = os.path.join(config.npcomp_obj_root, 'test')
 
 config.substitutions.append(('%PATH%', config.environment['PATH']))
 config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
+config.substitutions.append(('%PYTHON', config.python_executable))
 
 llvm_config.with_system_environment(
     ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])
@@ -59,6 +59,11 @@ config.npcomp_tools_dir = os.path.join(config.npcomp_obj_root, 'bin')
 
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
+llvm_config.with_environment('PYTHONPATH', [
+    os.path.join(config.llvm_obj_root, "python"),
+    os.path.join(config.npcomp_obj_root, "python")],
+    append_path=True)
+
 
 tool_dirs = [config.npcomp_tools_dir, config.llvm_tools_dir]
 tools = [

--- a/test/Python/extension_coexistence.py
+++ b/test/Python/extension_coexistence.py
@@ -1,0 +1,13 @@
+# Some checks that we can import the various extensions and libraries and
+# not have symbol collisions or other goings on.
+# RUN: %PYTHON %s
+
+import sys
+
+print(f"PYTHONPATH={sys.path}")
+
+import mlir
+import npcomp
+import _npcomp
+
+print("Extensions all loaded")

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -55,9 +55,10 @@ config.npcomp_runtime_shlib = os.path.join(
 
 # Tweak the PATH and PYTHONPATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
-llvm_config.with_environment('PYTHONPATH',
-                             [os.path.join(config.npcomp_obj_root, "python")],
-                             append_path=True)
+llvm_config.with_environment('PYTHONPATH', [
+    os.path.join(config.llvm_obj_root, "python"),
+    os.path.join(config.npcomp_obj_root, "python")],
+    append_path=True)
 
 tool_dirs = [
     os.path.join(config.npcomp_bin_dir),


### PR DESCRIPTION
* Also adds two lit tests to verify that all of our extensions load without fireworks, which is a good indication that the shared library deps are sane.
* Depends on upstream D89167.