### PR TITLE
[RefBackend] Use upstream BufferizeTypeConverter

### DIFF
--- a/include/npcomp/Dialect/Refback/IR/RefbackOps.td
+++ b/include/npcomp/Dialect/Refback/IR/RefbackOps.td
@@ -36,35 +36,8 @@ def Refback_GlobalOp : Refback_Op<"global", [Symbol]> {
 }
 
 //===----------------------------------------------------------------------===//
-// Ops related to tensor->memref conversion.
+// Ops related to bufferization.
 //===----------------------------------------------------------------------===//
-// TODO: These ops probably belong in a "Refback on memrefs" dialect analogous
-// to `lmhlo`
-
-// TODO: Use TypesMatchWith to verify this better.
-def Refback_TensorToMemrefOp : Refback_Op<"tensor_to_memref", [NoSideEffect]> {
-  let summary = "Converts a tensor to a memref";
-  let description = [{
-    This op is used to materialize conversions to allow incremental lowering of
-    tensors to memrefs.
-  }];
-  let arguments = (ins AnyRankedTensor:$tensor);
-  let results = (outs AnyMemRef:$memref);
-  let assemblyFormat = "attr-dict $tensor `:` type($tensor) `->` type($memref)";
-  let hasFolder = 1;
-}
-
-// TODO: Use TypesMatchWith to verify this better.
-def Refback_MemrefToTensorOp : Refback_Op<"memref_to_tensor", [NoSideEffect]> {
-  let summary = "Converts a memref to a tensor";
-  let description = [{
-    This op is used to materialize conversions to allow incremental lowering of
-    tensors to memrefs.
-  }];
-  let arguments = (ins AnyMemRef:$memref);
-  let results = (outs AnyRankedTensor:$tensor);
-  let assemblyFormat = "attr-dict $memref `:` type($memref) `->` type($tensor)";
-}
 
 def Refback_AllocMemRefOp : Refback_Op<"alloc_memref", []> {
   let summary = "Allocates a memref of the given shape.";

--- a/lib/Dialect/Refback/IR/RefbackOps.cpp
+++ b/lib/Dialect/Refback/IR/RefbackOps.cpp
@@ -16,16 +16,6 @@ using namespace mlir::NPCOMP;
 using namespace mlir::NPCOMP::refback;
 
 //===----------------------------------------------------------------------===//
-// TensorToMemrefOp
-//===----------------------------------------------------------------------===//
-
-OpFoldResult TensorToMemrefOp::fold(ArrayRef<Attribute> operands) {
-  if (auto memrefToTensor = tensor().getDefiningOp<refback::MemrefToTensorOp>())
-    return memrefToTensor.memref();
-  return nullptr;
-}
-
-//===----------------------------------------------------------------------===//
 // ShapedResultsOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/RefBackend/RefBackend.cpp
+++ b/lib/RefBackend/RefBackend.cpp
@@ -224,7 +224,7 @@ void mlir::NPCOMP::createRefBackendLoweringPipeline(
   // rather than a single mega dialect conversion pass.
   //
   // This means that intermediate steps have source/target materializations
-  // (refback.memref_to_tensor / refback.tensor_to_memref) in the IR.
+  // (tensor_load / tensor_to_memref) in the IR.
 
   // Lower ops enclosed in refback.shaped_results regions.
   // For now, this is covering the "tensor compute" ops like tcp.add /

--- a/lib/RefBackend/TensorToMemref/LowerConstantTensorsToMemref.cpp
+++ b/lib/RefBackend/TensorToMemref/LowerConstantTensorsToMemref.cpp
@@ -99,8 +99,7 @@ class LowerConstantTensorsToMemref
       auto memrefType = MemRefType::get(type.getShape(), type.getElementType());
       auto memref = builder.create<refback::GetGlobalMemrefOp>(
           op.getLoc(), memrefType, global.getName());
-      Value tensor =
-          builder.create<refback::MemrefToTensorOp>(op.getLoc(), type, memref);
+      Value tensor = builder.create<TensorLoadOp>(op.getLoc(), type, memref);
       op.replaceAllUsesWith(tensor);
       op.erase();
     });

--- a/test/Dialect/Refback/canonicalize.mlir
+++ b/test/Dialect/Refback/canonicalize.mlir
@@ -1,9 +1,0 @@
-// RUN: npcomp-opt -canonicalize <%s | FileCheck %s --dump-input=fail
-
-// CHECK-LABEL: func @tensor_to_memref
-func @tensor_to_memref_fold(%arg0: memref<?xf32>) -> memref<?xf32> {
-  // CHECK-NEXT: return %arg0 : memref<?xf32>
-  %0 = refback.memref_to_tensor %arg0 : memref<?xf32> -> tensor<?xf32>
-  %1 = refback.tensor_to_memref %0 : tensor<?xf32> -> memref<?xf32>
-  return %1 : memref<?xf32>
-}

--- a/test/RefBackend/lower-constant-tensors-to-memref.mlir
+++ b/test/RefBackend/lower-constant-tensors-to-memref.mlir
@@ -7,7 +7,7 @@
 // CHECK: func @basic
 func @basic() -> tensor<3x4xf32> {
   // CHECK: %[[MEMREF:.*]] = refback.get_global_memref @__constant_3x4xf32 : memref<3x4xf32>
-  // CHECK: %[[TENSOR:.*]] = refback.memref_to_tensor %[[MEMREF]]
+  // CHECK: %[[TENSOR:.*]] = tensor_load %[[MEMREF]]
   %0 = constant dense<7.0> : tensor<3x4xf32>
   // CHECK: return %[[TENSOR]]
   return %0 : tensor<3x4xf32>

--- a/test/RefBackend/lower-shaped-results-to-memref.mlir
+++ b/test/RefBackend/lower-shaped-results-to-memref.mlir
@@ -20,15 +20,15 @@ func @tcp_broadcast_to(%arg0: tensor<?xf32>, %arg1: tensor<?xindex>) -> tensor<?
 // CHECK-SAME:                  %arg0: tensor<?xf32>,
 // CHECK-SAME:                  %arg1: tensor<?xf32>) -> tensor<?xf32> {
 // CHECK:           %[[LHSSHAPE:.*]] = shape.shape_of %arg0 : tensor<?xf32> -> tensor<?xindex>
-// CHECK:           %[[LHS:.*]] = refback.tensor_to_memref %arg0 : tensor<?xf32> -> memref<?xf32>
-// CHECK:           %[[RHS:.*]] = refback.tensor_to_memref %arg1 : tensor<?xf32> -> memref<?xf32>
+// CHECK:           %[[LHS:.*]] = tensor_to_memref %arg0 : memref<?xf32>
+// CHECK:           %[[RHS:.*]] = tensor_to_memref %arg1 : memref<?xf32>
 // CHECK:           %[[RESULT:.*]] = refback.alloc_memref %[[LHSSHAPE]] : memref<?xf32>
 // CHECK:           linalg.generic {{.*}} ins(%[[LHS]], %[[RHS]] {{.*}}) outs(%[[RESULT]] {{.*}}) {
 // CHECK:           ^bb0(%[[VAL_6:.*]]: f32, %[[VAL_7:.*]]: f32, %[[VAL_8:.*]]: f32):
 // CHECK:             %[[VAL_9:.*]] = addf %[[VAL_6]], %[[VAL_7]] : f32
 // CHECK:             linalg.yield %[[VAL_9]] : f32
 // CHECK:           }
-// CHECK:           %[[RET:.*]] = refback.memref_to_tensor %[[RESULT]] : memref<?xf32> -> tensor<?xf32>
+// CHECK:           %[[RET:.*]] = tensor_load %[[RESULT]] : memref<?xf32>
 // CHECK:           return %[[RET]] : tensor<?xf32>
 // CHECK:         }
 func @tcp_add(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
@@ -62,13 +62,13 @@ func @tcp_max(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
 // CHECK-SAME:                     %arg0: tensor<?x?xf32>,
 // CHECK-SAME:                     %arg1: tensor<?x?xf32>,
 // CHECK-SAME:                     %[[SHAPE:.*]]: tensor<?xindex>) -> tensor<?x?xf32> {
-// CHECK:           %[[LHS:.*]] = refback.tensor_to_memref %arg0 : tensor<?x?xf32> -> memref<?x?xf32>
-// CHECK:           %[[RHS:.*]] = refback.tensor_to_memref %arg1 : tensor<?x?xf32> -> memref<?x?xf32>
+// CHECK:           %[[LHS:.*]] = tensor_to_memref %arg0 : memref<?x?xf32>
+// CHECK:           %[[RHS:.*]] = tensor_to_memref %arg1 : memref<?x?xf32>
 // CHECK:           %[[RESULT:.*]] = refback.alloc_memref %[[SHAPE]] : memref<?x?xf32>
 // CHECK:           %[[C0:.*]] = constant 0.000000e+00 : f32
 // CHECK:           linalg.fill(%2, %[[C0]]) : memref<?x?xf32>, f32
 // CHECK:           linalg.matmul ins(%[[LHS]], %[[RHS]] : memref<?x?xf32>, memref<?x?xf32>) outs(%[[RESULT]] : memref<?x?xf32>)
-// CHECK:           %[[RET:.*]] = refback.memref_to_tensor %[[RESULT]] : memref<?x?xf32> -> tensor<?x?xf32>
+// CHECK:           %[[RET:.*]] = tensor_load %[[RESULT]] : memref<?x?xf32>
 // CHECK:           return %[[RET]] : tensor<?x?xf32>
 // CHECK:         }
 func @tcp_matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %shape: tensor<?xindex>) -> tensor<?x?xf32> {

--- a/test/RefBackend/lower-std-to-memref.mlir
+++ b/test/RefBackend/lower-std-to-memref.mlir
@@ -5,7 +5,7 @@
 // that to make the test actually check what happens in practice.
 
 // CHECK-LABEL:   func @extract_element
-// CHECK:           %[[MEMREF:.*]] = refback.tensor_to_memref %arg0
+// CHECK:           %[[MEMREF:.*]] = tensor_to_memref %arg0
 // CHECK:           %[[RET:.*]] = load %[[MEMREF]][%arg1] : memref<?xf32>
 // CHECK:           return %[[RET]] : f32
 func @extract_element(%arg0: tensor<?xf32>, %arg1: index) -> f32 {
@@ -20,7 +20,7 @@ func @extract_element(%arg0: tensor<?xf32>, %arg1: index) -> f32 {
 // CHECK:           store %[[ARG0]], %[[MEMREF]][%[[C0]]]
 // CHECK:           %[[C1:.*]] = constant 1 : index
 // CHECK:           store %[[ARG1]], %[[MEMREF]][%[[C1]]]
-// CHECK:           %[[RET:.*]] = refback.memref_to_tensor %[[MEMREF]]
+// CHECK:           %[[RET:.*]] = tensor_load %[[MEMREF]]
 // CHECK:           return %[[RET]] : tensor<2xindex>
 func @tensor_from_elements(%arg0: index, %arg1: index) -> tensor<2xindex> {
   %0 = tensor_from_elements %arg0, %arg1 : tensor<2xindex>
@@ -30,9 +30,9 @@ func @tensor_from_elements(%arg0: index, %arg1: index) -> tensor<2xindex> {
 
 // CHECK-LABEL:   func @tensor_cast(
 // CHECK-SAME:                      %[[ARG0:.*]]: tensor<?xindex>) -> tensor<2xindex> {
-// CHECK:           %[[MEMREF:.*]] = refback.tensor_to_memref %[[ARG0]] : tensor<?xindex> -> memref<?xindex>
+// CHECK:           %[[MEMREF:.*]] = tensor_to_memref %[[ARG0]]
 // CHECK:           %[[CASTED:.*]] = memref_cast %[[MEMREF]] : memref<?xindex> to memref<2xindex>
-// CHECK:           %[[RET:.*]] = refback.memref_to_tensor %[[CASTED]] : memref<2xindex> -> tensor<2xindex>
+// CHECK:           %[[RET:.*]] = tensor_load %[[CASTED]]
 // CHECK:           return %[[RET]] : tensor<2xindex>
 func @tensor_cast(%arg0: tensor<?xindex>) -> tensor<2xindex> {
   %0 = tensor_cast %arg0 : tensor<?xindex> to tensor<2xindex>
@@ -41,7 +41,7 @@ func @tensor_cast(%arg0: tensor<?xindex>) -> tensor<2xindex> {
 
 // CHECK-LABEL:   func @tensor_load(
 // CHECK-SAME:                      %[[ARG0:.*]]: memref<?xindex>) -> tensor<?xindex> {
-// CHECK:           %[[RET:.*]] = refback.memref_to_tensor %[[ARG0]] : memref<?xindex> -> tensor<?xindex>
+// CHECK:           %[[RET:.*]] = tensor_load %[[ARG0]]
 // CHECK:           return %[[RET]] : tensor<?xindex>
 func @tensor_load(%arg0: memref<?xindex>) -> tensor<?xindex> {
   %0 = tensor_load %arg0 : memref<?xindex>

--- a/test/RefBackend/lower-structural-to-memref.mlir
+++ b/test/RefBackend/lower-structural-to-memref.mlir
@@ -63,8 +63,8 @@ func @for(%arg0: tensor<f32>, %lb: index, %ub: index, %step: index) -> tensor<f3
 // CHECK-LABEL: func @identity_materializations(%arg0: memref<?xf32>) -> memref<?xf32> {
 // CHECK-NEXT:    return %arg0 : memref<?xf32>
 func @identity_materializations(%arg0: tensor<?xf32>) -> tensor<?xf32> {
-  %0 = refback.tensor_to_memref %arg0 : tensor<?xf32> -> memref<?xf32>
-  %1 = refback.memref_to_tensor %0 : memref<?xf32> -> tensor<?xf32>
+  %0 = tensor_to_memref %arg0 : memref<?xf32>
+  %1 = tensor_load %0 : memref<?xf32>
   return %1 : tensor<?xf32>
 }
 
@@ -76,7 +76,7 @@ func @identity_materializations(%arg0: tensor<?xf32>) -> tensor<?xf32> {
 // CHECK-NEXT:    }
 // CHECK-NEXT:    return %[[RET]] : memref<?xf32>
 func @if_materializations(%pred: i1, %true_val_memref: memref<?xf32>, %false_val: tensor<?xf32>) -> tensor<?xf32> {
-  %true_val = refback.memref_to_tensor %true_val_memref : memref<?xf32> -> tensor<?xf32>
+  %true_val = tensor_load %true_val_memref : memref<?xf32>
   %0 = scf.if %pred -> (tensor<?xf32>) {
     scf.yield %true_val : tensor<?xf32>
   } else {
@@ -85,16 +85,16 @@ func @if_materializations(%pred: i1, %true_val_memref: memref<?xf32>, %false_val
   return %0 : tensor<?xf32>
 }
 
-// CHECK-LABEL: func @elide_memref_to_tensor(%arg0: memref<?xf32>) -> memref<?xf32> {
+// CHECK-LABEL: func @elide_tensor_load(%arg0: memref<?xf32>) -> memref<?xf32> {
 // CHECK-NEXT:    return %arg0 : memref<?xf32>
-func @elide_memref_to_tensor(%arg0: memref<?xf32>) -> tensor<?xf32> {
-  %0 = refback.memref_to_tensor %arg0 : memref<?xf32> -> tensor<?xf32>
+func @elide_tensor_load(%arg0: memref<?xf32>) -> tensor<?xf32> {
+  %0 = tensor_load %arg0 : memref<?xf32>
   return %0 : tensor<?xf32>
 }
 
 // CHECK-LABEL: func @elide_tensor_to_memref(%arg0: memref<?xf32>) -> memref<?xf32> {
 // CHECK-NEXT:    return %arg0 : memref<?xf32>
 func @elide_tensor_to_memref(%arg0: tensor<?xf32>) -> memref<?xf32> {
-  %0 = refback.tensor_to_memref %arg0 : tensor<?xf32> -> memref<?xf32>
+  %0 = tensor_to_memref %arg0 : memref<?xf32>
   return %0 : memref<?xf32>
 }

--- a/tools/bash_helpers.sh
+++ b/tools/bash_helpers.sh
@@ -12,7 +12,7 @@ npcomp-opt() {
   # Usage:
   # $ npcomp-opt <regular npcomp-opt options>
   ninja -C "$build_dir" npcomp-opt 1>&2 || return 1
-  "${build_dir}/tools/npcomp-opt/npcomp-opt" "$@"
+  "${build_dir}/bin/npcomp-opt" "$@"
 }
 
 npcomp-run-mlir() {
@@ -24,7 +24,7 @@ npcomp-run-mlir() {
   # Usage:
   # $ npcomp-run-mlir <regular npcomp-run-mlir options>
   ninja -C "$build_dir" npcomp-run-mlir NPCOMPCompilerRuntimeShlib 1>&2 || return 1
-  $build_dir/tools/npcomp-run-mlir/npcomp-run-mlir \
+  "$build_dir/bin/npcomp-run-mlir" \
     -shared-libs="${build_dir}/lib/libNPCOMPCompilerRuntimeShlib.so" "$@"
 }
 
@@ -37,7 +37,7 @@ mnist-playground() {
   # Usage:
   # $ mnist-playground <regular mnist-playground options>
   ninja -C "$build_dir" mnist-playground NPCOMPCompilerRuntimeShlib 1>&2 || return 1
-  $build_dir/tools/mnist-playground/mnist-playground \
+  "$build_dir/bin/mnist-playground" \
     -shared-libs="${build_dir}/lib/libNPCOMPCompilerRuntimeShlib.so" "$@"
 }
 
@@ -59,6 +59,3 @@ npctall() {
 # https://stackoverflow.com/a/34272881
 # https://superuser.com/q/253068
 export FIGNORE=$FIGNORE:nstall-mlir
-
-export PYTHONPATH="$(realpath ${build_dir}/python):$(realpath ${build_dir}/python_native):$(realpath ${build_dir}/iree/bindings/python)"
-


### PR DESCRIPTION
Now that it has grown source/target materialization capabilities
(spelled with ops tensor_load/tensor_to_memref), we can use it. We can
also now delete refback.memref_to_tensor/refback.tensor_to_memref.

This is also a first step to reducing the downstream functionality
needed in the refback dialect.