### PR TITLE
cmake_configure.sh: Add mlir native modules to PYTHONPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ cd build
 ninja
 ninja check-npcomp
 
-# Setup PYTHONPATH for interactive use
-export PYTHONPATH="$(realpath python):$(realpath build/python)"
+# cmake_configure.sh should emit a .env file with needed
+# PYTHONPATH setup.
+source .env
 ```
 
 ### PyTorch Frontend (with PyTorch installed via conda)

--- a/build_tools/cmake_configure.sh
+++ b/build_tools/cmake_configure.sh
@@ -82,7 +82,7 @@ echo "Using llvm-lit: $LLVM_LIT"
 # Write a .env file for python tooling.
 function write_env_file() {
   echo "Updating $build_dir/.env file"
-  echo "PYTHONPATH=\"$(realpath "$build_dir/python_native"):$(realpath "$build_dir/python")\"" > "$build_dir/.env"
+  echo "PYTHONPATH=\"$(realpath "$build_dir/python"):$(realpath "$install_mlir/python")\"" > "$build_dir/.env"
   echo "NUMPY_EXPERIMENTAL_ARRAY_FUNCTION=1" >> "$build_dir/.env"
   if ! cp "$build_dir/.env" "$td/.env"; then
     echo "WARNING: Failed to write $td/.env"


### PR DESCRIPTION
Also, update README.md to use the canonical .env file written by
`cmake_configure.sh`.