### PR TITLE
Add missing dependency on NPCOMPCAPI from NPCOMPPythonCommon

### DIFF
--- a/lib/Python/CMakeLists.txt
+++ b/lib/Python/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(NPCOMPPythonCommon
 target_link_libraries(NPCOMPPythonCommon
   pybind11::module
   NPCOMPInitAll
+  NPCOMPCAPI
 
   # Core dialects
   MLIRSCF


### PR DESCRIPTION
Fix linker error:

lib/Python/libNPCOMPPythonCommon.a(MlirInit.cpp.o): in function `mlir::npcomp::python::npcompMlirInitialize()':
mlir-npcomp/build/../lib/Python/MlirInit.cpp:46: undefined reference to `npcompInitializeLLVMCodegen'