### PR TITLE
Add cos_e2e.py, test_utils and support for tensor inputs

### DIFF
--- a/frontends/pytorch/examples/cos_e2e.py
+++ b/frontends/pytorch/examples/cos_e2e.py
@@ -2,7 +2,6 @@
 # This file is licensed under a pytorch-style license
 # See frontends/pytorch/LICENSE for license information.
 
-import sys
 import torch
 import torch_mlir
 

--- a/frontends/pytorch/examples/cos_e2e.py
+++ b/frontends/pytorch/examples/cos_e2e.py
@@ -27,6 +27,6 @@ jit_module = backend.load(backend.compile(mb.module))
 logging.debug(f"Executing jit_module.cos")
 test_utils.compare_outputs(torch.cos, jit_module.cos, input)
 
-# This fails because the "Initial PyTorch IR" hardcodes the input value and
-# ignores %arg0.
+# This fails because ModuleBuilder represents torch.cos with a constant:
+#   https://github.com/llvm/mlir-npcomp/issues/135
 test_utils.compare_outputs(torch.cos, jit_module.cos, input + 1)

--- a/frontends/pytorch/examples/cos_e2e.py
+++ b/frontends/pytorch/examples/cos_e2e.py
@@ -16,16 +16,19 @@ import test_utils
 logging.enable()
 
 torch.manual_seed(0)
-lhs = torch.rand(2, 3)
-rhs = torch.rand(3, 4)
+input = torch.rand(2, 3)
 
 mb = torch_mlir.ModuleBuilder()
-with mb.capture_function("mm", [lhs, rhs]) as f:
-  result = torch.mm(lhs, rhs)
+with mb.capture_function("cos", [input]) as f:
+  result = torch.cos(input)
   f.returns([result])
 
 backend = refjit.CompilerBackend()
 jit_module = backend.load(backend.compile(mb.module))
 
-test_utils.compare_outputs(torch.mm, jit_module.mm, lhs, rhs)
-test_utils.compare_outputs(torch.mm, jit_module.mm, lhs + 1, rhs - 1)
+logging.debug(f"Executing jit_module.cos")
+test_utils.compare_outputs(torch.cos, jit_module.cos, input)
+
+# This fails because the "Initial PyTorch IR" hardcodes the input value and
+# ignores %arg0.
+test_utils.compare_outputs(torch.cos, jit_module.cos, input + 1)

--- a/frontends/pytorch/examples/cos_e2e.py
+++ b/frontends/pytorch/examples/cos_e2e.py
@@ -3,7 +3,6 @@
 # See frontends/pytorch/LICENSE for license information.
 
 import sys
-import numpy as np
 import torch
 import torch_mlir
 

--- a/frontends/pytorch/examples/mm_e2e.py
+++ b/frontends/pytorch/examples/mm_e2e.py
@@ -2,7 +2,6 @@
 # This file is licensed under a pytorch-style license
 # See frontends/pytorch/LICENSE for license information.
 
-import sys
 import torch
 import torch_mlir
 

--- a/frontends/pytorch/examples/mm_e2e.py
+++ b/frontends/pytorch/examples/mm_e2e.py
@@ -3,7 +3,6 @@
 # See frontends/pytorch/LICENSE for license information.
 
 import sys
-import numpy as np
 import torch
 import torch_mlir
 

--- a/frontends/pytorch/examples/mul_maximum_e2e.py
+++ b/frontends/pytorch/examples/mul_maximum_e2e.py
@@ -8,8 +8,10 @@ import torch
 import torch_mlir
 
 import npcomp
-from npcomp.compiler.pytorch.backend.refjit import *
+from npcomp.compiler.pytorch.backend import refjit
 from npcomp.compiler.utils import logging
+
+import test_utils
 
 logging.enable()
 
@@ -18,19 +20,20 @@ rhs = torch.ones((1, 1, 3)) * 0.6
 bias = torch.ones((1, 1, 3)) * 0.2
 threshold = torch.tensor((0.75, 0.25, 0.10))
 
+
+def mul_maximum(lhs, rhs, threshold, bias):
+  return torch.maximum(lhs * rhs, threshold) + bias
+
+
 mb = torch_mlir.ModuleBuilder()
 with mb.capture_function("mul_maximum", [lhs, rhs, threshold, bias]) as f:
-  result = torch.maximum(lhs * rhs, threshold)
-  result = result + bias
+  result = mul_maximum(lhs, rhs, threshold, bias)
   f.returns([result])
 
-backend = CompilerBackend()
+backend = refjit.CompilerBackend()
 jit_module = backend.load(backend.compile(mb.module))
 
-jit_result = jit_module.mul_maximum(lhs.numpy(), rhs.numpy(), threshold.numpy(),
-                                    bias.numpy())
-
-print(f"PyTorch Result = {result.numpy()}", file=sys.stderr)
-print(f"JIT Result = {jit_result}", file=sys.stderr)
-
-np.testing.assert_allclose(result.numpy(), jit_result)
+test_utils.compare_outputs(mul_maximum, jit_module.mul_maximum,
+                           lhs, rhs, threshold, bias,)
+test_utils.compare_outputs(mul_maximum, jit_module.mul_maximum,
+                           lhs + 1, rhs + 2, threshold, bias)

--- a/frontends/pytorch/examples/mul_maximum_e2e.py
+++ b/frontends/pytorch/examples/mul_maximum_e2e.py
@@ -2,7 +2,6 @@
 # This file is licensed under a pytorch-style license
 # See frontends/pytorch/LICENSE for license information.
 
-import sys
 import torch
 import torch_mlir
 

--- a/frontends/pytorch/examples/mul_maximum_e2e.py
+++ b/frontends/pytorch/examples/mul_maximum_e2e.py
@@ -33,7 +33,7 @@ with mb.capture_function("mul_maximum", [lhs, rhs, threshold, bias]) as f:
 backend = refjit.CompilerBackend()
 jit_module = backend.load(backend.compile(mb.module))
 
-test_utils.compare_outputs(mul_maximum, jit_module.mul_maximum,
-                           lhs, rhs, threshold, bias,)
-test_utils.compare_outputs(mul_maximum, jit_module.mul_maximum,
-                           lhs + 1, rhs + 2, threshold, bias)
+test_utils.compare_outputs(mul_maximum, jit_module.mul_maximum, lhs, rhs,
+                           threshold, bias)
+test_utils.compare_outputs(mul_maximum, jit_module.mul_maximum, lhs + 1,
+                           rhs + 2, threshold, bias)

--- a/frontends/pytorch/examples/mul_maximum_e2e.py
+++ b/frontends/pytorch/examples/mul_maximum_e2e.py
@@ -3,7 +3,6 @@
 # See frontends/pytorch/LICENSE for license information.
 
 import sys
-import numpy as np
 import torch
 import torch_mlir
 

--- a/frontends/pytorch/examples/test_utils.py
+++ b/frontends/pytorch/examples/test_utils.py
@@ -1,0 +1,29 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See frontends/pytorch/LICENSE for license information.
+
+import sys
+import textwrap
+
+import numpy as np
+
+INDENT = "  "
+
+
+def _indent(value):
+  return textwrap.indent(str(value), INDENT)
+
+
+def compare_outputs(torch_func, jit_func, *args):
+  print('—' * 80)
+
+  print(f"Input args:\n{_indent(args)}", file=sys.stderr)
+  result = torch_func(*args)
+  jit_result = jit_func(*args)
+
+  np.testing.assert_allclose(result.numpy(), jit_result)
+
+  # Only print these if the test passes, as np.testing will print them if it
+  # fails.
+  print(f"PyTorch Result:\n{_indent(result.numpy())}", file=sys.stderr)
+  print(f"JIT Result:\n{_indent(jit_result)}", file=sys.stderr)

--- a/python/npcomp/compiler/pytorch/backend/refjit.py
+++ b/python/npcomp/compiler/pytorch/backend/refjit.py
@@ -85,8 +85,5 @@ class CompilerBackend:
     return jit_module
 
   def load(self, jit_module) -> TorchJitModuleInvoker:
-    """Loads a compiled artifact into the runtime.
-
-    Since this is a JIT instead of an AOT compiler, TODO: finish this sentence.
-    """
+    """Loads a compiled artifact into the runtime."""
     return TorchJitModuleInvoker(jit_module)


### PR DESCRIPTION
- Add `test_utils` to dedupe jit comparison code and make testing multiple inputs easier
- Use `refjit.CompilerBackend` to make things a bit more obvious for the clueless.
- Add `TorchJitModuleInvoker` to allow `torch.Tensor`s to be passed to module invocations
- Add `cos_e2e.py` which is "failing" due to #135.

I did a cursory dig through the bindings for `capture_function` but am not familiar enough with C++ debug this on my own.

Adding `torch.cos` because I hit a number of walls trying to add `torch.diag`.