### PR TITLE
 Bump llvm-project to be7352c00d51f4358db3a23ed6a077f7cb48eafd 

### DIFF
--- a/build_tools/cmake_configure.sh
+++ b/build_tools/cmake_configure.sh
@@ -105,6 +105,7 @@ cmake -GNinja \
   "-DNPCOMP_USE_SPLIT_DWARF=ON" \
   "-DCMAKE_CXX_FLAGS_DEBUG=$DEBUG_FLAGS" \
   "-DPYTHON_EXECUTABLE=$python_exe" \
+  "-DPython3_EXECUTABLE=$python_exe" \
   "-DMLIR_DIR=$install_mlir/lib/cmake/mlir" \
   "-DLLVM_EXTERNAL_LIT=$LLVM_LIT" \
   "-DLLVM_ENABLE_WARNINGS=ON" \

--- a/build_tools/install_mlir.sh
+++ b/build_tools/install_mlir.sh
@@ -67,6 +67,7 @@ cmake -GNinja \
   "-B$build_mlir" \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=TRUE \
   "-DPYTHON_EXECUTABLE=$python_exe" \
+  "-DPython3_EXECUTABLE=$python_exe" \
   -DLLVM_BUILD_LLVM_DYLIB=ON \
   -DLLVM_LINK_LLVM_DYLIB=ON \
   -DLLVM_INSTALL_UTILS=ON \

--- a/test/Conversion/TCFToLinalg/basic.mlir
+++ b/test/Conversion/TCFToLinalg/basic.mlir
@@ -8,12 +8,12 @@
 // CHECK:           %[[C1:.*]] = constant 1 : index
 // CHECK:           %[[LHSK:.*]] = dim %[[LHS]], %[[C1]] : tensor<?x?xf32>
 // CHECK:           %[[RHSK:.*]] = dim %[[RHS]], %[[C0]] : tensor<?x?xf32>
-// CHECK:           %[[KEQUAL:.*]] = cmpi "eq", %[[LHSK]], %[[RHSK]] : index
+// CHECK:           %[[KEQUAL:.*]] = cmpi eq, %[[LHSK]], %[[RHSK]] : index
 // CHECK:           %[[WINESS:.*]] = shape.cstr_require %[[KEQUAL]], "mismatching contracting dimension for matmul"
 // CHECK:           %[[RET:.*]] = shape.assuming %[[WINESS]] -> (tensor<?x?xf32>) {
 // CHECK:             %[[LHSROWS:.*]] = dim %[[LHS]], %[[C0]] : tensor<?x?xf32>
 // CHECK:             %[[RHSCOLS:.*]] = dim %[[RHS]], %[[C1]] : tensor<?x?xf32>
-// CHECK:             %[[SHAPE:.*]] = tensor_from_elements %[[LHSROWS]], %[[RHSCOLS]] : tensor<2xindex>
+// CHECK:             %[[SHAPE:.*]] = tensor.from_elements %[[LHSROWS]], %[[RHSCOLS]] : tensor<2xindex>
 // CHECK:             %[[INIT_TENSOR:.*]] = tcp.splatted %[[C0F32]], %[[SHAPE]] : (f32, tensor<2xindex>) -> tensor<?x?xf32>
 // CHECK:             %[[MATMUL:.*]] = linalg.matmul ins(%[[LHS]], %[[RHS]] : tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[INIT_TENSOR]] : tensor<?x?xf32>)  -> tensor<?x?xf32>
 // CHECK:             shape.assuming_yield %[[MATMUL]] : tensor<?x?xf32>
@@ -38,9 +38,9 @@ func @tcf_matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf
 // CHECK:           %[[FILTERCHANNELS:.*]] = dim %[[FILTER]], %[[C1]] : tensor<?x?x?x?xf32>
 // CHECK:           %[[FILTERHEIGHT:.*]] = dim %[[FILTER]], %[[C2]] : tensor<?x?x?x?xf32>
 // CHECK:           %[[FILTERWIDTH:.*]] = dim %[[FILTER]], %[[C3]] : tensor<?x?x?x?xf32>
-// CHECK:           %[[CMPCHANNELS:.*]] = cmpi "eq", %[[CHANNELS]], %[[FILTERCHANNELS]] : index
-// CHECK:           %[[CMPHEIGHT:.*]] = cmpi "uge", %[[HEIGHT]], %[[FILTERHEIGHT]] : index
-// CHECK:           %[[CMPWIDTH:.*]] = cmpi "uge", %[[WIDTH]], %[[FILTERWIDTH]] : index
+// CHECK:           %[[CMPCHANNELS:.*]] = cmpi eq, %[[CHANNELS]], %[[FILTERCHANNELS]] : index
+// CHECK:           %[[CMPHEIGHT:.*]] = cmpi uge, %[[HEIGHT]], %[[FILTERHEIGHT]] : index
+// CHECK:           %[[CMPWIDTH:.*]] = cmpi uge, %[[WIDTH]], %[[FILTERWIDTH]] : index
 // CHECK:           %[[CSTRCHANNELS:.*]] = shape.cstr_require %[[CMPCHANNELS]], "input and filter in-channels must be equal"
 // CHECK:           %[[CSTRHEIGHT:.*]] = shape.cstr_require %[[CMPHEIGHT]], "input height must be greater than or equal to filter KH-dimension"
 // CHECK:           %[[CSTRWIDTH:.*]] = shape.cstr_require %[[CMPWIDTH]], "input width must be greater than or equal to filter KW-dimension"
@@ -60,7 +60,7 @@ func @tcf_matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf
 // CHECK:             %[[WIDTHV0:.*]] = subi %[[WIDTH]], %[[FILTERWIDTHM1]] : index
 // CHECK:             %[[WIDTHV0M1:.*]] = subi %[[WIDTHV0]], %[[C1]] : index
 // CHECK:             %[[OUTWIDTH:.*]] = addi %[[WIDTHV0M1]], %[[C1]] : index
-// CHECK:             %[[SHAPE:.*]] = tensor_from_elements %[[BATCH]], %[[OUTCHANNELS]], %[[OUTHEIGHT]], %[[OUTWIDTH]] : tensor<4xindex>
+// CHECK:             %[[SHAPE:.*]] = tensor.from_elements %[[BATCH]], %[[OUTCHANNELS]], %[[OUTHEIGHT]], %[[OUTWIDTH]] : tensor<4xindex>
 // CHECK:             %[[INIT_TENSOR:.*]] = tcp.splatted %[[C0F32]], %[[SHAPE]] : (f32, tensor<4xindex>) -> tensor<?x?x?x?xf32>
 // CHECK:             %[[CONVNCHW:.*]] = linalg.conv_2d_nchw ins(%[[IN]], %[[FILTER]] : tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) outs(%[[INIT_TENSOR]] : tensor<?x?x?x?xf32>)  -> tensor<?x?x?x?xf32>
 // CHECK:             shape.assuming_yield %[[CONVNCHW]] : tensor<?x?x?x?xf32>

--- a/test/Dialect/Numpy/public_functions_to_tensor.mlir
+++ b/test/Dialect/Numpy/public_functions_to_tensor.mlir
@@ -22,8 +22,7 @@ module @legalConversion {
 // CHECK-LABEL: @nonPublic
 module @nonPublic {
   // CHECK: @f(%arg0: !numpy.ndarray<[3,?]:f32>) -> !numpy.ndarray<[3,?]:f32>
-  func @f(%arg0: !numpy.ndarray<[3,?]:f32>) -> (!numpy.ndarray<[3,?]:f32>)
-      attributes { sym_visibility = "private" } {
+  func private @f(%arg0: !numpy.ndarray<[3,?]:f32>) -> (!numpy.ndarray<[3,?]:f32>) {
     return %arg0 : !numpy.ndarray<[3,?]:f32>
   }
 }
@@ -37,8 +36,7 @@ module @called {
     return %arg0 : !numpy.ndarray<*:f32>
   }
 
-  func @caller(%arg0: !numpy.ndarray<*:f32>) -> !numpy.ndarray<*:f32>
-    attributes { sym_visibility = "private" } {
+  func private @caller(%arg0: !numpy.ndarray<*:f32>) -> !numpy.ndarray<*:f32> {
     %0 = call @f(%arg0) : (!numpy.ndarray<*:f32>) -> !numpy.ndarray<*:f32>
     return %0 : !numpy.ndarray<*:f32>
   }

--- a/test/Python/Compiler/Numpy/primitive_ops_to_std.py
+++ b/test/Python/Compiler/Numpy/primitive_ops_to_std.py
@@ -121,7 +121,7 @@ def float_floordiv(a: float, b: float):
 @import_global
 def to_boolean(x: int):
   # CHECK: %[[ZERO:.*]] = constant 0 : i64
-  # CHECK: %[[BOOL:.*]] = cmpi "ne", %arg0, %[[ZERO]] : i64
+  # CHECK: %[[BOOL:.*]] = cmpi ne, %arg0, %[[ZERO]] : i64
   # CHECK: select %[[BOOL]]
   # Note that the not operator is just used to force a bool conversion.
   return not x
@@ -145,7 +145,7 @@ def to_boolean_float(x: float):
 # CHECK-LABEL: func @int_lt_
 @import_global
 def int_lt_(x: int, y: int):
-  # CHECK: %[[CMP:.*]] = cmpi "slt", %arg0, %arg1 : i64
+  # CHECK: %[[CMP:.*]] = cmpi slt", %arg0, %arg1 : i64
   # CHECK: %{{.*}} = basicpy.bool_cast %[[CMP]] : i1 -> !basicpy.BoolType
   return x < y
 
@@ -153,49 +153,49 @@ def int_lt_(x: int, y: int):
 # CHECK-LABEL: func @int_gt_
 @import_global
 def int_gt_(x: int, y: int):
-  # CHECK: cmpi "sgt"
+  # CHECK: cmpi sgt
   return x > y
 
 
 # CHECK-LABEL: func @int_lte_
 @import_global
 def int_lte_(x: int, y: int):
-  # CHECK: cmpi "sle"
+  # CHECK: cmpi sle
   return x <= y
 
 
 # CHECK-LABEL: func @int_gte_
 @import_global
 def int_gte_(x: int, y: int):
-  # CHECK: cmpi "sge"
+  # CHECK: cmpi sge
   return x >= y
 
 
 # CHECK-LABEL: func @int_eq_
 @import_global
 def int_eq_(x: int, y: int):
-  # CHECK: cmpi "eq"
+  # CHECK: cmpi eq
   return x == y
 
 
 # CHECK-LABEL: func @int_neq_
 @import_global
 def int_neq_(x: int, y: int):
-  # CHECK: cmpi "ne"
+  # CHECK: cmpi ne
   return x != y
 
 
 # CHECK-LABEL: func @int_is_
 @import_global
 def int_is_(x: int, y: int):
-  # CHECK: cmpi "eq"
+  # CHECK: cmpi eq
   return x is y
 
 
 # CHECK-LABEL: func @int_is_not_
 @import_global
 def int_is_not_(x: int, y: int):
-  # CHECK: cmpi "ne"
+  # CHECK: cmpi ne
   return x is not y
 
 


### PR DESCRIPTION
- TensorFromElementsOp -> tensor::FromElementsOp
- `cmpi "eq", ...` -> `cmpi eq, ...`
- syntax change for private func ops