### PR TITLE
Replace most of "TCP" with std elementwise ops + linalg named ops on tensors

### DIFF
--- a/include/npcomp/Conversion/Passes.td
+++ b/include/npcomp/Conversion/Passes.td
@@ -39,6 +39,15 @@ def ConvertNumpyToTCF : Pass<"convert-numpy-to-tcf", "FuncOp"> {
 }
 
 //===----------------------------------------------------------------------===//
+// TCFToStd
+//===----------------------------------------------------------------------===//
+
+def ConvertTCFToStd : Pass<"convert-tcf-to-std", "ModuleOp"> {
+  let summary = "Convert TCF to Std";
+  let constructor = "mlir::NPCOMP::createConvertTCFToStdPass()";
+}
+
+//===----------------------------------------------------------------------===//
 // TCFToTCP
 //===----------------------------------------------------------------------===//
 

--- a/include/npcomp/Conversion/Passes.td
+++ b/include/npcomp/Conversion/Passes.td
@@ -39,6 +39,21 @@ def ConvertNumpyToTCF : Pass<"convert-numpy-to-tcf", "FuncOp"> {
 }
 
 //===----------------------------------------------------------------------===//
+// TCFToTCP
+//===----------------------------------------------------------------------===//
+
+def ConvertTCFToLinalg : Pass<"convert-tcf-to-linalg", "ModuleOp"> {
+  let summary = "Convert TCF to Linalg";
+  let description = [{
+    The intention is for this pass to convert mainly to linalg named ops.
+
+    Because linalg is at the "TCP" layer of abstraction, this pass has to
+    concern itself with generating guards for error cases.
+  }];
+  let constructor = "mlir::NPCOMP::createConvertTCFToLinalgPass()";
+}
+
+//===----------------------------------------------------------------------===//
 // TCFToStd
 //===----------------------------------------------------------------------===//
 

--- a/include/npcomp/Conversion/TCFToLinalg/TCFToLinalg.h
+++ b/include/npcomp/Conversion/TCFToLinalg/TCFToLinalg.h
@@ -1,0 +1,21 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef NPCOMP_CONVERSION_TCFTOLINALG_TCFTOLINALG_H
+#define NPCOMP_CONVERSION_TCFTOLINALG_TCFTOLINALG_H
+
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir {
+namespace NPCOMP {
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTCFToLinalgPass();
+}
+} // namespace mlir
+
+#endif // NPCOMP_CONVERSION_TCFTOLINALG_TCFTOLINALG_H

--- a/include/npcomp/Conversion/TCFToStd/TCFToStd.h
+++ b/include/npcomp/Conversion/TCFToStd/TCFToStd.h
@@ -1,0 +1,21 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef NPCOMP_CONVERSION_TCFTOTCP_CONVERTTCFTOSTD_H
+#define NPCOMP_CONVERSION_TCFTOTCP_CONVERTTCFTOSTD_H
+
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir {
+namespace NPCOMP {
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTCFToStdPass();
+}
+} // namespace mlir
+
+#endif // NPCOMP_CONVERSION_TCFTOTCP_CONVERTTCFTOSTD_H

--- a/include/npcomp/Dialect/TCP/IR/TCPOps.td
+++ b/include/npcomp/Dialect/TCP/IR/TCPOps.td
@@ -20,33 +20,6 @@ class TCP_Op<string mnemonic, list<OpTrait> traits = []>
     : Op<TCP_Dialect, mnemonic, traits> {
 }
 
-// TODO: Generalize this op appropriately and add more verification.
-// For example, should we have a single primitive that does multidimensional
-// contractions? + batching as well in the same op? In fact, if we want to
-// get really general, we can include convolution as well; matmul is the 1x1
-// image and 1x1 kernel special case.
-// It still lowers trivially into linalg.generic even with such generalization
-// -- the main question is what transforms we want to do at the TCP level that
-// would be affected by those design choices.
-def TCP_MatmulOp : TCP_Op<"matmul"> {
-  let summary = "Performs a matrix multiplication";
-  let description = [{
-    Performs a matrix multiplication.
-
-    The tensors have dimensions:
-    - lhs: [M, K]
-    - rhs: [K, N]
-    - result: [M, N]
-
-    If the `K` dimension mismatches between operands, this op has
-    undefined behavior.
-  }];
-  let arguments = (ins 2DTensorOf<[F32]>:$lhs, 2DTensorOf<[F32]>:$rhs);
-  let results = (outs 2DTensorOf<[F32]>:$result);
-
-  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` functional-type(operands, results)";
-}
-
 def TCP_BroadcastToOp : TCP_Op<"broadcast_to"> {
   let summary = "Broadcasts an operand to a given shape.";
   let description = [{
@@ -58,6 +31,27 @@ It is undefined behavior if such a broadcast is not legal.
   let results = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = "$operand `,` $shape attr-dict `:` functional-type(operands, results)";
+}
+
+def TCP_SplattedOp : TCP_Op<"splatted"> {
+  let summary = "Creates a tensor filled with a particular scalar value.";
+  let description = [{
+    Creates a tensor of shape `shape` with all elements filled with `splatVal`.
+
+    This op is somewhat redundant with tcp.broadcast_to. However,
+    tcp.broadcast_to handles degenerate "size-1" broadcasting which structurally
+    cannot happen with this op. So to avoid losing that information, we keep
+    this op separate.
+
+    NOTE: The name "splatted" separates it from std.splat, which currently
+    only handles statically shaped memrefs.
+
+    TODO: Improve std.splat to take dynamic shapes.
+  }];
+  let arguments = (ins AnyType:$splatVal, Shape_ExtentTensorType:$shape);
+  let results = (outs AnyRankedTensor:$result);
+
+  let assemblyFormat = "$splatVal `,` $shape attr-dict `:` functional-type(operands, results)";
 }
 
 #endif // TCP_OPS

--- a/include/npcomp/Dialect/TCP/IR/TCPOps.td
+++ b/include/npcomp/Dialect/TCP/IR/TCPOps.td
@@ -20,58 +20,6 @@ class TCP_Op<string mnemonic, list<OpTrait> traits = []>
     : Op<TCP_Dialect, mnemonic, traits> {
 }
 
-// TODO: Clarify allowed tensor element types.
-class BinaryArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
-  TCP_Op<mnemonic, traits> {
-  let arguments = (ins AnyRankedTensor:$lhs, AnyRankedTensor:$rhs);
-  let results = (outs AnyRankedTensor:$result);
-  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` functional-type(operands, results)";
-}
-
-def TCP_AddOp : BinaryArithmeticOp<"add"> {
-  let summary = "Addition of two tensors";
-  let description = [{
-    Addition of two tensors.
-  }];
-}
-
-def TCP_MaxOp : BinaryArithmeticOp<"max"> {
-  let summary = "Maximum of two tensors";
-  let description = [{
-    Maximum of two tensors.
-  }];
-}
-
-def TCP_MulOp : BinaryArithmeticOp<"mul"> {
-  let summary = "Multiply an input tensor by a scalar tensor.";
-  let description = [{
-    Multiplies each element of the input `input` with the scalar `other` and returns a new resulting tensor. The tensor types must match and shapes must be broadcastable.
-  }];
-}
-
-class UnaryArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
-  TCP_Op<mnemonic,
-        !listconcat(traits, [AllTypesMatch<["operand", "result"]>])>,
-  AllTypesMatch<["operand", "result"]> {
-  let arguments = (ins AnyTensor:$operand);
-  let results = (outs AnyTensor:$result);
-  let assemblyFormat = "$operand attr-dict `:` type($operand)";
-}
-
-def TCP_ExpOp : UnaryArithmeticOp<"exp"> {
-  let summary = "base-e exponential";
-  let description = [{
-    See std.exp for more details.
-  }];
-}
-
-def TCP_TanhOp : UnaryArithmeticOp<"tanh"> {
-  let summary = "hyperbolic tangent";
-  let description = [{
-    See std.tanh for more details.
-  }];
-}
-
 // TODO: Generalize this op appropriately and add more verification.
 // For example, should we have a single primitive that does multidimensional
 // contractions? + batching as well in the same op? In fact, if we want to

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(ATenToTCF)
 add_subdirectory(BasicpyToStd)
 add_subdirectory(NumpyToTCF)
+add_subdirectory(TCFToStd)
 add_subdirectory(TCFToTCP)
 
 if(NPCOMP_ENABLE_IREE)

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(ATenToTCF)
 add_subdirectory(BasicpyToStd)
 add_subdirectory(NumpyToTCF)
+add_subdirectory(TCFToLinalg)
 add_subdirectory(TCFToStd)
 add_subdirectory(TCFToTCP)
 

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -11,6 +11,7 @@
 #include "npcomp/Conversion/ATenToTCF/Passes.h"
 #include "npcomp/Conversion/BasicpyToStd/Passes.h"
 #include "npcomp/Conversion/NumpyToTCF/Passes.h"
+#include "npcomp/Conversion/TCFToStd/TCFToStd.h"
 #include "npcomp/Conversion/TCFToTCP/TCFToTCP.h"
 
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -11,6 +11,7 @@
 #include "npcomp/Conversion/ATenToTCF/Passes.h"
 #include "npcomp/Conversion/BasicpyToStd/Passes.h"
 #include "npcomp/Conversion/NumpyToTCF/Passes.h"
+#include "npcomp/Conversion/TCFToLinalg/TCFToLinalg.h"
 #include "npcomp/Conversion/TCFToStd/TCFToStd.h"
 #include "npcomp/Conversion/TCFToTCP/TCFToTCP.h"
 

--- a/lib/Conversion/TCFToLinalg/CMakeLists.txt
+++ b/lib/Conversion/TCFToLinalg/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_npcomp_conversion_library(NPCOMPTCFToLinalg
+  TCFToLinalg.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/npcomp/Conversion/TCFToLinalg
+
+  DEPENDS
+  NPCOMPConversionPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRTransforms
+  MLIRShape
+  NPCOMPTCFDialect
+)

--- a/lib/Conversion/TCFToLinalg/TCFToLinalg.cpp
+++ b/lib/Conversion/TCFToLinalg/TCFToLinalg.cpp
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "npcomp/Conversion/TCFToLinalg/TCFToLinalg.h"
+
+#include "../PassDetail.h"
+#include "mlir/Dialect/Linalg/IR/LinalgOps.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Traits.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "npcomp/Dialect/TCF/IR/TCFOps.h"
+#include "npcomp/Dialect/TCP/IR/TCPDialect.h"
+#include "npcomp/Dialect/TCP/IR/TCPOps.h"
+
+using namespace mlir;
+using namespace mlir::NPCOMP;
+
+static SmallVector<Value, 6> bypassResultShapes(Operation *op,
+                                                OpBuilder &builder) {
+
+  if (auto matmul = dyn_cast<tcf::MatmulOp>(op)) {
+    auto lhsRows = builder.create<DimOp>(op->getLoc(), matmul.lhs(), 0);
+    auto rhsCols = builder.create<DimOp>(op->getLoc(), matmul.rhs(), 1);
+    auto shape = builder.create<TensorFromElementsOp>(
+        op->getLoc(), ValueRange({lhsRows, rhsCols}));
+    return {shape};
+  }
+
+  // No shape transfer function.
+  return {};
+}
+
+namespace {
+class ConvertMatmul : public OpRewritePattern<tcf::MatmulOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(tcf::MatmulOp op,
+                                PatternRewriter &rewriter) const override {
+    // Create the constraints, and the assuming region.
+    Value lhsK = rewriter.create<DimOp>(op.getLoc(), op.lhs(), 1);
+    Value rhsK = rewriter.create<DimOp>(op.getLoc(), op.rhs(), 0);
+    Value matchingK =
+        rewriter.create<CmpIOp>(op.getLoc(), CmpIPredicate::eq, lhsK, rhsK);
+    Value witness = rewriter.create<shape::CstrRequireOp>(
+        op.getLoc(), matchingK, "mismatching contracting dimension for matmul");
+    auto assuming = rewriter.create<shape::AssumingOp>(
+        op.getLoc(), ArrayRef<Type>{op.getType()}, witness);
+
+    // Build the region body.
+    rewriter.createBlock(&assuming.doRegion());
+    // Create the init tensor for the matmul.
+    // TODO: Expand supported data types.
+    Value c0 =
+        rewriter.create<ConstantOp>(op.getLoc(), rewriter.getF32FloatAttr(0.0));
+    Value shape = bypassResultShapes(op, rewriter)[0];
+    Value initTensor =
+        rewriter.create<tcp::SplattedOp>(op.getLoc(), op.getType(), c0, shape);
+
+    // Create the matmul.
+    auto matmul = rewriter.create<linalg::MatmulOp>(
+        op.getLoc(), TypeRange(op.getType()), op.getOperands(), ValueRange(),
+        ValueRange(initTensor));
+    rewriter.create<shape::AssumingYieldOp>(op.getLoc(), matmul.getResult(0));
+
+    // Finally, replace with the results of the shape.assuming
+    rewriter.replaceOp(op, assuming.getResults());
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class ConvertTCFToLinalg : public ConvertTCFToLinalgBase<ConvertTCFToLinalg> {
+public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<shape::ShapeDialect, tcp::TCPDialect>();
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    (void)applyPatternsAndFoldGreedily(module, getPatterns());
+  }
+
+  FrozenRewritePatternList getPatterns() {
+    MLIRContext *context = &getContext();
+    OwningRewritePatternList patterns;
+    patterns.insert<ConvertMatmul>(context);
+    return std::move(patterns);
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::NPCOMP::createConvertTCFToLinalgPass() {
+  return std::make_unique<ConvertTCFToLinalg>();
+}

--- a/lib/Conversion/TCFToStd/CMakeLists.txt
+++ b/lib/Conversion/TCFToStd/CMakeLists.txt
@@ -1,8 +1,8 @@
-add_npcomp_conversion_library(NPCOMPTCFToTCP
-  TCFToTCP.cpp
+add_npcomp_conversion_library(NPCOMPTCFToStd
+  TCFToStd.cpp
 
   ADDITIONAL_HEADER_DIRS
-  ${PROJECT_SOURCE_DIR}/include/npcomp/Conversion/TCFToTCP
+  ${PROJECT_SOURCE_DIR}/include/npcomp/Conversion/TCFToStd
 
   DEPENDS
   NPCOMPConversionPassIncGen
@@ -15,5 +15,7 @@ add_npcomp_conversion_library(NPCOMPTCFToTCP
   MLIRPass
   MLIRTransforms
   MLIRShape
+  MLIRStandard
+  MLIRLinalg
   NPCOMPTCFDialect
 )

--- a/lib/Conversion/TCFToStd/TCFToStd.cpp
+++ b/lib/Conversion/TCFToStd/TCFToStd.cpp
@@ -1,0 +1,162 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "npcomp/Conversion/TCFToStd/TCFToStd.h"
+
+#include "../PassDetail.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Traits.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "npcomp/Dialect/TCF/IR/TCFOps.h"
+#include "npcomp/Dialect/TCP/IR/TCPDialect.h"
+#include "npcomp/Dialect/TCP/IR/TCPOps.h"
+
+using namespace mlir;
+using namespace mlir::NPCOMP;
+
+static RankedTensorType getExtentTensorType(Builder &builder) {
+  return RankedTensorType::get({ShapedType::kDynamicSize},
+                               builder.getIndexType());
+}
+
+// Non-templated version of the body of ConvertBinaryElementwise to keep things
+// simple.
+static LogicalResult
+matchAndRewriteBinaryElementwise(Operation *op, PatternRewriter &rewriter) {
+  Value lhs = op->getOperand(0);
+  Value rhs = op->getOperand(1);
+  Location loc = op->getLoc();
+  Value result = op->getResult(0);
+
+  auto lhsType = lhs.getType().dyn_cast<RankedTensorType>();
+  auto rhsType = rhs.getType().dyn_cast<RankedTensorType>();
+  if (!lhsType || !rhsType)
+    return rewriter.notifyMatchFailure(op, "requires ranked tensors");
+
+  Value lhsShape = rewriter.create<shape::ShapeOfOp>(loc, lhs);
+  Value rhsShape = rewriter.create<shape::ShapeOfOp>(loc, rhs);
+
+  // Create the constraints, and the assuming region.
+  Value witness =
+      rewriter.create<shape::CstrBroadcastableOp>(loc, lhsShape, rhsShape);
+  auto assuming = rewriter.create<shape::AssumingOp>(
+      loc, ArrayRef<Type>{result.getType()}, witness);
+
+  // Start building the region body.
+  rewriter.createBlock(&assuming.doRegion());
+  Value broadcastedShape = rewriter.create<shape::BroadcastOp>(
+      loc, getExtentTensorType(rewriter), lhsShape, rhsShape,
+      /*error=*/nullptr);
+
+  // TODO: It's annoying to do the dynamic broadcast above then
+  // do the static transfer function here. Would be nice if they could
+  // somehow be unified.
+  SmallVector<int64_t, 6> broadcastedStaticShape;
+  OpTrait::util::getBroadcastedShape(lhsType.getShape(), rhsType.getShape(),
+                                     broadcastedStaticShape);
+  auto resultType =
+      RankedTensorType::get(broadcastedStaticShape, lhsType.getElementType());
+  Value lhsBroadcasted = rewriter.create<tcp::BroadcastToOp>(
+      loc, resultType, lhs, broadcastedShape);
+  Value rhsBroadcasted = rewriter.create<tcp::BroadcastToOp>(
+      loc, resultType, rhs, broadcastedShape);
+  Value binaryOpResult;
+  if (isa<tcf::AddOp>(op)) {
+    binaryOpResult = rewriter.create<AddFOp>(
+        loc, result.getType(), lhsBroadcasted, rhsBroadcasted);
+  } else if (isa<tcf::MaxOp>(op)) {
+    // XXX: remove TCP dep
+    // XXX: remove TCP ops from TCP
+    auto pred = rewriter.create<CmpFOp>(loc, CmpFPredicate::OGT, lhsBroadcasted,
+                                        rhsBroadcasted);
+    binaryOpResult =
+        rewriter.create<SelectOp>(loc, pred, lhsBroadcasted, rhsBroadcasted);
+  } else if (isa<tcf::MulOp>(op)) {
+    binaryOpResult = rewriter.create<MulFOp>(
+        loc, result.getType(), lhsBroadcasted, rhsBroadcasted);
+  } else {
+    op->dump();
+    llvm::report_fatal_error(
+        "unhandled op (see dump above): TCF->Std binary elementwise");
+  }
+  rewriter.create<shape::AssumingYieldOp>(loc, binaryOpResult);
+
+  // Finally, replace with the results of the shape.assuming
+  rewriter.replaceOp(op, assuming.getResults());
+  return success();
+}
+
+namespace {
+template <typename SourceOp>
+class ConvertBinaryElementwise : public OpRewritePattern<SourceOp> {
+public:
+  using OpRewritePattern<SourceOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(SourceOp op,
+                                PatternRewriter &rewriter) const override {
+    return matchAndRewriteBinaryElementwise(op, rewriter);
+  }
+};
+} // namespace
+
+static LogicalResult
+matchAndRewriteUnaryElementwise(Operation *op, PatternRewriter &rewriter) {
+  if (isa<tcf::ExpOp>(op)) {
+    rewriter.replaceOpWithNewOp<ExpOp>(op, op->getOperand(0));
+  } else if (isa<tcf::TanhOp>(op)) {
+    rewriter.replaceOpWithNewOp<TanhOp>(op, op->getOperand(0));
+  } else {
+    op->dump();
+    llvm::report_fatal_error(
+        "unhandled op (see dump above): TCF->TCP unary elementwise");
+  }
+  return success();
+}
+
+namespace {
+template <typename SourceOp>
+class ConvertUnaryElementwise : public OpRewritePattern<SourceOp> {
+public:
+  using OpRewritePattern<SourceOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(SourceOp op,
+                                PatternRewriter &rewriter) const override {
+    return matchAndRewriteUnaryElementwise(op, rewriter);
+  }
+};
+} // namespace
+
+namespace {
+class ConvertTCFToStd : public ConvertTCFToStdBase<ConvertTCFToStd> {
+public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<shape::ShapeDialect>();
+  }
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    (void)applyPatternsAndFoldGreedily(module, getPatterns());
+  }
+
+  FrozenRewritePatternList getPatterns() {
+    MLIRContext *context = &getContext();
+    OwningRewritePatternList patterns;
+    patterns.insert<ConvertUnaryElementwise<tcf::ExpOp>,
+                    ConvertUnaryElementwise<tcf::TanhOp>>(context);
+    patterns.insert<ConvertBinaryElementwise<tcf::AddOp>,
+                    ConvertBinaryElementwise<tcf::MaxOp>,
+                    ConvertBinaryElementwise<tcf::MulOp>>(context);
+    return std::move(patterns);
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::NPCOMP::createConvertTCFToStdPass() {
+  return std::make_unique<ConvertTCFToStd>();
+}

--- a/lib/RefBackend/RefBackend.cpp
+++ b/lib/RefBackend/RefBackend.cpp
@@ -40,6 +40,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
+#include "npcomp/Conversion/TCFToLinalg/TCFToLinalg.h"
 #include "npcomp/Conversion/TCFToStd/TCFToStd.h"
 #include "npcomp/Conversion/TCFToTCP/TCFToTCP.h"
 #include "npcomp/Dialect/Refback/IR/RefbackOps.h"
@@ -305,6 +306,7 @@ void mlir::NPCOMP::createTCFRefBackendLoweringPipeline(
   //
   // TCP does not. So we need to reify the broadcasting and error checking.
   pm.addPass(createConvertTCFToStdPass());
+  pm.addPass(createConvertTCFToLinalgPass());
   pm.addPass(createConvertTCFToTCPPass());
 
   createRefBackendLoweringPipeline(pm, options);

--- a/test/Conversion/TCFToLinalg/basic.mlir
+++ b/test/Conversion/TCFToLinalg/basic.mlir
@@ -1,0 +1,25 @@
+// RUN: npcomp-opt <%s -convert-tcf-to-linalg | FileCheck %s --dump-input=fail
+
+// CHECK-LABEL:   func @tcf_matmul(
+// CHECK-SAME:                     %[[LHS:.*]]: tensor<?x?xf32>,
+// CHECK-SAME:                     %[[RHS:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
+// CHECK:           %[[C0F32:.*]] = constant 0.000000e+00 : f32
+// CHECK:           %[[C0:.*]] = constant 0 : index
+// CHECK:           %[[C1:.*]] = constant 1 : index
+// CHECK:           %[[LHSK:.*]] = dim %[[LHS]], %[[C1]] : tensor<?x?xf32>
+// CHECK:           %[[RHSK:.*]] = dim %[[RHS]], %[[C0]] : tensor<?x?xf32>
+// CHECK:           %[[KEQUAL:.*]] = cmpi "eq", %[[LHSK]], %[[RHSK]] : index
+// CHECK:           %[[WINESS:.*]] = shape.cstr_require %[[KEQUAL]], "mismatching contracting dimension for matmul"
+// CHECK:           %[[RET:.*]] = shape.assuming %[[WINESS]] -> (tensor<?x?xf32>) {
+// CHECK:             %[[LHSROWS:.*]] = dim %[[LHS]], %[[C0]] : tensor<?x?xf32>
+// CHECK:             %[[RHSCOLS:.*]] = dim %[[RHS]], %[[C1]] : tensor<?x?xf32>
+// CHECK:             %[[SHAPE:.*]] = tensor_from_elements %[[LHSROWS]], %[[RHSCOLS]] : tensor<2xindex>
+// CHECK:             %[[INIT_TENSOR:.*]] = tcp.splatted %[[C0F32]], %[[SHAPE]] : (f32, tensor<2xindex>) -> tensor<?x?xf32>
+// CHECK:             %[[MATMUL:.*]] = linalg.matmul ins(%[[LHS]], %[[RHS]] : tensor<?x?xf32>, tensor<?x?xf32>) init(%[[INIT_TENSOR]] : tensor<?x?xf32>)  -> tensor<?x?xf32>
+// CHECK:             shape.assuming_yield %[[MATMUL]] : tensor<?x?xf32>
+// CHECK:           }
+// CHECK:           return %[[RET:.*]] : tensor<?x?xf32>
+func @tcf_matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcf.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}

--- a/test/Conversion/TCFToStd/basic.mlir
+++ b/test/Conversion/TCFToStd/basic.mlir
@@ -1,0 +1,31 @@
+// RUN: npcomp-opt <%s -convert-tcf-to-std | FileCheck %s
+
+// CHECK-LABEL:   func @unary_ops(
+// CHECK-SAME:                    %[[ARG:.*]]: tensor<?xf32>) -> tensor<?xf32> {
+// CHECK:           %[[RET:.*]] = exp %[[ARG]] : tensor<?xf32>
+// CHECK:           return %[[RET]] : tensor<?xf32>
+// CHECK:         }
+func @unary_ops(%arg0: tensor<?xf32>) -> tensor<?xf32> {
+  %0 = tcf.exp %arg0 : tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+
+// CHECK-LABEL:   func @tcf_add(
+// CHECK-SAME:            %[[LHS:.*]]: tensor<?xf32>,
+// CHECK-SAME:            %[[RHS:.*]]: tensor<?xf32>) -> tensor<?xf32> {
+// CHECK:           %[[LHSSHAPE:.*]] = shape.shape_of %[[LHS]]
+// CHECK:           %[[RHSSHAPE:.*]] = shape.shape_of %[[RHS]]
+// CHECK:           %[[WITNESS:.*]] = shape.cstr_broadcastable %[[LHSSHAPE]], %[[RHSSHAPE]]
+// CHECK:           %[[RET:.*]] = shape.assuming %[[WITNESS]] -> (tensor<?xf32>) {
+// CHECK:             %[[RESULTSHAPE:.*]] = shape.broadcast %[[LHSSHAPE]], %[[RHSSHAPE]]
+// CHECK:             %[[LHSBCAST:.*]] = tcp.broadcast_to %[[LHS]], %[[RESULTSHAPE]]
+// CHECK:             %[[RHSBCAST:.*]] = tcp.broadcast_to %[[RHS]], %[[RESULTSHAPE]]
+// CHECK:             %[[ADD:.*]] = addf %[[LHSBCAST]], %[[RHSBCAST]]
+// CHECK:             shape.assuming_yield %[[ADD]] : tensor<?xf32>
+// CHECK:           }
+// CHECK:           return %[[RET:.*]] : tensor<?xf32>
+// CHECK:         }
+func @tcf_add(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+  %0 = tcf.add %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}

--- a/test/Conversion/TCFToTCP/basic.mlir
+++ b/test/Conversion/TCFToTCP/basic.mlir
@@ -1,21 +1,10 @@
-// RUN: npcomp-opt <%s -convert-tcf-to-tcp | FileCheck %s --dump-input=fail
+// RUN: npcomp-opt <%s -convert-tcf-to-tcp | FileCheck %s
 
-// CHECK-LABEL:   func @tcf_matmul(
-// CHECK-SAME:                     %[[LHS:.*]]: tensor<?x?xf32>,
-// CHECK-SAME:                     %[[RHS:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
-// CHECK:           %[[C1:.*]] = constant 1 : index
-// CHECK:           %[[C0:.*]] = constant 0 : index
-// CHECK:           %[[LHSK:.*]] = dim %[[LHS]], %[[C1]] : tensor<?x?xf32>
-// CHECK:           %[[RHSK:.*]] = dim %[[RHS]], %[[C0]] : tensor<?x?xf32>
-// CHECK:           %[[KEQUAL:.*]] = cmpi "eq", %[[LHSK]], %[[RHSK]] : index
-// CHECK:           %[[WITNESS:.*]] = shape.cstr_require %[[KEQUAL]], "{{.*}}"
-// CHECK:           %[[RET:.*]] = shape.assuming %[[WITNESS]] -> (tensor<?x?xf32>) {
-// CHECK:             %[[MATMUL:.*]] = tcp.matmul %[[LHS]], %[[RHS]] : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
-// CHECK:             shape.assuming_yield %[[MATMUL]] : tensor<?x?xf32>
-// CHECK:           }
-// CHECK:           return %[[RET:.*]] : tensor<?x?xf32>
-// CHECK:         }
-func @tcf_matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = tcf.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
-  return %0 : tensor<?x?xf32>
+// NOTE: We are keeping this pass around, even though it currently does
+// nothing, in order to avoid having to reintroduce the same
+// boilerplate.
+
+// CHECK: @f
+func @f() {
+  return
 }

--- a/test/Conversion/TCFToTCP/basic.mlir
+++ b/test/Conversion/TCFToTCP/basic.mlir
@@ -1,35 +1,5 @@
 // RUN: npcomp-opt <%s -convert-tcf-to-tcp | FileCheck %s --dump-input=fail
 
-// CHECK-LABEL:   func @unary_ops(
-// CHECK-SAME:                    %[[ARG:.*]]: tensor<?xf32>) -> tensor<?xf32> {
-// CHECK:           %[[RET:.*]] = tcp.exp %[[ARG]] : tensor<?xf32>
-// CHECK:           return %[[RET]] : tensor<?xf32>
-// CHECK:         }
-func @unary_ops(%arg0: tensor<?xf32>) -> tensor<?xf32> {
-  %0 = tcf.exp %arg0 : tensor<?xf32>
-  return %0 : tensor<?xf32>
-}
-
-// CHECK-LABEL:   func @tcf_add(
-// CHECK-SAME:            %[[LHS:.*]]: tensor<?xf32>,
-// CHECK-SAME:            %[[RHS:.*]]: tensor<?xf32>) -> tensor<?xf32> {
-// CHECK:           %[[LHSSHAPE:.*]] = shape.shape_of %[[LHS]]
-// CHECK:           %[[RHSSHAPE:.*]] = shape.shape_of %[[RHS]]
-// CHECK:           %[[WITNESS:.*]] = shape.cstr_broadcastable %[[LHSSHAPE]], %[[RHSSHAPE]]
-// CHECK:           %[[RET:.*]] = shape.assuming %[[WITNESS]] -> (tensor<?xf32>) {
-// CHECK:             %[[RESULTSHAPE:.*]] = shape.broadcast %[[LHSSHAPE]], %[[RHSSHAPE]]
-// CHECK:             %[[LHSBCAST:.*]] = tcp.broadcast_to %[[LHS]], %[[RESULTSHAPE]]
-// CHECK:             %[[RHSBCAST:.*]] = tcp.broadcast_to %[[RHS]], %[[RESULTSHAPE]]
-// CHECK:             %[[ADD:.*]] = tcp.add %[[LHSBCAST]], %[[RHSBCAST]]
-// CHECK:             shape.assuming_yield %[[ADD]] : tensor<?xf32>
-// CHECK:           }
-// CHECK:           return %[[RET:.*]] : tensor<?xf32>
-// CHECK:         }
-func @tcf_add(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
-  %0 = tcf.add %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
-  return %0 : tensor<?xf32>
-}
-
 // CHECK-LABEL:   func @tcf_matmul(
 // CHECK-SAME:                     %[[LHS:.*]]: tensor<?x?xf32>,
 // CHECK-SAME:                     %[[RHS:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {

--- a/test/Dialect/TCP/bufferize.mlir
+++ b/test/Dialect/TCP/bufferize.mlir
@@ -14,24 +14,14 @@ func @tcp_broadcast_to(%arg0: tensor<?xf32>, %arg1: tensor<?xindex>) -> tensor<?
   return %0 : tensor<?x?xf32>
 }
 
-// CHECK-LABEL:   func @tcp_matmul(
-// CHECK-SAME:                     %[[LHS_TENSOR:.*]]: tensor<?x?xf32>,
-// CHECK-SAME:                     %[[RHS_TENSOR:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
-// CHECK:           %[[LHS:.*]] = tensor_to_memref %[[LHS_TENSOR]] : memref<?x?xf32>
-// CHECK:           %[[RHS:.*]] = tensor_to_memref %[[RHS_TENSOR]] : memref<?x?xf32>
-// CHECK:           %[[C0:.*]] = constant 0 : index
-// CHECK:           %[[LHS_ROWS:.*]] = dim %[[LHS_TENSOR]], %[[C0]] : tensor<?x?xf32>
-// CHECK:           %[[C1:.*]] = constant 1 : index
-// CHECK:           %[[RHS_COLS:.*]] = dim %[[RHS_TENSOR]], %[[C1]] : tensor<?x?xf32>
-// CHECK:           %[[SHAPE:.*]] = tensor_from_elements %[[LHS_ROWS]], %[[RHS_COLS]] : tensor<2xindex>
+// CHECK-LABEL:   func @tcp_splatted(
+// CHECK-SAME:                       %[[SPLAT_VAL:.*]]: f32,
+// CHECK-SAME:                       %[[SHAPE:.*]]: tensor<?xindex>) -> tensor<?x?xf32> {
 // CHECK:           %[[RESULT:.*]] = refback.alloc_memref %[[SHAPE]] : memref<?x?xf32>
-// CHECK:           %[[C0F32:.*]] = constant 0.000000e+00 : f32
-// CHECK:           linalg.fill(%[[RESULT]], %[[C0F32]]) : memref<?x?xf32>, f32
-// CHECK:           linalg.matmul ins(%[[LHS]], %[[RHS]] : memref<?x?xf32>, memref<?x?xf32>) outs(%[[RESULT]] : memref<?x?xf32>)
+// CHECK:           linalg.fill(%[[RESULT]], %[[SPLAT_VAL]]) : memref<?x?xf32>, f32
 // CHECK:           %[[RESULT_TENSOR:.*]] = tensor_load %[[RESULT]] : memref<?x?xf32>
 // CHECK:           return %[[RESULT_TENSOR]] : tensor<?x?xf32>
-// CHECK:         }
-func @tcp_matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
-  %0 = tcp.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+func @tcp_splatted(%arg0: f32, %arg1: tensor<?xindex>) -> tensor<?x?xf32> {
+  %0 = tcp.splatted %arg0, %arg1 : (f32, tensor<?xindex>) -> tensor<?x?xf32>
   return %0 : tensor<?x?xf32>
 }

--- a/test/Dialect/TCP/bufferize.mlir
+++ b/test/Dialect/TCP/bufferize.mlir
@@ -14,46 +14,6 @@ func @tcp_broadcast_to(%arg0: tensor<?xf32>, %arg1: tensor<?xindex>) -> tensor<?
   return %0 : tensor<?x?xf32>
 }
 
-// CHECK-LABEL:   func @tcp_add(
-// CHECK-SAME:                  %[[LHS_TENSOR:.*]]: tensor<?xf32>,
-// CHECK-SAME:                  %[[RHS_TENSOR:.*]]: tensor<?xf32>) -> tensor<?xf32> {
-// CHECK:           %[[LHS:.*]] = tensor_to_memref %[[LHS_TENSOR]] : memref<?xf32>
-// CHECK:           %[[RHS:.*]] = tensor_to_memref %[[RHS_TENSOR]] : memref<?xf32>
-// CHECK:           %[[SHAPE:.*]] = shape.shape_of %[[LHS_TENSOR]] : tensor<?xf32> -> tensor<?xindex>
-// CHECK:           %[[RESULT:.*]] = refback.alloc_memref %[[SHAPE]] : memref<?xf32>
-// CHECK:           linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%[[LHS]], %[[RHS]] : memref<?xf32>, memref<?xf32>) outs(%[[RESULT]] : memref<?xf32>) {
-// CHECK:           ^bb0(%[[LHS_SCALR:.*]]: f32, %[[RHS_SCALAR:.*]]: f32, %{{.*}}: f32):
-// CHECK:             %[[RESULT_SCALAR:.*]] = addf %[[LHS_SCALR]], %[[RHS_SCALAR]] : f32
-// CHECK:             linalg.yield %[[RESULT_SCALAR]] : f32
-// CHECK:           }
-// CHECK:           %[[RESULT_TENSOR:.*]] = tensor_load %[[RESULT]] : memref<?xf32>
-// CHECK:           return %[[RESULT_TENSOR]] : tensor<?xf32>
-// CHECK:         }
-func @tcp_add(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
-  %0 = tcp.add %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
-  return %0 : tensor<?xf32>
-}
-
-// CHECK-LABEL:   func @tcp_mul(
-// CHECK-SAME:                  %[[LHS_TENSOR:.*]]: tensor<?xf32>,
-// CHECK-SAME:                  %[[RHS_TENSOR:.*]]: tensor<?xf32>) -> tensor<?xf32> {
-// CHECK:           %[[LHS:.*]] = tensor_to_memref %[[LHS_TENSOR]] : memref<?xf32>
-// CHECK:           %[[RHS:.*]] = tensor_to_memref %[[RHS_TENSOR]] : memref<?xf32>
-// CHECK:           %[[SHAPE:.*]] = shape.shape_of %[[LHS_TENSOR]] : tensor<?xf32> -> tensor<?xindex>
-// CHECK:           %[[RESULT:.*]] = refback.alloc_memref %[[SHAPE]] : memref<?xf32>
-// CHECK:           linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%[[LHS]], %[[RHS]] : memref<?xf32>, memref<?xf32>) outs(%[[RESULT]] : memref<?xf32>) {
-// CHECK:           ^bb0(%[[LHS_SCALR:.*]]: f32, %[[RHS_SCALAR:.*]]: f32, %{{.*}}: f32):
-// CHECK:             %[[RESULT_SCALAR:.*]] = mulf %[[LHS_SCALR]], %[[RHS_SCALAR]] : f32
-// CHECK:             linalg.yield %[[RESULT_SCALAR]] : f32
-// CHECK:           }
-// CHECK:           %[[RESULT_TENSOR:.*]] = tensor_load %[[RESULT]] : memref<?xf32>
-// CHECK:           return %[[RESULT_TENSOR]] : tensor<?xf32>
-// CHECK:         }
-func @tcp_mul(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
-  %0 = tcp.mul %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
-  return %0 : tensor<?xf32>
-}
-
 // CHECK-LABEL:   func @tcp_matmul(
 // CHECK-SAME:                     %[[LHS_TENSOR:.*]]: tensor<?x?xf32>,
 // CHECK-SAME:                     %[[RHS_TENSOR:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {

--- a/test/Dialect/TCP/ops.mlir
+++ b/test/Dialect/TCP/ops.mlir
@@ -1,16 +1,5 @@
 // RUN: npcomp-opt <%s | npcomp-opt | FileCheck %s
 
-// CHECK-LABEL: func @binary_elementwise
-func @binary_elementwise(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>, %arg2: i32) {
-  // CHECK: tcp.add %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
-  // CHECK: tcp.max %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
-  // CHECK: tcp.exp %arg0 : tensor<?xf32>
-  %0 = tcp.add %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
-  %1 = tcp.max %arg0, %arg1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
-  %2 = tcp.exp %arg0 : tensor<?xf32>
-  return
-}
-
 // CHECK-LABEL: func @matmul
 func @matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
   // CHECK: tcp.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>

--- a/test/Dialect/TCP/ops.mlir
+++ b/test/Dialect/TCP/ops.mlir
@@ -1,8 +1,15 @@
 // RUN: npcomp-opt <%s | npcomp-opt | FileCheck %s
 
-// CHECK-LABEL: func @matmul
-func @matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
-  // CHECK: tcp.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
-  %0 = tcp.matmul %arg0, %arg1 : (tensor<?x?xf32>, tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK-LABEL: @broadcast_to
+func @broadcast_to(%arg0: tensor<?xf32>, %arg1: tensor<?xindex>) -> tensor<?x?xf32> {
+  // CHECK: tcp.broadcast_to
+  %0 = tcp.broadcast_to %arg0, %arg1 : (tensor<?xf32>, tensor<?xindex>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+// CHECK-LABEL: @splatted
+func @splatted(%arg0: f32, %arg1: tensor<?xindex>) -> tensor<?x?xf32> {
+  // CHECK: tcp.splatted
+  %0 = tcp.splatted %arg0, %arg1 : (f32, tensor<?xindex>) -> tensor<?x?xf32>
   return %0 : tensor<?x?xf32>
 }


### PR DESCRIPTION
This removes most ops from our homegrown "TCP" dialect and replaces them with std elementwise ops + linalg named ops on tensors.

This seems like a strict improvement over the homegrown "tcp.add". But we're still very much experimenting in how far we can take std elementwise + linalg named ops on tensors. Definitely the "init tensor" stuff is a bit clunky, and the builders are pretty hard to use (they look more or less like the ones on linalg.generic, rather than a simple  `create<Matmul>(loc, lhs, rhs)`).

Suggest reviewing individual commits for clarity (sorry, can't stack PR's on github).