### PR TITLE
More progress on PyTorch acap device capture.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Create docker image (or follow your own preferences):
 * Mount the `/build` directory (in the container) appropriately for your case.
 
 ```shell
-docker build docker/pytorch-1.6 --tag local/npcomp:build-pytorch-1.6
+docker build docker/pytorch-nightly --tag local/npcomp:build-pytorch-nightly
 docker volume create npcomp-build
 ```
 
@@ -134,7 +134,7 @@ Shell into docker image:
 docker run \
   --mount type=bind,source=$HOME/src/mlir-npcomp,target=/src/mlir-npcomp \
   --mount source=npcomp-build,target=/build \
-  --rm -it local/npcomp:build-pytorch-1.6 /bin/bash
+  --rm -it local/npcomp:build-pytorch-nightly /bin/bash
 ```
 
 Build/test npcomp (from within docker image):

--- a/build_tools/docker_shell_funcs.sh
+++ b/build_tools/docker_shell_funcs.sh
@@ -4,25 +4,25 @@
 # source $WHERE_YOU_CHECKED_OUT_NPCOMP/build_tools/docker_shell_funcs.sh
 # ```
 
-td="$(realpath $(dirname "${BASH_SOURCE[0]}")/..)"
+__npcomp_dir="$(realpath $(dirname "${BASH_SOURCE[0]}")/..)"
 
 # Build the docker images for npcomp:
-#   npcomp:build-pytorch-1.6
-#   me/npcomp:build-pytorch-1.6  (additional dev packages and current user)
+#   npcomp:build-pytorch-nightly
+#   me/npcomp:build-pytorch-nightly  (additional dev packages and current user)
 function npcomp_docker_build() {
-  if ! [ -f "docker/pytorch-1.6/Dockerfile" ]; then
+  if ! [ -f "docker/pytorch-nightly/Dockerfile" ]; then
     echo "Please run out of mlir-npcomp/ source directory..."
     return 1
   fi
   echo "Building out of $(pwd)..."
-  docker build docker/pytorch-1.6 --tag npcomp:build-pytorch-1.6
-  npcomp_docker_build_for_me npcomp:build-pytorch-1.6
+  docker build docker/pytorch-nightly --tag npcomp:build-pytorch-nightly
+  npcomp_docker_build_for_me npcomp:build-pytorch-nightly
 }
 
 # Start a container named "npcomp" in the background with the current-user
 # dev image built above.
 function npcomp_docker_start() {
-  local host_src_dir="${1-$td}"
+  local host_src_dir="${1-$__npcomp_dir}"
   if ! [ -d "$host_src_dir" ]; then
     echo "mlir-npcomp source directory not found:"
     echo "Pass path to host source directory as argument (default=$host_src_dir)."
@@ -32,7 +32,7 @@ function npcomp_docker_start() {
   docker run -d --rm --name "npcomp" \
     --mount source=npcomp-build,target=/build \
     --mount type=bind,source=$host_src_dir,target=/src/mlir-npcomp \
-    me/npcomp:build-pytorch-1.6 tail -f /dev/null
+    me/npcomp:build-pytorch-nightly tail -f /dev/null
 }
 
 # Stop the container named "npcomp".

--- a/docker/pytorch-nightly/Dockerfile
+++ b/docker/pytorch-nightly/Dockerfile
@@ -14,7 +14,8 @@ RUN ln -s /usr/bin/llvm-symbolizer-10 /usr/bin/llvm-symbolizer
 
 # Install PyTorch
 # Installs under: /usr/local/lib/python3.8/dist-packages/torch
-RUN pip3 install torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+RUN pip3 install numpy
+RUN pip3 install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 RUN ln -s /usr/local/lib/python3.8/dist-packages/torch /pytorch
 
 # Build configuration

--- a/frontends/pytorch/csrc/c10_dispatch/acap_dispatch.h
+++ b/frontends/pytorch/csrc/c10_dispatch/acap_dispatch.h
@@ -56,11 +56,14 @@ public:
                              c10::Stack *stack);
 
 private:
+  MlirLocation getCurrentLocation();
   void redispatch(const c10::OperatorHandle &opHandle, c10::Stack *stack);
   void fallbackKernelImpl(const c10::OperatorHandle &opHandle,
                           c10::Stack *stack);
   MlirValue mapIValueToMlirValue(MlirLocation loc, c10::IValue &ival);
   MlirType mapIValueToMlirType(MlirLocation loc, c10::IValue &ival);
+  /// Imports a tensor by value (as a constant), remembering the association.
+  MlirValue importTensorByValue(at::Tensor tensor);
   void verifyHasNotReturned();
   struct Activation {
     Activation(std::shared_ptr<AcapController> controller)

--- a/frontends/pytorch/csrc/c10_dispatch/func_builder.h
+++ b/frontends/pytorch/csrc/c10_dispatch/func_builder.h
@@ -120,6 +120,13 @@ public:
   /// Gets a scalar constant value.
   MlirValue getScalarConstant(MlirLocation loc, at::Scalar s);
 
+  /// Gets a bool constant value.
+  MlirValue getBoolConstant(MlirLocation loc, bool v);
+
+  /// Gets a general constant value representing the given value
+  /// attribute.
+  MlirValue getGeneralConstant(MlirLocation loc, MlirAttribute value);
+
 private:
   FuncBuilder(MlirContext context, MlirOperation funcOp,
               BlockBuilder entryBlock)

--- a/frontends/pytorch/test/CMakeLists.txt
+++ b/frontends/pytorch/test/CMakeLists.txt
@@ -11,6 +11,7 @@ configure_lit_site_cfg(
 
 set(TEST_DEPENDS
   FileCheck count not
+  npcomp-opt
   NPCOMPTorchMLIRExt
   )
 

--- a/include/npcomp-c/Types.h
+++ b/include/npcomp-c/Types.h
@@ -49,6 +49,9 @@ int npcompTypeIsANdArray(MlirType t);
 MlirType npcompNdArrayTypeGetRanked(intptr_t rank, const int64_t *shape,
                                     MlirType elementType);
 
+/// Helper that gets an equivalent NdArrayType from a ShapedType.
+MlirType npcompNdArrayTypeGetFromShaped(MlirType shapedType);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/npcomp/Dialect/Numpy/IR/NumpyDialect.h
+++ b/include/npcomp/Dialect/Numpy/IR/NumpyDialect.h
@@ -40,6 +40,9 @@ public:
   static NdArrayType get(Type dtype,
                          llvm::Optional<ArrayRef<int64_t>> shape = llvm::None);
 
+  /// Helper that gets an equivalent NdArrayType from a ShapedType.
+  static NdArrayType getFromShapedType(ShapedType shapedType);
+
   /// Returns whether the dtype is a concrete type (versus
   /// !basicpy.UnknownType).
   bool hasKnownDtype();

--- a/include/npcomp/Dialect/Torch/IR/TorchBase.td
+++ b/include/npcomp/Dialect/Torch/IR/TorchBase.td
@@ -86,6 +86,7 @@ def AnyTorchTensorType : AnyTypeOf<[
 
 def AnyScalar : AnyTypeOf<[
     AnySignedInteger,
+    AnyFloat,
     Basicpy_BoolType,
     Basicpy_StrType,
     Basicpy_NoneType,

--- a/lib/CAPI/Types.cpp
+++ b/lib/CAPI/Types.cpp
@@ -9,9 +9,11 @@
 #include "npcomp-c/Types.h"
 
 #include "mlir/CAPI/IR.h"
+#include "mlir/IR/StandardTypes.h"
 #include "npcomp/Dialect/Basicpy/IR/BasicpyDialect.h"
 #include "npcomp/Dialect/Numpy/IR/NumpyDialect.h"
 
+using namespace mlir;
 using namespace mlir::NPCOMP::Basicpy;
 using namespace mlir::NPCOMP::Numpy;
 
@@ -45,4 +47,9 @@ MlirType npcompNdArrayTypeGetRanked(intptr_t rank, const int64_t *shape,
                                     MlirType elementType) {
   llvm::ArrayRef<int64_t> shapeArray(shape, rank);
   return wrap(NdArrayType::get(unwrap(elementType), shapeArray));
+}
+
+MlirType npcompNdArrayTypeGetFromShaped(MlirType shapedType) {
+  return wrap(
+      NdArrayType::getFromShapedType(unwrap(shapedType).cast<ShapedType>()));
 }

--- a/lib/Dialect/Numpy/IR/NumpyDialect.cpp
+++ b/lib/Dialect/Numpy/IR/NumpyDialect.cpp
@@ -195,6 +195,13 @@ NdArrayType NdArrayType::get(Type dtype,
   return Base::get(dtype.getContext(), dtype, shape);
 }
 
+NdArrayType NdArrayType::getFromShapedType(ShapedType shapedType) {
+  llvm::Optional<ArrayRef<int64_t>> shape;
+  if (shapedType.hasRank())
+    shape = shapedType.getShape();
+  return get(shapedType.getElementType(), shape);
+}
+
 bool NdArrayType::hasKnownDtype() {
   return getDtype() != Basicpy::UnknownType::get(getContext());
 }


### PR DESCRIPTION
* Now gets far enough to capture batch_norm.
* Has some issues still with in-place ops.
* Can materialize constants.
* Includes an upgrade to PyTorch nightly, which has important bug fixes for fallback and boxed kernel dispatch.
* Fixes #78, #79, #80.
* Will do more testing in a follow-up once further bugs are fixed that facilitate getting at the other features.