### PR TITLE
[RefBackend] Open-code shape.get_extent as extract_element

### DIFF
--- a/include/npcomp/Dialect/Refback/IR/RefbackOps.td
+++ b/include/npcomp/Dialect/Refback/IR/RefbackOps.td
@@ -30,7 +30,7 @@ def Refback_AllocMemRefOp : Refback_Op<"alloc_memref", []> {
     Allocates a memref of the given shape.
 
     This op is a convenience for creating a bunch of
-    shape.get_extent + std.alloc ops.
+    extract_element ops + std.alloc.
   }];
   let arguments = (ins Shape_ExtentTensorType:$shape);
   let results = (outs AnyMemRef:$memref);

--- a/lib/Dialect/TCP/Transforms/Bufferize.cpp
+++ b/lib/Dialect/TCP/Transforms/Bufferize.cpp
@@ -85,8 +85,8 @@ public:
     SmallVector<Value, 6> outputExtents;
     for (int i = 0, e = resultType.getRank(); i < e; i++) {
       Value dimIndex = rewriter.create<ConstantIndexOp>(op.getLoc(), i);
-      Value outputExtent = rewriter.create<shape::GetExtentOp>(
-          op.getLoc(), rewriter.getIndexType(), resultShape, dimIndex);
+      Value outputExtent = rewriter.create<ExtractElementOp>(
+          op.getLoc(), resultShape, ValueRange({dimIndex}));
       outputExtents.push_back(outputExtent);
     }
     int rankDiff = resultType.getRank() - inputType.getRank();
@@ -163,7 +163,6 @@ class TCPBufferizePass : public TCPBufferizeBase<TCPBufferizePass> {
     registry.insert<refback::RefbackDialect>();
     registry.insert<linalg::LinalgDialect>();
     registry.insert<scf::SCFDialect>();
-    registry.insert<shape::ShapeDialect>();
   }
 
   void runOnOperation() override {
@@ -189,7 +188,6 @@ class TCPBufferizePass : public TCPBufferizeBase<TCPBufferizePass> {
     target.addLegalDialect<linalg::LinalgDialect>();
     target.addLegalDialect<StandardOpsDialect>();
     target.addLegalDialect<scf::SCFDialect>();
-    target.addLegalOp<shape::GetExtentOp>();
 
     if (failed(applyPartialConversion(func, target, std::move(patterns))))
       return signalPassFailure();

--- a/test/RefBackend/lower-alloc-memref-ops.mlir
+++ b/test/RefBackend/lower-alloc-memref-ops.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: func @basic
 func @basic(%arg0: tensor<?xindex>) -> memref<?xf32> {
   // CHECK: %[[I:.*]] = constant 0 : index
-  // CHECK: %[[E:.*]] = shape.get_extent %arg0, %[[I]]
+  // CHECK: %[[E:.*]] = extract_element %arg0[%[[I]]]
   // CHECK: alloc(%[[E]])
   %0 = refback.alloc_memref %arg0 : memref<?xf32>
   return %0 : memref<?xf32>
@@ -12,7 +12,7 @@ func @basic(%arg0: tensor<?xindex>) -> memref<?xf32> {
 // -----
 // CHECK-LABEL: func @all_static
 func @all_static(%arg0: tensor<?xindex>) -> memref<3x4x5xf32> {
-  // CHECK-NOT: shape.get_extent
+  // CHECK-NOT: extract_element
   // CHECK: alloc()
   %0 = refback.alloc_memref %arg0 : memref<3x4x5xf32>
   return %0 : memref<3x4x5xf32>
@@ -22,9 +22,9 @@ func @all_static(%arg0: tensor<?xindex>) -> memref<3x4x5xf32> {
 // CHECK-LABEL: func @some_static
 func @some_static(%arg0: tensor<?xindex>) -> memref<3x?x5x?x7xf32> {
   // CHECK-DAG: %[[I1:.*]] = constant 1 : index
-  // CHECK-DAG: %[[E1:.*]] = shape.get_extent %arg0, %[[I1]]
+  // CHECK-DAG: %[[E1:.*]] = extract_element %arg0[%[[I1]]]
   // CHECK-DAG: %[[I3:.*]] = constant 3 : index
-  // CHECK-DAG: %[[E3:.*]] = shape.get_extent %arg0, %[[I3]]
+  // CHECK-DAG: %[[E3:.*]] = extract_element %arg0[%[[I3]]]
   // CHECK: alloc(%[[E1]], %[[E3]])
   %0 = refback.alloc_memref %arg0 : memref<3x?x5x?x7xf32>
   return %0 : memref<3x?x5x?x7xf32>


### PR DESCRIPTION
It was annoying that we were creating shape.get_extent in the middle of
the bufferization pipeline, as it required running convert-shape-to-std
at an awkward place. To make that cleaner, just open-code the
extract_element ops that shape.get_extent expands into.

This is a little gross, but it helps with the macroscopic pipeline
ordering issues. Anyway, the train is long-gone of trying to treat
shapes as some special data type that should only be operated on with
shape ops.

Also,
- reorder tensor constant bufferize (which is a module pass) to bracket
all the bufferization function passes, to make the parallelism
opportunities there clearer. Now we have a very clean little
bufferization segment of our pipeline construction.