### PR TITLE
[RefBackend] Support element-wise multiply op

### DIFF
--- a/include/npcomp/Dialect/TCF/IR/TCFOps.td
+++ b/include/npcomp/Dialect/TCF/IR/TCFOps.td
@@ -43,6 +43,13 @@ def TCF_MaxOp : BinaryArithmeticOp<"max"> {
   }];
 }
 
+def TCF_MulOp : BinaryArithmeticOp<"mul"> {
+  let summary = "Multiply an input tensor by a scalar tensor.";
+  let description = [{
+    Multiplies each element of the input `input` with the scalar `other` and returns a new resulting tensor. The tensor types must match and shapes must be broadcastable.
+  }];
+}
+
 class UnaryArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
   TCF_Op<mnemonic,
         !listconcat(traits, [AllTypesMatch<["operand", "result"]>])>,

--- a/include/npcomp/Dialect/TCP/IR/TCPOps.td
+++ b/include/npcomp/Dialect/TCP/IR/TCPOps.td
@@ -42,6 +42,13 @@ def TCP_MaxOp : BinaryArithmeticOp<"max"> {
   }];
 }
 
+def TCF_MulOp : BinaryArithmeticOp<"mul"> {
+  let summary = "Multiply an input tensor by a scalar tensor.";
+  let description = [{
+    Multiplies each element of the input `input` with the scalar `other` and returns a new resulting tensor. The tensor types must match and shapes must be broadcastable.
+  }];
+}
+
 class UnaryArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
   TCP_Op<mnemonic,
         !listconcat(traits, [AllTypesMatch<["operand", "result"]>])>,

--- a/lib/Conversion/TCFToTCP/TCFToTCP.cpp
+++ b/lib/Conversion/TCFToTCP/TCFToTCP.cpp
@@ -73,6 +73,9 @@ matchAndRewriteBinaryElementwise(Operation *op, PatternRewriter &rewriter) {
   } else if (isa<tcf::MaxOp>(op)) {
     binaryOpResult = rewriter.create<tcp::MaxOp>(
         loc, result.getType(), lhsBroadcasted, rhsBroadcasted);
+  } else if (isa<tcf::MulOp>(op)) {
+    binaryOpResult = rewriter.create<tcp::MulOp>(
+        loc, result.getType(), lhsBroadcasted, rhsBroadcasted);
   } else {
     op->dump();
     llvm::report_fatal_error(
@@ -167,7 +170,8 @@ public:
     patterns.insert<ConvertUnaryElementwise<tcf::ExpOp>,
                     ConvertUnaryElementwise<tcf::TanhOp>>(context);
     patterns.insert<ConvertBinaryElementwise<tcf::AddOp>,
-                    ConvertBinaryElementwise<tcf::MaxOp>>(context);
+                    ConvertBinaryElementwise<tcf::MaxOp>,
+                    ConvertBinaryElementwise<tcf::MulOp>>(context);
     patterns.insert<ConvertMatmul>(context);
     (void)applyPatternsAndFoldGreedily(module, patterns);
   }

--- a/test/npcomp-run-mlir/elementwise.mlir
+++ b/test/npcomp-run-mlir/elementwise.mlir
@@ -6,6 +6,13 @@
 // RUN:   | FileCheck %s --check-prefix=MAX
 
 // RUN: npcomp-run-mlir %s \
+// RUN:   -invoke mul \
+// RUN:   -arg-value="dense<[1.0, 2.0]> : tensor<2xf32>" \
+// RUN:   -arg-value="dense<[3.0, 4.0]> : tensor<2xf32>" \
+// RUN:   -shared-libs=%npcomp_runtime_shlib 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=MUL
+
+// RUN: npcomp-run-mlir %s \
 // RUN:   -invoke exp \
 // RUN:   -arg-value="dense<[0.0, 1.0]> : tensor<2xf32>" \
 // RUN:   -shared-libs=%npcomp_runtime_shlib 2>&1 \
@@ -23,6 +30,12 @@
 // MAX: output #0: dense<3.000000e+00> : tensor<1xf32>
 func @max(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
   %0 =  tcf.max %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+
+// MUL: output #0: dense<[3.000000e+00, 8.000000e+00]> : tensor<2xf32>
+func @mul(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+  %0 =  tcf.mul %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
   return %0 : tensor<?xf32>
 }
 


### PR DESCRIPTION
Register the following for the multiply op:
- tcf.mul
- tcp.mul
- TCP->TCP lowering
- Shape transfer, broadcasted multiplicands
- Lower to standard `MulFOp` op