### PR TITLE
Expand pytype coverage for torch_signature_ods_gen.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build-mlir
 install-mlir
 __pycache__
 
+.pytype


### PR DESCRIPTION
- Added `REG_OP_TYPE` and `SIGLIST_TYPE` to better characterize the registered ops data structure.
- Generally expanded typing.
- Add `pytype: disable` statements to make it green where it gets confused.
- Small typo fixes.
- Made yapf make slightly better decisions by using trailing commas:
```python
opdef.return_transforms(type_transforms={
    "Tensor:0": "AnyTorchImmutableTensor",
},
                        flag_transforms={
                            ":0": ["kImmutableTensor"],
                        })
```

```python
opdef.return_transforms(
    type_transforms={
        "Tensor:0": "AnyTorchImmutableTensor",
    },
    flag_transforms={
        ":0": ["kImmutableTensor"],
    },
)    ^
```