### PR TITLE
Replace deprecated add-path in GitHub Action

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Configure Environment
-      run: echo "::add-path::$GITHUB_WORKSPACE/${LLVM}/install/bin"
+      run: echo "$GITHUB_WORKSPACE/${LLVM}/install/bin" >> $GITHUB_PATH
     - name: Get npcomp
       uses: actions/checkout@v2
       with:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Configure Environment
-      run: echo "::add-path::$GITHUB_WORKSPACE/${LLVM}/install/bin"
+      run: echo "$GITHUB_WORKSPACE/${LLVM}/install/bin" >> $GITHUB_PATH
     - name: Get npcomp
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
The add-path command is deprecated and should be replaced as stated in
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/