### PR TITLE
Capture backward conv and copy_ kernels.

### DIFF
--- a/frontends/pytorch/csrc/c10_dispatch/acap_dispatch.h
+++ b/frontends/pytorch/csrc/c10_dispatch/acap_dispatch.h
@@ -60,12 +60,25 @@ public:
                     const at::IntArrayRef dilation, const bool transposed,
                     const at::IntArrayRef output_padding, const int64_t groups);
 
+  // Kernel implementation for the boxing-incompatible convolution kernel.
+  static std::tuple<at::Tensor, at::Tensor, at::Tensor> mklConvolutionBackward(
+      const at::Tensor &input, const at::Tensor &grad_output,
+      const at::Tensor &weight, const at::IntArrayRef padding,
+      const at::IntArrayRef stride, const at::IntArrayRef dilation,
+      const int64_t groups, std::array<bool, 3> output_mask);
+
+  // Implementation for the aten::copy_ kernel.
+  static at::Tensor &copyUnderKernel(at::Tensor &self, const at::Tensor &src,
+                                     bool non_blocking);
+
 private:
   /// Builds a kernel call step by step.
   class KernelCallBuilder {
   public:
-    KernelCallBuilder(AcapController &parent, MlirContext context,
-                      MlirLocation loc, const c10::OperatorHandle &opHandle);
+    KernelCallBuilder(
+        AcapController &parent, MlirContext context, MlirLocation loc,
+        const c10::OperatorHandle &opHandle,
+        llvm::Optional<std::string> overrideKernelName = llvm::None);
     void addOperand(const c10::IValue &value);
     void addResult(const c10::IValue &result);
     MlirOperation create();

--- a/frontends/pytorch/csrc/c10_dispatch/func_builder.cpp
+++ b/frontends/pytorch/csrc/c10_dispatch/func_builder.cpp
@@ -58,8 +58,11 @@ MlirType TypeMapper::mapScalarType(c10::ScalarType scalarType) {
 }
 
 MlirType TypeMapper::forwardTensorToType(at::Tensor tensor) {
-  if (!tensor.defined())
-    throw std::invalid_argument("Tensor is not defined");
+  if (!tensor.defined()) {
+    // Undefined tensors are equivalent to None.
+    // This may need to be re-evaluated at some point.
+    return npcompNoneTypeGet(context);
+  }
 
   MlirType elementType = mapScalarType(tensor.scalar_type());
   // TODO: Decide when it is necessary to take strides into account. Right now,

--- a/frontends/pytorch/test/acap_export/test_conv_nllloss_grads.py
+++ b/frontends/pytorch/test/acap_export/test_conv_nllloss_grads.py
@@ -30,17 +30,22 @@ class Net(nn.Module):
 model = Net(Cin, Cout)
 
 inputs = torch.ones((N,Cin,h,w))
-# Note that the NLLLoss kernel accepts an optional parameter, which is what
-# this test is trying to verify.
 loss = torch.nn.NLLLoss()
 target = torch.empty(N, 8, 8, dtype=torch.long).random_(0, Cout)
 
 mb = torch_mlir.ModuleBuilder()
 with mb.capture_function("resa", [inputs, target]) as f:
   result = loss(model(inputs), target)
-  f.returns([result])
+  result.backward()
+  f.returns([result] + [p.grad for p in model.parameters()])
 
-# CHECK: "aten::convolution"
-# CHECK: "aten::_log_softmax"
-# CHECK: "aten::nll_loss2d_forward"
+# CHECK: torch.kernel_call "aten::convolution"
+# CHECK: torch.kernel_call "aten::_log_softmax"
+# CHECK: %[[FWD:.*]]:2 = torch.kernel_call "aten::nll_loss2d_forward"
+# CHECK: torch.kernel_call "aten::nll_loss2d_backward"
+# CHECK: torch.kernel_call "aten::_log_softmax_backward_data"
+# CHECK: %[[BWD_CONV:.*]]:3 = torch.kernel_call "aten::convolution_backward"
+# CHECK: %[[BWD_CONV_WEIGHTS:.*]] = torch.kernel_call "aten::copy_" {{.*}} %[[BWD_CONV]]#1
+# CHECK: %[[BWD_CONV_BIAS:.*]] = torch.kernel_call "aten::copy_" {{.*}} %[[BWD_CONV]]#2
+# CHECK: return %[[FWD]]#0, %[[BWD_CONV_WEIGHTS]], %[[BWD_CONV_BIAS]]
 mb.module.operation.print(large_elements_limit=2)


### PR DESCRIPTION
* This is sufficient to capture the forward and backward pass and gradients of a convolutional model with an nllloss.
* As with the forward conv, the backward conv is a special case wrapped in an enigma on the PyTorch side. There aren't many like it, so special casing is just what we do.
* When I traced this, I found that the copy_ op is not yet boxing compatible so I had to map it manually. If there are many more like this, I'll probably do something a bit more clever to reduce duplication.
* This exposes new signature patterns that will need to be handled by the ATen lowering. Will take care of that next: It will be nice to have an e2e of a non-trivial case with full gradients.
* Fixes #97.