### PR TITLE
[RefBackend] Add refback-tcf-to-tcp-pipeline

### DIFF
--- a/include/npcomp/RefBackend/RefBackend.h
+++ b/include/npcomp/RefBackend/RefBackend.h
@@ -45,6 +45,16 @@ struct RefBackendLoweringPipelineOptions
 void createRefBackendLoweringPipeline(
     OpPassManager &pm, const RefBackendLoweringPipelineOptions &options);
 
+// Helper pipeline that runs TCF->TCP lowering.
+//
+// For now, just piggy-back on the same set of options since this is such a
+// simple set of passes.
+//
+// TODO: Move this out of RefBackend once the TCF->TCP conversions
+// become more substantial.
+void createRefBackendTCFToTCPPipeline(
+    OpPassManager &pm, const RefBackendLoweringPipelineOptions &options);
+
 // Helper pipeline that runs TCF->TCP lowering before invoking
 // RefBackendLoweringPipeline.
 // For now, just piggy-back on the same set of options since this is such a


### PR DESCRIPTION
This allows invoking TCF to TCP-level conversion more easily, and starts
us towards a path of factoring it out of the RefBackend.