### PR TITLE
Add TorchScript graph importer.

### DIFF
--- a/frontends/pytorch/csrc/CMakeLists.txt
+++ b/frontends/pytorch/csrc/CMakeLists.txt
@@ -13,6 +13,13 @@ include_directories(BEFORE
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   ${Python3_INCLUDE_DIRS}
+  # TODO: Fix implicit ordering. If PyTorch was build against an external
+  # pybind11, then it will not be in the above search path and must be
+  # resolved here, in the hope that it is the same one we were configured
+  # with (which it should be if installed via pip). This is really fragile,
+  # though, causing cast failures at runtime if we get it wrong. Come up with
+  # a way to strengthen this.
+  ${pybind11_INCLUDE_DIR}
   )
 link_directories("${TORCH_INSTALL_PREFIX}/lib")
 
@@ -28,7 +35,11 @@ target_link_libraries(NPCOMPTorchMLIRExt
   # NPCOMP shared library.
   NPCOMP
 )
-
+add_dependencies(NPCOMPTorchMLIRExt
+  # Uses of the torch_mlir extension also require the npcomp extension to
+  # be built.
+  NPCOMPNativePyExt
+)
 set_target_properties(NPCOMPTorchMLIRExt PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/python
   OUTPUT_NAME _torch_mlir

--- a/frontends/pytorch/csrc/builder/CMakeLists.txt
+++ b/frontends/pytorch/csrc/builder/CMakeLists.txt
@@ -5,12 +5,20 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   ${Python3_INCLUDE_DIRS}
+  # TODO: Fix implicit ordering. If PyTorch was build against an external
+  # pybind11, then it will not be in the above search path and must be
+  # resolved here, in the hope that it is the same one we were configured
+  # with (which it should be if installed via pip). This is really fragile,
+  # though, causing cast failures at runtime if we get it wrong. Come up with
+  # a way to strengthen this.
+  ${pybind11_INCLUDE_DIR}
   )
 link_directories("${TORCH_INSTALL_PREFIX}/lib")
 add_library(npcomp_torch_builder_bindings
   acap_dispatch.cpp
   debug.cpp
   func_builder.cpp
+  graph_importer.cpp
   module_builder.cpp
   python_bindings.cpp
 )

--- a/frontends/pytorch/csrc/builder/acap_dispatch.h
+++ b/frontends/pytorch/csrc/builder/acap_dispatch.h
@@ -80,9 +80,9 @@ public:
 
 private:
   /// Builds a kernel call step by step.
-  class KernelCallBuilder {
+  class TracedKernelCallBuilder : private KernelCallBuilder {
   public:
-    KernelCallBuilder(
+    TracedKernelCallBuilder(
         AcapController &parent, MlirContext context, MlirLocation loc,
         const c10::OperatorHandle &opHandle,
         llvm::Optional<std::string> overrideKernelName = llvm::None);
@@ -91,12 +91,8 @@ private:
     MlirOperation create();
 
   private:
-    void addSchemaAttrs();
     AcapController &parent;
-    MlirContext context;
-    MlirLocation loc;
     const c10::OperatorHandle &opHandle;
-    OperationStateHolder state;
     int resultCount = 0;
     llvm::SmallVector<std::pair<size_t, at::Tensor>, 4> resultIndexToTensorMap;
   };

--- a/frontends/pytorch/csrc/builder/graph_importer.cpp
+++ b/frontends/pytorch/csrc/builder/graph_importer.cpp
@@ -1,0 +1,303 @@
+//===- graph_importer.cpp -------------------------------------------------===//
+//
+// This file is licensed under a pytorch-style license
+// See frontends/pytorch/LICENSE for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include "graph_importer.h"
+
+#include "mlir-c/Diagnostics.h"
+#include "mlir-c/StandardAttributes.h"
+#include "mlir-c/StandardTypes.h"
+
+namespace py = pybind11;
+using namespace torch_mlir;
+
+//------------------------------------------------------------------------------
+// GraphImporter::NodeScope implementation
+//------------------------------------------------------------------------------
+
+// A scope of Graph Value * to corresponding MlirValue. Scopes nest
+// region-wise. Note that in PyTorch, the thing called 'Block' is analagous
+// to a capturing MLIR region.
+class GraphImporter::NodeScope {
+public:
+  NodeScope() = default;
+  NodeScope(NodeScope *prev) : prev(prev) {}
+
+  void bindValue(torch::jit::Value *torchValue, MlirValue value);
+  MlirValue findValue(torch::jit::Value *torchValue);
+  MlirValue findRequiredValue(MlirLocation loc, torch::jit::Value *torchValue);
+
+private:
+  llvm::DenseMap<torch::jit::Value *, MlirValue> valueMap;
+  NodeScope *prev = nullptr;
+};
+
+void GraphImporter::NodeScope::bindValue(torch::jit::Value *torchValue,
+                                         MlirValue value) {
+  assert(valueMap.count(torchValue) == 0 && "duplicate torch Value bind");
+  valueMap[torchValue] = value;
+}
+
+MlirValue GraphImporter::NodeScope::findValue(torch::jit::Value *torchValue) {
+  auto foundIt = valueMap.find(torchValue);
+  if (foundIt == valueMap.end()) {
+    if (prev)
+      return prev->findValue(torchValue);
+    else
+      return {nullptr};
+  }
+  return foundIt->second;
+}
+
+MlirValue
+GraphImporter::NodeScope::findRequiredValue(MlirLocation loc,
+                                            torch::jit::Value *torchValue) {
+  MlirValue value = findValue(torchValue);
+  if (mlirValueIsNull(value)) {
+    std::stringstream msg;
+    msg << "internal error: unmapped torch value: %" << torchValue->debugName();
+    mlirEmitError(loc, msg.str().c_str());
+    throw mlir_diagnostic_emitted();
+  }
+  return value;
+}
+
+//------------------------------------------------------------------------------
+// GraphImporter::NodeImporter implementation
+//------------------------------------------------------------------------------
+
+/// Helper class to import a torch::jit::Node into an MLIR function.
+/// This class primarily exists to eliminate the need for large lists of
+/// carried arguments related to doing the import.
+class GraphImporter::NodeImporter {
+public:
+  NodeImporter(torch::jit::Node *node, GraphImporter &parent,
+               FuncBuilder *funcBuilder, MlirBlock block, MlirOperation ip,
+               NodeScope *scope);
+
+  void importNode();
+  void importReturnOp();
+
+private:
+  MlirContext context() { return parent.context(); }
+  void importPrimNode();
+  MlirAttribute importValueAttribute();
+
+  torch::jit::Node *node;
+  GraphImporter &parent;
+  FuncBuilder *funcBuilder;
+  MlirBlock block;
+  MlirOperation ip;
+  NodeScope *scope;
+  MlirLocation loc;
+};
+
+GraphImporter::NodeImporter::NodeImporter(torch::jit::Node *node,
+                                          GraphImporter &parent,
+                                          FuncBuilder *funcBuilder,
+                                          MlirBlock block, MlirOperation ip,
+                                          NodeScope *scope)
+    : node(node), parent(parent), funcBuilder(funcBuilder), block(block),
+      ip(ip), scope(scope) {
+  loc = parent.extractCallstackLoc(node);
+}
+
+void GraphImporter::NodeImporter::importNode() {
+  // Prim namespace handled specially.
+  auto kind = node->kind();
+  if (kind.ns() == c10::namespaces::prim) {
+    importPrimNode();
+    return;
+  }
+
+  // Generic import.
+  auto funcSchema = node->maybeSchema();
+  if (funcSchema) {
+    KernelCallBuilder kcb(context(), loc, kind.toQualString(), *funcSchema);
+    for (auto *input : node->inputs()) {
+      kcb.addOperand(scope->findRequiredValue(loc, input));
+    }
+    for (auto *output : node->outputs()) {
+      MlirType type =
+          parent.type_mapper().mapFromTorchType(loc, output->type());
+      if (mlirTypeIsNull(type)) {
+        throw mlir_diagnostic_emitted();
+      }
+      kcb.addResultType(type);
+    }
+    MlirOperation op = kcb.create();
+    mlirBlockInsertOwnedOperationBefore(block, ip, op);
+
+    // Map results.
+    for (auto it : llvm::enumerate(node->outputs())) {
+      scope->bindValue(it.value(), mlirOperationGetResult(op, it.index()));
+    }
+    return;
+  }
+
+  // No soup for you. Not exactly sure when this can happen.
+  {
+    std::stringstream msg;
+    msg << "unhandled: generic operation " << kind.toDisplayString();
+    mlirEmitError(loc, msg.str().c_str());
+    throw mlir_diagnostic_emitted();
+  }
+}
+
+void GraphImporter::NodeImporter::importReturnOp() {
+  OperationStateHolder s("std.return", loc);
+  llvm::SmallVector<MlirValue, 4> returnsValues;
+  for (auto *input : node->inputs()) {
+    returnsValues.push_back(scope->findRequiredValue(loc, input));
+  }
+  mlirOperationStateAddOperands(s, returnsValues.size(), returnsValues.data());
+  mlirBlockInsertOwnedOperationBefore(block, ip, s.createOperation());
+}
+
+void GraphImporter::NodeImporter::importPrimNode() {
+  auto kind = node->kind();
+  if (kind == c10::prim::Constant) {
+    auto output = node->output();
+    MlirAttribute valueAttr = importValueAttribute();
+    MlirValue constValue = funcBuilder->getGeneralConstant(loc, valueAttr);
+    scope->bindValue(output, constValue);
+    return;
+  }
+
+  // Unhandled.
+  {
+    std::stringstream msg;
+    msg << "unhandled: prim operation " << kind.toDisplayString();
+    mlirEmitError(loc, msg.str().c_str());
+    throw mlir_diagnostic_emitted();
+  }
+}
+
+MlirAttribute GraphImporter::NodeImporter::importValueAttribute() {
+  using torch::jit::AttributeKind;
+  auto s = c10::attr::value;
+  auto kind = node->kindOf(s);
+  switch (kind) {
+  case AttributeKind::i:
+    // TODO: This should be a signed int once we have a constant op that can
+    // do that.
+    return mlirIntegerAttrGet(mlirIntegerTypeGet(context(), 64), node->i(s));
+    break;
+  case AttributeKind::f:
+    return mlirFloatAttrDoubleGet(context(), mlirF64TypeGet(context()),
+                                  node->f(s));
+    break;
+
+  default: {
+    std::stringstream msg;
+    msg << "unhandled: value attribute kind " << toString(kind);
+    mlirEmitError(loc, msg.str().c_str());
+    throw mlir_diagnostic_emitted();
+  }
+  }
+}
+
+//------------------------------------------------------------------------------
+// GraphImporter implementation
+//------------------------------------------------------------------------------
+
+GraphImporter::GraphImporter(std::shared_ptr<torch::jit::Graph> graph,
+                             MlirMappingOptions mappingOptions)
+    : graph(std::move(graph)), mappingOptions(std::move(mappingOptions)) {}
+
+std::shared_ptr<GraphImporter> GraphImporter::forPythonJitFunc(
+    torch::jit::Function *function,
+    GraphImporter::MlirMappingOptions mappingOptions) {
+  // Disallow an attempt to compile a native function.
+  if (!function->isGraphFunction()) {
+    throw std::invalid_argument(
+        "Expected a torch.jit.ScriptFunction with a graph");
+  }
+  auto graph = function->graph();
+  if (!mappingOptions.genericFuncName) {
+    mappingOptions.genericFuncName = function->name() + "$generic";
+  }
+  if (!mappingOptions.funcName) {
+    mappingOptions.funcName = function->name() + "$generic";
+  }
+  return std::make_shared<GraphImporter>(graph, std::move(mappingOptions));
+}
+
+void GraphImporter::initialize() {
+  defaultLoc = mlirLocationUnknownGet(context());
+  // There is not a callstack associated with the graph so, try to grab
+  // a location from the first node that has one as a better than nothing
+  // thing.
+  // TODO: This doesn't actually seem to be working. Investigate when more
+  // examples are built out.
+  for (auto *node : graph->nodes()) {
+    MlirLocation nodeLoc = extractCallstackLoc(node, /*useDefault=*/false);
+    if (nodeLoc.ptr) {
+      defaultLoc = nodeLoc;
+      break;
+    }
+  }
+
+  // Map inputs.
+  MlirLocation inputLoc = extractCallstackLoc(graph->param_node());
+  for (const auto &input : graph->inputs()) {
+    MlirType t = type_mapper().mapFromTorchType(inputLoc, input->type());
+    if (mlirTypeIsNull(t))
+      throw mlir_diagnostic_emitted("could not convert function input type");
+    genericFuncArgTypes.push_back(t);
+  }
+
+  // Map outputs.
+  MlirLocation outputLoc = extractCallstackLoc(graph->return_node());
+  for (const auto &output : graph->outputs()) {
+    MlirType t = type_mapper().mapFromTorchType(outputLoc, output->type());
+    if (mlirTypeIsNull(t))
+      throw mlir_diagnostic_emitted("could not convert function output type");
+    genericFuncReturnTypes.push_back(t);
+  }
+}
+
+void GraphImporter::importGenericFunc() {
+  auto funcBuilder = FuncBuilder::createFunction(
+      mappingOptions.inserter, defaultLoc, *mappingOptions.genericFuncName,
+      genericFuncArgTypes);
+  funcBuilder->rewriteFuncReturnTypes(genericFuncReturnTypes);
+  MlirBlock entryBlock = funcBuilder->getEntryBlock();
+
+  // Bind inputs.
+  NodeScope scope;
+  for (const auto &it : llvm::enumerate(graph->inputs())) {
+    MlirValue value = mlirBlockGetArgument(entryBlock, it.index());
+    scope.bindValue(it.value(), value);
+  }
+
+  // Walk body nodes.
+  for (auto *node : graph->nodes()) {
+    NodeImporter importer{
+        node, *this, funcBuilder.get(), entryBlock, /*ip=*/{nullptr}, &scope};
+    importer.importNode();
+  }
+
+  // Map the output node to a return.
+  auto *outputNode = graph->return_node();
+  NodeImporter returnImporter{outputNode,        *this,
+                              funcBuilder.get(), entryBlock,
+                              /*ip=*/{nullptr},  &scope};
+  returnImporter.importReturnOp();
+}
+
+MlirLocation GraphImporter::extractCallstackLoc(torch::jit::Node *node,
+                                                bool useDefault) {
+  auto flc = node->sourceRange().file_line_col();
+  if (flc) {
+    const std::string &file = std::get<0>(*flc);
+    int line = std::get<1>(*flc);
+    int col = std::get<2>(*flc);
+    return mlirLocationFileLineColGet(context(), file.c_str(), line, col);
+  }
+
+  return useDefault ? defaultLoc : MlirLocation{nullptr};
+}

--- a/frontends/pytorch/csrc/builder/graph_importer.h
+++ b/frontends/pytorch/csrc/builder/graph_importer.h
@@ -1,0 +1,91 @@
+//===- graph_importer.h -----------------------------------------*- C++ -*-===//
+//
+// This file is licensed under a pytorch-style license
+// See frontends/pytorch/LICENSE for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef NPCOMP_FRONTENDS_PYTORCH_CSRC_GRAPH_IMPORTER_H
+#define NPCOMP_FRONTENDS_PYTORCH_CSRC_GRAPH_IMPORTER_H
+
+#include <memory>
+
+#include "../pybind.h"
+#include "func_builder.h"
+
+#include "mlir-c/IR.h"
+
+#include <torch/csrc/jit/api/compilation_unit.h>
+#include <torch/csrc/jit/ir/ir.h>
+
+namespace torch_mlir {
+
+/// Main entry-point for importing torch::jit::Graph instances (and structures
+/// surrounding them such as modules and methods).
+///
+/// In torch terminology, a Graph is a function. Later in the compiler, we may
+/// specialize multiple versions of it.
+///
+/// Since graph functions typically have enough annotations for the most
+/// generic form of every type (i.e. Tensor, List, etc), and since we often
+/// want to multi-version specific specializations, we take the approach of
+/// generating a '$generic' suffixed function at that level and then generate
+/// the actual named function with using a 'numpy.generic_call' op to invoke
+/// the generic function with metadata controlling how it is legal to
+/// specialize. This leaves the process of inlining and expanding the
+/// specializations to compiler passes.
+class GraphImporter : public std::enable_shared_from_this<GraphImporter> {
+public:
+  /// Options for mapping Graph concepts to MLIR. In addition to things like
+  /// names and type mappings, this includes various policy options such as
+  /// when to import globals as constants vs shared arrays, etc.
+  struct MlirMappingOptions {
+    MlirContext context;
+    llvm::Optional<std::string> genericFuncName;
+    llvm::Optional<std::string> funcName;
+    TypeMapper &typeMapper;
+    FuncBuilder::Inserter &inserter;
+  };
+  /// Construct an importer.
+  GraphImporter(std::shared_ptr<torch::jit::Graph> graph,
+                MlirMappingOptions mappingOptions);
+
+  /// Helper to create a graph importer from a traced/scripted python function.
+  /// If the funcName of the mapping options is not set, it is set from the
+  /// function name. It is the responsibility of the caller to ensure that the
+  /// funcObj and associated graph outlives this instance.
+  static std::shared_ptr<GraphImporter>
+  forPythonJitFunc(torch::jit::Function *function,
+                   MlirMappingOptions mappingOptions);
+
+  /// Initialize for import. This is separate from the constructor purely for
+  /// ergonomics and must be called post-construction. Initialization activities
+  /// that throw go here.
+  void initialize();
+
+  /// Imports the generic function into the module.
+  void importGenericFunc();
+
+private:
+  class NodeScope;
+  class NodeImporter;
+
+  MlirContext context() { return mappingOptions.context; }
+  TypeMapper &type_mapper() { return mappingOptions.typeMapper; }
+  MlirLocation extractCallstackLoc(torch::jit::Node *node,
+                                   bool useDefault = true);
+  std::shared_ptr<torch::jit::Graph> graph;
+  MlirMappingOptions mappingOptions;
+
+  /// Default function location, to be used when a more specific is not
+  /// available.
+  MlirLocation defaultLoc;
+
+  /// Argument and return types for the generic func.
+  llvm::SmallVector<MlirType, 4> genericFuncArgTypes;
+  llvm::SmallVector<MlirType, 4> genericFuncReturnTypes;
+};
+
+} // namespace torch_mlir
+
+#endif // NPCOMP_FRONTENDS_PYTORCH_CSRC_GRAPH_IMPORTER_H

--- a/frontends/pytorch/csrc/builder/module_builder.h
+++ b/frontends/pytorch/csrc/builder/module_builder.h
@@ -16,6 +16,8 @@
 #include "llvm/ADT/SmallVector.h"
 
 #include <ATen/Tensor.h>
+#include <torch/csrc/jit/api/compilation_unit.h>
+#include <torch/csrc/jit/ir/ir.h>
 
 namespace torch_mlir {
 
@@ -32,11 +34,16 @@ public:
   pybind11::object getModuleObj() { return moduleObj; }
 
   // Starts a device-capture based function.
-  // TODO: Add inputs.
   std::shared_ptr<AcapController>
   startCaptureFunction(std::string &name, std::vector<at::Tensor> args);
 
+  // Imports a traced function. Note that the python type
+  // torch.jit.ScriptFunction is the C++ type torch::jit::StrongFunctionPtr.
+  // Just a bit of naming cruft.
+  void importFunction(torch::jit::StrongFunctionPtr function);
+
 private:
+  FuncBuilder::Inserter createInserter();
   MlirBlock getBodyBlock();
 
   // Capture references to the python-owned context and module. Ownership

--- a/frontends/pytorch/csrc/builder/python_bindings.cpp
+++ b/frontends/pytorch/csrc/builder/python_bindings.cpp
@@ -140,4 +140,3 @@ void torch_mlir::InitBuilderBindings(py::module &m) {
 
   ModuleBuilder::bind(m);
 }
-

--- a/frontends/pytorch/csrc/pybind.h
+++ b/frontends/pytorch/csrc/pybind.h
@@ -14,4 +14,15 @@
 
 #include <torch/csrc/utils/pybind.h>
 
+namespace torch_mlir {
+
+/// Thrown on failure when details are in MLIR emitted diagnostics.
+class mlir_diagnostic_emitted : public std::runtime_error {
+public:
+  mlir_diagnostic_emitted(const char *what) : std::runtime_error(what) {}
+  mlir_diagnostic_emitted() : std::runtime_error("see diagnostics") {}
+};
+
+} // namespace torch_mlir
+
 #endif // NPCOMP_FRONTENDS_PYTORCH_CSRC_PYBIND_H

--- a/frontends/pytorch/test/acap_export/test_export_add3.py
+++ b/frontends/pytorch/test/acap_export/test_export_add3.py
@@ -2,6 +2,8 @@
 # This file is licensed under a pytorch-style license
 # See frontends/pytorch/LICENSE for license information.
 
+
+
 import torch
 import torch_mlir
 

--- a/frontends/pytorch/test/graph_export/test_script_add3.py
+++ b/frontends/pytorch/test/graph_export/test_script_add3.py
@@ -1,0 +1,25 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See frontends/pytorch/LICENSE for license information.
+
+import torch
+import torch_mlir
+
+# RUN: %PYTHON %s | npcomp-opt | FileCheck %s
+
+@torch.jit.script
+def add3(t0, t1, t2):
+  return t0 + t1 + t2
+
+mb = torch_mlir.ModuleBuilder()
+mb.import_function(add3)
+
+# Verify without debug info.
+# CHECK-LABEL: func @add3$generic
+# CHECK-SAME: (%arg0: !numpy.ndarray<*:!numpy.any_dtype>, %arg1: !numpy.ndarray<*:!numpy.any_dtype>, %arg2: !numpy.ndarray<*:!numpy.any_dtype>) -> !numpy.ndarray<*:!numpy.any_dtype> {
+# CHECK:   %[[C1:.*]] = constant 1 : i64
+# CHECK:   %[[A0:.*]] = torch.kernel_call "aten::add" %arg0, %arg1, %[[C1]] : (!numpy.ndarray<*:!numpy.any_dtype>, !numpy.ndarray<*:!numpy.any_dtype>, i64) -> !numpy.ndarray<*:!numpy.any_dtype> {sigArgTypes = ["Tensor", "Tensor", "Scalar"], sigIsMutable = false, sigIsVararg = false, sigIsVarret = false, sigRetTypes = ["Tensor"]}
+# CHECK:   %[[A1:.*]] = torch.kernel_call "aten::add" %[[A0]], %arg2, %[[C1]] : (!numpy.ndarray<*:!numpy.any_dtype>, !numpy.ndarray<*:!numpy.any_dtype>, i64) -> !numpy.ndarray<*:!numpy.any_dtype> {sigArgTypes = ["Tensor", "Tensor", "Scalar"], sigIsMutable = false, sigIsVararg = false, sigIsVarret = false, sigRetTypes = ["Tensor"]}
+# CHECK:   return %[[A1]] : !numpy.ndarray<*:!numpy.any_dtype>
+mb.module.operation.print()
+print()

--- a/frontends/pytorch/test/graph_export/test_script_debug_info.py
+++ b/frontends/pytorch/test/graph_export/test_script_debug_info.py
@@ -1,0 +1,26 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See frontends/pytorch/LICENSE for license information.
+
+import torch
+import torch_mlir
+
+# RUN: %PYTHON %s | FileCheck %s
+
+@torch.jit.script
+def add3(t0, t1, t2):
+  intermediate = t0 + t1
+  final = intermediate + t2
+  return final
+
+mb = torch_mlir.ModuleBuilder()
+mb.import_function(add3)
+
+# Verify again with debug info present. Just checking that it makes it in there.
+# CHECK-LABEL: func @add3$generic
+# CHECK: constant 1{{.*}}loc({{.*}}test_script_debug_info.py
+# CHECK: aten::add{{.*}}loc({{.*}}test_script_debug_info.py
+# CHECK: return{{.*}}loc({{.*}}test_script_debug_info.py
+# CHECK: }{{.*}}loc({{.*}}test_script_debug_info.py
+mb.module.operation.print(enable_debug_info=True)
+print()

--- a/include/npcomp-c/Types.h
+++ b/include/npcomp-c/Types.h
@@ -64,6 +64,9 @@ MlirType npcompListTypeGet(MlirContext context);
 /** Checks whether the given type is an NdArray type. */
 int npcompTypeIsANdArray(MlirType t);
 
+/** Gets a numpy.NdArray type that is unranked. */
+MlirType npcompNdArrayTypeGetUnranked(MlirType elementType);
+
 /** Gets a numpy.NdArray type that is ranked. Any dimensions that are -1 are
  * unknown. */
 MlirType npcompNdArrayTypeGetRanked(intptr_t rank, const int64_t *shape,

--- a/lib/CAPI/Types.cpp
+++ b/lib/CAPI/Types.cpp
@@ -70,6 +70,10 @@ int npcompTypeIsANdArray(MlirType t) {
   return unwrap(t).isa<Numpy::NdArrayType>();
 }
 
+MlirType npcompNdArrayTypeGetUnranked(MlirType elementType) {
+  return wrap(Numpy::NdArrayType::get(unwrap(elementType)));
+}
+
 MlirType npcompNdArrayTypeGetRanked(intptr_t rank, const int64_t *shape,
                                     MlirType elementType) {
   llvm::ArrayRef<int64_t> shapeArray(shape, rank);


### PR DESCRIPTION
* Does not handle all features yet but should conservatively fail on unsupported things.
* Location tracking is still somewhat mismatched between what TorchScript and MLIR do. Likely need a better heuristic for tracking locations from defs for nodes that do not carry location.
* Sets the ground-work for a specialized/generic split but only implements the generic side.
* Had some evidence that this requires a recent bump of PT nightly (within the last month) to pick up pybind11 2.6, which includes some cross-module symbol fixes (vs the previously sync'd version). No source changes, but older versions fail to cast function types at runtime.