### PR TITLE
Update PYTHON cmake variables to Python3

### DIFF
--- a/frontends/pytorch/csrc/builder/CMakeLists.txt
+++ b/frontends/pytorch/csrc/builder/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(
   ${TORCH_INSTALL_PREFIX}/include/THC/opt/pytorch/pytorch
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
-  ${PYTHON_INCLUDE_DIRS}
+  ${Python3_INCLUDE_DIRS}
   )
 link_directories("${TORCH_INSTALL_PREFIX}/lib")
 add_library(npcomp_torch_builder_bindings
@@ -17,6 +17,6 @@ add_library(npcomp_torch_builder_bindings
 
 target_link_libraries(npcomp_torch_builder_bindings
   ${TORCH_LIBRARIES}
-  ${PYTHON_LIBRARIES}
+  ${Python3_LIBRARIES}
   torch_python
   )

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -37,7 +37,7 @@ npcomp_python_create_symlinks(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE
 # TODO(laurenzo): OSX requires allowing undefined (-undefined dynamic_lookup)
 if(NPCOMP_PYTHON_BINDINGS_VERSION_LOCKED)
   set(NPCOMP_PYEXT_LINK_MODE SHARED)
-  set(NPCOMP_PYEXT_LIBADD ${PYTHON_LIBRARIES})
+  set(NPCOMP_PYEXT_LIBADD ${Python3_LIBRARIES})
 else()
   set(NPCOMP_PYEXT_LINK_MODE MODULE)
   set(NPCOMP_PYEXT_LIBADD)

--- a/tools/mnist-playground/CMakeLists.txt
+++ b/tools/mnist-playground/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(
   ${TORCH_INSTALL_PREFIX}/include/THC/opt/pytorch/pytorch
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
-  ${PYTHON_INCLUDE_DIRS}
+  ${Python3_INCLUDE_DIRS}
   )
 link_directories("${TORCH_INSTALL_PREFIX}/lib")
 


### PR DESCRIPTION
After the recent change of cmake variables
from PYTHON_INCLUDE_DIRS to Python3_INCLUDE_DIRS
and PYTHON_LIBRARIES to Python3_LIBRARIES, there were
a few files that still had references to the old
variables. This patch fixes that.