### PR TITLE
Indent generated .td traits to limit linewidth

### DIFF
--- a/frontends/pytorch/python/torch_mlir_utils/codegen/torch_signature_ods_gen.py
+++ b/frontends/pytorch/python/torch_mlir_utils/codegen/torch_signature_ods_gen.py
@@ -559,6 +559,21 @@ class EmitterBase:
     self.indent_level -= level
     assert self.indent_level >= 0, "Unbalanced indentation"
 
+  def indent_sequence(
+      self,
+      sequence: Sequence[str],
+      base_indent_level: int = 0,
+      sequence_indent_level: int = 1,
+      brackets: Tuple[str, str] = ("[", "]")
+  ) -> str:
+    base_indent = self._INDENT * base_indent_level
+    sequence_indent = f"{base_indent}{self._INDENT * sequence_indent_level}"
+    return "".join([
+        f"{brackets[0]}\n{sequence_indent}",
+        f",\n{sequence_indent}".join(sequence),
+        f"\n{base_indent}{brackets[1]}",
+    ])
+
   def print(self, s: str, *, end: str = "\n", indent: bool = True):
     if indent and self.indent_level:
       self.out.write(self._INDENT * self.indent_level)
@@ -601,9 +616,10 @@ class OdsEmitter(EmitterBase):
     full_traits.append("DeclareOpInterfaceMethods<TorchKernelOpInterface>")
     identifier = f"{self.ods_def_prefix}{ods_def_name}{self.ods_def_suffix}"
     self.print(f"def {identifier}: {self.ods_template_name}"
-               f"<{self.quote(mnemonic)}, ["
-               f"{', '.join(full_traits)}"
-               f"]> {{")
+               f"<{self.quote(mnemonic)}, "
+               f"{self.indent_sequence(full_traits, base_indent_level=1)}"
+               f"> {{")
+
     with self.indent():
       # Summary.
       if not summary:

--- a/include/npcomp/Dialect/ATen/IR/GeneratedATenOps.td
+++ b/include/npcomp/Dialect/ATen/IR/GeneratedATenOps.td
@@ -18,7 +18,11 @@
 // Binary arithmetic ops
 // -----------------------------------------------------------------------------
 
-def aten_AddOp: aten_Op<"add", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_AddOp: aten_Op<"add", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::add";
   let arguments = (ins
     AnyTorchImmutableTensor:$self,
@@ -30,7 +34,11 @@ def aten_AddOp: aten_Op<"add", [NoSideEffect, DeclareOpInterfaceMethods<TorchBui
   );
 }
 
-def aten_Atan2Op: aten_Op<"atan2", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_Atan2Op: aten_Op<"atan2", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::atan2";
   let arguments = (ins
     AnyTorchImmutableTensor:$self,
@@ -41,7 +49,11 @@ def aten_Atan2Op: aten_Op<"atan2", [NoSideEffect, DeclareOpInterfaceMethods<Torc
   );
 }
 
-def aten_DivOp: aten_Op<"div", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_DivOp: aten_Op<"div", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::div";
   let arguments = (ins
     AnyTorchImmutableTensor:$self,
@@ -52,7 +64,11 @@ def aten_DivOp: aten_Op<"div", [NoSideEffect, DeclareOpInterfaceMethods<TorchBui
   );
 }
 
-def aten_FloorDivideOp: aten_Op<"floor_divide", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_FloorDivideOp: aten_Op<"floor_divide", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::floor_divide";
   let arguments = (ins
     AnyTorchImmutableTensor:$self,
@@ -63,7 +79,11 @@ def aten_FloorDivideOp: aten_Op<"floor_divide", [NoSideEffect, DeclareOpInterfac
   );
 }
 
-def aten_MulOp: aten_Op<"mul", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_MulOp: aten_Op<"mul", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::mul";
   let arguments = (ins
     AnyTorchImmutableTensor:$self,
@@ -74,7 +94,11 @@ def aten_MulOp: aten_Op<"mul", [NoSideEffect, DeclareOpInterfaceMethods<TorchBui
   );
 }
 
-def aten_RemainderOp: aten_Op<"remainder", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_RemainderOp: aten_Op<"remainder", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::remainder";
   let arguments = (ins
     AnyTorchImmutableTensor:$self,
@@ -85,7 +109,11 @@ def aten_RemainderOp: aten_Op<"remainder", [NoSideEffect, DeclareOpInterfaceMeth
   );
 }
 
-def aten_TrueDivideOp: aten_Op<"true_divide", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_TrueDivideOp: aten_Op<"true_divide", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::true_divide";
   let arguments = (ins
     AnyTorchImmutableTensor:$self,
@@ -96,7 +124,11 @@ def aten_TrueDivideOp: aten_Op<"true_divide", [NoSideEffect, DeclareOpInterfaceM
   );
 }
 
-def aten_MaximumOp: aten_Op<"maximum", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_MaximumOp: aten_Op<"maximum", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::maximum";
   let arguments = (ins
     AnyTorchImmutableTensor:$self,
@@ -107,7 +139,11 @@ def aten_MaximumOp: aten_Op<"maximum", [NoSideEffect, DeclareOpInterfaceMethods<
   );
 }
 
-def aten_MinimumOp: aten_Op<"minimum", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_MinimumOp: aten_Op<"minimum", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::minimum";
   let arguments = (ins
     AnyTorchImmutableTensor:$self,
@@ -122,7 +158,11 @@ def aten_MinimumOp: aten_Op<"minimum", [NoSideEffect, DeclareOpInterfaceMethods<
 // Unary arithmetic ops
 // -----------------------------------------------------------------------------
 
-def aten_AbsOp: aten_Op<"abs", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_AbsOp: aten_Op<"abs", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::abs";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -132,7 +172,11 @@ def aten_AbsOp: aten_Op<"abs", [NoSideEffect, DeclareOpInterfaceMethods<TorchBui
   );
 }
 
-def aten_AcosOp: aten_Op<"acos", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_AcosOp: aten_Op<"acos", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::acos";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -142,7 +186,11 @@ def aten_AcosOp: aten_Op<"acos", [NoSideEffect, DeclareOpInterfaceMethods<TorchB
   );
 }
 
-def aten_AngleOp: aten_Op<"angle", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_AngleOp: aten_Op<"angle", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::angle";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -152,7 +200,11 @@ def aten_AngleOp: aten_Op<"angle", [NoSideEffect, DeclareOpInterfaceMethods<Torc
   );
 }
 
-def aten_AsinOp: aten_Op<"asin", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_AsinOp: aten_Op<"asin", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::asin";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -162,7 +214,11 @@ def aten_AsinOp: aten_Op<"asin", [NoSideEffect, DeclareOpInterfaceMethods<TorchB
   );
 }
 
-def aten_AtanOp: aten_Op<"atan", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_AtanOp: aten_Op<"atan", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::atan";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -172,7 +228,11 @@ def aten_AtanOp: aten_Op<"atan", [NoSideEffect, DeclareOpInterfaceMethods<TorchB
   );
 }
 
-def aten_CeilOp: aten_Op<"ceil", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_CeilOp: aten_Op<"ceil", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::ceil";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -182,7 +242,11 @@ def aten_CeilOp: aten_Op<"ceil", [NoSideEffect, DeclareOpInterfaceMethods<TorchB
   );
 }
 
-def aten_ConjOp: aten_Op<"conj", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_ConjOp: aten_Op<"conj", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::conj";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -192,7 +256,11 @@ def aten_ConjOp: aten_Op<"conj", [NoSideEffect, DeclareOpInterfaceMethods<TorchB
   );
 }
 
-def aten_CosOp: aten_Op<"cos", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_CosOp: aten_Op<"cos", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::cos";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -202,7 +270,11 @@ def aten_CosOp: aten_Op<"cos", [NoSideEffect, DeclareOpInterfaceMethods<TorchBui
   );
 }
 
-def aten_CoshOp: aten_Op<"cosh", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_CoshOp: aten_Op<"cosh", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::cosh";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -212,7 +284,11 @@ def aten_CoshOp: aten_Op<"cosh", [NoSideEffect, DeclareOpInterfaceMethods<TorchB
   );
 }
 
-def aten_DigammaOp: aten_Op<"digamma", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_DigammaOp: aten_Op<"digamma", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::digamma";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -222,7 +298,11 @@ def aten_DigammaOp: aten_Op<"digamma", [NoSideEffect, DeclareOpInterfaceMethods<
   );
 }
 
-def aten_ErfOp: aten_Op<"erf", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_ErfOp: aten_Op<"erf", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::erf";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -232,7 +312,11 @@ def aten_ErfOp: aten_Op<"erf", [NoSideEffect, DeclareOpInterfaceMethods<TorchBui
   );
 }
 
-def aten_ErfcOp: aten_Op<"erfc", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_ErfcOp: aten_Op<"erfc", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::erfc";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -242,7 +326,11 @@ def aten_ErfcOp: aten_Op<"erfc", [NoSideEffect, DeclareOpInterfaceMethods<TorchB
   );
 }
 
-def aten_ErfinvOp: aten_Op<"erfinv", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_ErfinvOp: aten_Op<"erfinv", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::erfinv";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -252,7 +340,11 @@ def aten_ErfinvOp: aten_Op<"erfinv", [NoSideEffect, DeclareOpInterfaceMethods<To
   );
 }
 
-def aten_ExpOp: aten_Op<"exp", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_ExpOp: aten_Op<"exp", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::exp";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -262,7 +354,11 @@ def aten_ExpOp: aten_Op<"exp", [NoSideEffect, DeclareOpInterfaceMethods<TorchBui
   );
 }
 
-def aten_Expm1Op: aten_Op<"expm1", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_Expm1Op: aten_Op<"expm1", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::expm1";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -272,7 +368,11 @@ def aten_Expm1Op: aten_Op<"expm1", [NoSideEffect, DeclareOpInterfaceMethods<Torc
   );
 }
 
-def aten_FloorOp: aten_Op<"floor", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_FloorOp: aten_Op<"floor", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::floor";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -282,7 +382,11 @@ def aten_FloorOp: aten_Op<"floor", [NoSideEffect, DeclareOpInterfaceMethods<Torc
   );
 }
 
-def aten_FracOp: aten_Op<"frac", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_FracOp: aten_Op<"frac", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::frac";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -292,7 +396,11 @@ def aten_FracOp: aten_Op<"frac", [NoSideEffect, DeclareOpInterfaceMethods<TorchB
   );
 }
 
-def aten_LgammaOp: aten_Op<"lgamma", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_LgammaOp: aten_Op<"lgamma", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::lgamma";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -302,7 +410,11 @@ def aten_LgammaOp: aten_Op<"lgamma", [NoSideEffect, DeclareOpInterfaceMethods<To
   );
 }
 
-def aten_LogOp: aten_Op<"log", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_LogOp: aten_Op<"log", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::log";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -312,7 +424,11 @@ def aten_LogOp: aten_Op<"log", [NoSideEffect, DeclareOpInterfaceMethods<TorchBui
   );
 }
 
-def aten_Log10Op: aten_Op<"log10", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_Log10Op: aten_Op<"log10", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::log10";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -322,7 +438,11 @@ def aten_Log10Op: aten_Op<"log10", [NoSideEffect, DeclareOpInterfaceMethods<Torc
   );
 }
 
-def aten_Log1pOp: aten_Op<"log1p", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_Log1pOp: aten_Op<"log1p", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::log1p";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -332,7 +452,11 @@ def aten_Log1pOp: aten_Op<"log1p", [NoSideEffect, DeclareOpInterfaceMethods<Torc
   );
 }
 
-def aten_Log2Op: aten_Op<"log2", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_Log2Op: aten_Op<"log2", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::log2";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -342,7 +466,11 @@ def aten_Log2Op: aten_Op<"log2", [NoSideEffect, DeclareOpInterfaceMethods<TorchB
   );
 }
 
-def aten_NegOp: aten_Op<"neg", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_NegOp: aten_Op<"neg", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::neg";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -352,7 +480,11 @@ def aten_NegOp: aten_Op<"neg", [NoSideEffect, DeclareOpInterfaceMethods<TorchBui
   );
 }
 
-def aten_ReluOp: aten_Op<"relu", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_ReluOp: aten_Op<"relu", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::relu";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -362,7 +494,11 @@ def aten_ReluOp: aten_Op<"relu", [NoSideEffect, DeclareOpInterfaceMethods<TorchB
   );
 }
 
-def aten_ReciprocalOp: aten_Op<"reciprocal", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_ReciprocalOp: aten_Op<"reciprocal", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::reciprocal";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -372,7 +508,11 @@ def aten_ReciprocalOp: aten_Op<"reciprocal", [NoSideEffect, DeclareOpInterfaceMe
   );
 }
 
-def aten_RoundOp: aten_Op<"round", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_RoundOp: aten_Op<"round", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::round";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -382,7 +522,11 @@ def aten_RoundOp: aten_Op<"round", [NoSideEffect, DeclareOpInterfaceMethods<Torc
   );
 }
 
-def aten_RsqrtOp: aten_Op<"rsqrt", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_RsqrtOp: aten_Op<"rsqrt", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::rsqrt";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -392,7 +536,11 @@ def aten_RsqrtOp: aten_Op<"rsqrt", [NoSideEffect, DeclareOpInterfaceMethods<Torc
   );
 }
 
-def aten_SigmoidOp: aten_Op<"sigmoid", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_SigmoidOp: aten_Op<"sigmoid", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::sigmoid";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -402,7 +550,11 @@ def aten_SigmoidOp: aten_Op<"sigmoid", [NoSideEffect, DeclareOpInterfaceMethods<
   );
 }
 
-def aten_SignOp: aten_Op<"sign", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_SignOp: aten_Op<"sign", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::sign";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -412,7 +564,11 @@ def aten_SignOp: aten_Op<"sign", [NoSideEffect, DeclareOpInterfaceMethods<TorchB
   );
 }
 
-def aten_SinOp: aten_Op<"sin", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_SinOp: aten_Op<"sin", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::sin";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -422,7 +578,11 @@ def aten_SinOp: aten_Op<"sin", [NoSideEffect, DeclareOpInterfaceMethods<TorchBui
   );
 }
 
-def aten_SinhOp: aten_Op<"sinh", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_SinhOp: aten_Op<"sinh", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::sinh";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -432,7 +592,11 @@ def aten_SinhOp: aten_Op<"sinh", [NoSideEffect, DeclareOpInterfaceMethods<TorchB
   );
 }
 
-def aten_SqrtOp: aten_Op<"sqrt", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_SqrtOp: aten_Op<"sqrt", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::sqrt";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -442,7 +606,11 @@ def aten_SqrtOp: aten_Op<"sqrt", [NoSideEffect, DeclareOpInterfaceMethods<TorchB
   );
 }
 
-def aten_TanOp: aten_Op<"tan", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_TanOp: aten_Op<"tan", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::tan";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -452,7 +620,11 @@ def aten_TanOp: aten_Op<"tan", [NoSideEffect, DeclareOpInterfaceMethods<TorchBui
   );
 }
 
-def aten_TanhOp: aten_Op<"tanh", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_TanhOp: aten_Op<"tanh", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::tanh";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -462,7 +634,11 @@ def aten_TanhOp: aten_Op<"tanh", [NoSideEffect, DeclareOpInterfaceMethods<TorchB
   );
 }
 
-def aten_TruncOp: aten_Op<"trunc", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_TruncOp: aten_Op<"trunc", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::trunc";
   let arguments = (ins
     AnyTorchImmutableTensor:$self
@@ -476,7 +652,11 @@ def aten_TruncOp: aten_Op<"trunc", [NoSideEffect, DeclareOpInterfaceMethods<Torc
 // NN ops
 // -----------------------------------------------------------------------------
 
-def aten_ConvolutionOp: aten_Op<"convolution", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_ConvolutionOp: aten_Op<"convolution", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::convolution_overrideable";
   let arguments = (ins
     AnyTorchImmutableTensor:$input,
@@ -494,7 +674,11 @@ def aten_ConvolutionOp: aten_Op<"convolution", [NoSideEffect, DeclareOpInterface
   );
 }
 
-def aten_ConvolutionBackwardOp: aten_Op<"convolution_backward", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_ConvolutionBackwardOp: aten_Op<"convolution_backward", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::convolution_backward_overrideable";
   let arguments = (ins
     AnyTorchImmutableTensor:$grad_output,
@@ -515,7 +699,11 @@ def aten_ConvolutionBackwardOp: aten_Op<"convolution_backward", [NoSideEffect, D
   );
 }
 
-def aten_LogSoftmaxOp: aten_Op<"log_softmax", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_LogSoftmaxOp: aten_Op<"log_softmax", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::_log_softmax";
   let arguments = (ins
     AnyTorchImmutableTensor:$self,
@@ -527,7 +715,11 @@ def aten_LogSoftmaxOp: aten_Op<"log_softmax", [NoSideEffect, DeclareOpInterfaceM
   );
 }
 
-def aten_LogSoftmaxBackwardDataOp: aten_Op<"log_softmax_backward_data", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_LogSoftmaxBackwardDataOp: aten_Op<"log_softmax_backward_data", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::_log_softmax_backward_data";
   let arguments = (ins
     AnyTorchImmutableTensor:$grad_output,
@@ -540,7 +732,11 @@ def aten_LogSoftmaxBackwardDataOp: aten_Op<"log_softmax_backward_data", [NoSideE
   );
 }
 
-def aten_MmOp: aten_Op<"mm", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_MmOp: aten_Op<"mm", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::mm";
   let arguments = (ins
     AnyTorchImmutableTensor:$self,
@@ -555,7 +751,11 @@ def aten_MmOp: aten_Op<"mm", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuild
 // Loss function ops
 // -----------------------------------------------------------------------------
 
-def aten_NllLossForwardOp: aten_Op<"nll_loss_forward", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_NllLossForwardOp: aten_Op<"nll_loss_forward", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::nll_loss_forward";
   let arguments = (ins
     AnyTorchImmutableTensor:$self,
@@ -570,7 +770,11 @@ def aten_NllLossForwardOp: aten_Op<"nll_loss_forward", [NoSideEffect, DeclareOpI
   );
 }
 
-def aten_NllLossBackwardOp: aten_Op<"nll_loss_backward", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_NllLossBackwardOp: aten_Op<"nll_loss_backward", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::nll_loss_backward";
   let arguments = (ins
     AnyTorchImmutableTensor:$grad_output,
@@ -586,7 +790,11 @@ def aten_NllLossBackwardOp: aten_Op<"nll_loss_backward", [NoSideEffect, DeclareO
   );
 }
 
-def aten_NllLoss2dForwardOp: aten_Op<"nll_loss2d_forward", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_NllLoss2dForwardOp: aten_Op<"nll_loss2d_forward", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::nll_loss2d_forward";
   let arguments = (ins
     AnyTorchImmutableTensor:$self,
@@ -601,7 +809,11 @@ def aten_NllLoss2dForwardOp: aten_Op<"nll_loss2d_forward", [NoSideEffect, Declar
   );
 }
 
-def aten_NllLoss2dBackwardOp: aten_Op<"nll_loss2d_backward", [NoSideEffect, DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_NllLoss2dBackwardOp: aten_Op<"nll_loss2d_backward", [
+    NoSideEffect,
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::nll_loss2d_backward";
   let arguments = (ins
     AnyTorchImmutableTensor:$grad_output,
@@ -617,7 +829,10 @@ def aten_NllLoss2dBackwardOp: aten_Op<"nll_loss2d_backward", [NoSideEffect, Decl
   );
 }
 
-def aten_CopyInplaceOp: aten_Op<"copy.inplace", [DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>]> {
+def aten_CopyInplaceOp: aten_Op<"copy.inplace", [
+    DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>,
+    DeclareOpInterfaceMethods<TorchKernelOpInterface>
+  ]> {
   let summary = "Recognized op for kernel aten::copy_";
   let arguments = (ins
     AnyTorchMutableTensor:$self,


### PR DESCRIPTION
Just a drive-by as part of understanding how `torch_signature_ods_gen.py` works.

Tested that the coverage of `cmake --build build --target check-npcomp check-frontends-pytorch` is identical to the current coverage at HEAD.