### PR TITLE
Enable building using LLVM_EXTERNAL_PROJECTS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,15 +14,6 @@ if(POLICY CMP0077)
 endif()
 
 #-------------------------------------------------------------------------------
-# Project setup and globals
-#-------------------------------------------------------------------------------
-
-project(npcomp LANGUAGES CXX C)
-set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_STANDARD 14)
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
-
-#-------------------------------------------------------------------------------
 # Options and settings
 #-------------------------------------------------------------------------------
 
@@ -55,38 +46,68 @@ if(MSVC)
     )
 endif()
 
-#-------------------------------------------------------------------------------
-# MLIR/LLVM Configuration
-#-------------------------------------------------------------------------------
+if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
+  # If we are not building as a part of LLVM, build NPCOMP as a standalone
+  # project, using LLVM as an external library.
 
-find_package(MLIR REQUIRED CONFIG)
-message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+  #-------------------------------------------------------------------------------
+  # Project setup and globals
+  #-------------------------------------------------------------------------------
 
-#set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
-set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
+  project(npcomp LANGUAGES CXX C)
+  set(CMAKE_C_STANDARD 11)
+  set(CMAKE_CXX_STANDARD 14)
 
-# Define the default arguments to use with 'lit', and an option for the user to
-# override.
-set(LIT_ARGS_DEFAULT "-sv")
-if (MSVC_IDE OR XCODE)
-  set(LIT_ARGS_DEFAULT "${LIT_ARGS_DEFAULT} --no-progress-bar")
+  #-------------------------------------------------------------------------------
+  # MLIR/LLVM Configuration
+  #-------------------------------------------------------------------------------
+
+  find_package(MLIR REQUIRED CONFIG)
+  message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+  message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+  #set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
+  set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
+
+  # Define the default arguments to use with 'lit', and an option for the user to
+  # override.
+  set(LIT_ARGS_DEFAULT "-sv")
+  if (MSVC_IDE OR XCODE)
+    set(LIT_ARGS_DEFAULT "${LIT_ARGS_DEFAULT} --no-progress-bar")
+  endif()
+  set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" CACHE STRING "Default options for lit")
+
+  list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
+  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+  include(TableGen)
+  include(AddLLVM)
+  include(AddMLIR)
+  include(HandleLLVMOptions)
+
+  set(NPCOMP_BUILT_STANDALONE 1)
+  set(BACKEND_PACKAGE_STRING "LLVM ${LLVM_PACKAGE_VERSION}")
+else()
+  # Otherwise, we are building as a part of LLVM, and we need to set up some
+  # variables and includes.
+
+  set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir/include ) # --src-root
+  set(MLIR_INCLUDE_DIR ${LLVM_MAIN_SRC_DIR}/../mlir/include ) # --includedir
+  set(MLIR_TABLEGEN_OUTPUT_DIR ${CMAKE_BINARY_DIR}/tools/mlir/include)
+  set(MLIR_TABLEGEN_EXE $<TARGET_FILE:mlir-tblgen>)
+  include_directories(SYSTEM ${MLIR_INCLUDE_DIR})
+  include_directories(SYSTEM ${MLIR_TABLEGEN_OUTPUT_DIR})
+
+  set(BACKEND_PACKAGE_STRING "${PACKAGE_STRING}")
 endif()
-set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" CACHE STRING "Default options for lit")
 
-list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
-list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-include(TableGen)
-include(AddLLVM)
-include(AddMLIR)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 include(AddNPCOMP)
-include(HandleLLVMOptions)
 include(NpcompDetectPythonEnv)
 include(ConfigurePyTorch)
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
-include_directories(${PROJECT_SOURCE_DIR}/include)
-include_directories(${PROJECT_BINARY_DIR}/include)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 set(NPCOMP_TABLEGEN_ARGS "")
@@ -172,8 +193,8 @@ set(MLIR_NPCOMP_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(MLIR_NPCOMP_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
 add_custom_target(check-npcomp)
-add_custom_target(check-all)
-add_dependencies(check-all check-npcomp)
+add_custom_target(check-npcomp-all)
+add_dependencies(check-npcomp-all check-npcomp)
 
 add_subdirectory(include/npcomp)
 add_subdirectory(lib)

--- a/frontends/pytorch/test/CMakeLists.txt
+++ b/frontends/pytorch/test/CMakeLists.txt
@@ -29,4 +29,4 @@ add_lit_testsuite(check-frontends-pytorch "Running the frontends-pytorch regress
 set_target_properties(check-frontends-pytorch PROPERTIES FOLDER "Tests")
 
 add_lit_testsuites(TORCH_MLIR ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${TEST_DEPENDS})
-add_dependencies(check-all check-frontends-pytorch)
+add_dependencies(check-npcomp-all check-frontends-pytorch)

--- a/frontends/pytorch/test/lit.cfg.py
+++ b/frontends/pytorch/test/lit.cfg.py
@@ -58,10 +58,11 @@ config.test_exec_root = os.path.join(config.npcomp_obj_root, 'test')
 config.npcomp_tools_dir = os.path.join(config.npcomp_obj_root, 'bin')
 
 # Tweak the PATH to include the tools dir.
+npcomp_python_dir = "python" if config.npcomp_built_standalone else "tools/npcomp/python"
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
 llvm_config.with_environment('PYTHONPATH', [
     os.path.join(config.llvm_obj_root, "python"),
-    os.path.join(config.npcomp_obj_root, "python")],
+    os.path.join(config.npcomp_obj_root, npcomp_python_dir)],
     append_path=True)
 
 

--- a/frontends/pytorch/test/lit.site.cfg.py.in
+++ b/frontends/pytorch/test/lit.site.cfg.py.in
@@ -34,6 +34,7 @@ config.llvm_host_triple = '@LLVM_HOST_TRIPLE@'
 config.host_arch = "@HOST_ARCH@"
 config.npcomp_src_root = "@CMAKE_SOURCE_DIR@"
 config.npcomp_obj_root = "@CMAKE_BINARY_DIR@"
+config.npcomp_built_standalone = bool("@NPCOMP_BUILT_STANDALONE@")
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.
@@ -50,4 +51,4 @@ import lit.llvm
 lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
-lit_config.load_config(config, "@CMAKE_SOURCE_DIR@/frontends/pytorch/test/lit.cfg.py")
+lit_config.load_config(config, "@CMAKE_CURRENT_SOURCE_DIR@/lit.cfg.py")

--- a/include/npcomp/Conversion/CMakeLists.txt
+++ b/include/npcomp/Conversion/CMakeLists.txt
@@ -2,4 +2,4 @@ set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls ${NPCOMP_TABLEGEN_ARGS})
 add_public_tablegen_target(NPCOMPConversionPassIncGen)
 
-add_mlir_doc(Passes -gen-pass-doc ConversionPasses ./)
+add_mlir_doc(Passes -gen-pass-doc NPCOMPConversionPasses ./)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -54,10 +54,11 @@ config.npcomp_runtime_shlib = os.path.join(
     'libNPCOMPCompilerRuntimeShlib' + config.llvm_shlib_ext)
 
 # Tweak the PATH and PYTHONPATH to include the tools dir.
+npcomp_python_dir = "python" if config.npcomp_built_standalone else "tools/npcomp/python"
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
 llvm_config.with_environment('PYTHONPATH', [
     os.path.join(config.llvm_obj_root, "python"),
-    os.path.join(config.npcomp_obj_root, "python")],
+    os.path.join(config.npcomp_obj_root, npcomp_python_dir)],
     append_path=True)
 
 tool_dirs = [

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -30,6 +30,7 @@ config.llvm_host_triple = '@LLVM_HOST_TRIPLE@'
 config.host_arch = "@HOST_ARCH@"
 config.npcomp_src_root = "@CMAKE_SOURCE_DIR@"
 config.npcomp_obj_root = "@CMAKE_BINARY_DIR@"
+config.npcomp_built_standalone = bool("@NPCOMP_BUILT_STANDALONE@")
 
 # Optional features.
 config.npcomp_enable_iree = @NPCOMP_ENABLE_IREE@
@@ -49,4 +50,4 @@ import lit.llvm
 lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
-lit_config.load_config(config, "@CMAKE_SOURCE_DIR@/test/lit.cfg.py")
+lit_config.load_config(config, "@CMAKE_CURRENT_SOURCE_DIR@/lit.cfg.py")


### PR DESCRIPTION
This allows building NPCOMP as an external project of LLVM, similar to
how CIRCT can be built: https://github.com/llvm/circt/pull/227.

The CMake options to use this build style look like this:

```
  -DLLVM_EXTERNAL_PROJECTS=npcomp \
  -DLLVM_EXTERNAL_NPCOMP_SOURCE_DIR=/path/to/mlir-npcomp \
```