### PR TITLE
Object identity

### DIFF
--- a/frontends/pytorch/csrc/builder/ivalue_importer.cpp
+++ b/frontends/pytorch/csrc/builder/ivalue_importer.cpp
@@ -19,22 +19,78 @@
 
 using namespace torch_mlir;
 
+// Hashing functionality for IValue's.
+//
+// What we want here is a strict object identity hash. This is different from
+// what Python usually treats as hashing, which is a deep equality hash. In
+// Python terms, what we want here is a hash of `id(x)` -- unfortunately, IValue
+// is not uniformly heap allocated the way a `PyObject*` is, so special handling
+// is needed. At the time of this writing, there seem to be two different
+// implementations, neither of which is exactly what we want.
+//
+// - c10::IValue::hash static method
+//   - Problem: Doesn't handle certain data types, in particular objects (which
+//   modules are a special case of) and lists/dicts. This makes sense when
+//   reflecting the Python semantics.
+// - c10::WeakIValue::hash method
+//   - Problem: it literally just returns the bits of the "union" as an int.
+//   This seems to read uninitialized bits for the bool variant.
+//
+// We use the `c10::IValue::hash` static method with special cases for data
+// types that need their identity to be handled specially. `c10::IValue::hash`
+// seems to be implemented in a principled way following the Python semantics,
+// which is compatible with the semantics we want (for the subset it doesn't
+// throw an error on).
+namespace {
+struct IValueHasher {
+  size_t operator()(const c10::IValue &ivalue) const {
+    if (ivalue.isObject() || ivalue.isList()) {
+      return std::hash<const void *>()(
+          static_cast<const void *>(ivalue.internalToPointer()));
+    }
+
+    return c10::IValue::hash(ivalue);
+  }
+};
+} // namespace
+
+// TODO: The implementation of isSameIdentity looks vulnerable to malloc reusing
+// the same memory block (if this hash function is used in an online setting,
+// such as when tracing). Can we do better?
+namespace {
+struct IValueEq {
+  bool operator()(const c10::IValue &lhs, const c10::IValue &rhs) const {
+    return lhs.isSameIdentity(rhs);
+  }
+};
+} // namespace
+
 namespace {
 /// Helper class for holding state during recursive IValue import.
 ///
 /// The intended usage pattern of this class is to construct it then call
-/// `importIValue` exactly once. Calling `importIValue` more than once
-/// is likely to produce unexpected results since the same in-memory IValue
-/// can be reimported more than once. That is, subsequent calls to
-/// `importIValue` will not properly unify IValue's with already-imported
-/// IValue's.
+/// `importIValue`.
 ///
-/// TODO: Support unifying repeated IValue's.
-/// This already is an issue when importing a single IValue through the current
-/// API, because the same underlying Tensor (or List/Dict) can be referenced by
-/// multiple properties of a module. There is an extra complication with tensors
-/// because they can alias each other in fairly arbitrary ways, which we will
-/// need to model with slice ops.
+/// The `importIValue` method can be called more than once, and values are
+/// unified *by object identity*. For types isomorphic to Python builtin types
+/// the behavior is what you would expect from `id(x)`.
+///
+/// For tensors, object identity is a little tricky. As background, at::Tensor
+/// basically has 4 parts:
+/// - at::Tensor which is a smart pointer to at::TensorImpl
+/// - at::TensorImpl which holds sizes/strides/etc. and points to at::Storage
+///   - the address of the at::TensorImpl is the identity of the tensor.
+/// - at::Storage which is a smart pointer to at::StorageImpl
+/// - at::StorageImpl which is a low-level buffer
+///   - the address of the at::StorageImpl is the identity of the "storage".
+///
+/// Multiple different tensors can share the same underlying storage. We
+/// currently import tensors by identity and emit errors in the case of tensors
+/// with different identity but sharing the same storage. This is done because
+/// correctly modeling the many ways that tensors can overlap and alias when
+/// they share storage is difficult. Example hard cases are weird
+/// strides/offsets that overlap, and even cases where the data types mismatch
+/// (PyTorch allows this!).
 class IValueImporter {
 public:
   IValueImporter(MlirBlock importBlock, MlirContext context)
@@ -43,12 +99,28 @@ public:
   MlirValue importIValue(c10::IValue value);
 
 private:
+  MlirValue rawImportIValue(c10::IValue value);
   MlirValue importModule(torch::jit::Module jitModule);
   void importMethod(torch::jit::Function *function, MlirBlock nnModuleBody);
 
   MlirBlock importBlock;
   MlirContext context;
   TypeMapper typeMapper;
+
+  // Map tracking already-imported values.
+  std::unordered_map<c10::IValue, MlirValue, IValueHasher, IValueEq> valueMap;
+  // Used to detect potentially aliasing tensors.
+  std::unordered_set<c10::StorageImpl *> seenStorageImpls;
+  // The stack of attribute names we have traversed to reach the current IValue.
+  // Used for diagnostics.
+  std::vector<std::string> attributeNameStack;
+  // The root module encountered during recursive IValue traversal.
+  // Used for diagnostics.
+  // Note that the "top-level" object being imported can in theory be a list
+  // of modules, so this is populated when our recursive traversal enters a
+  // module not enclosed in any other module, and unset after our recursive
+  // traversal exits the module.
+  c10::optional<std::string> rootModuleName;
 };
 } // namespace
 
@@ -63,6 +135,11 @@ MlirValue IValueImporter::importModule(torch::jit::Module currentModule) {
   mlirRegionAppendOwnedBlock(nnModuleRegion, mlirBlockCreate(0, nullptr));
   MlirBlock nnModuleBody = mlirRegionGetFirstBlock(nnModuleRegion);
 
+  if (!rootModuleName.has_value()) {
+    c10::optional<c10::QualifiedName> maybeName = currentModule.type()->name();
+    rootModuleName = maybeName ? maybeName->qualifiedName() : "unnamed module";
+  }
+
   const std::vector<c10::IValue> &slots = currentModule._ivalue()->slots();
   const std::vector<c10::ClassAttribute> &classAttributes =
       currentModule.type()->getAttributes();
@@ -70,6 +147,7 @@ MlirValue IValueImporter::importModule(torch::jit::Module currentModule) {
          "mismatch between object and type!");
   for (int i = 0, e = slots.size(); i < e; i++) {
     const c10::ClassAttribute &classAttribute = classAttributes[i];
+    attributeNameStack.push_back(classAttribute.getName());
     MlirValue slotValue = importIValue(slots[i]);
     // TODO: Is it necessary to track whether an attribute is a "parameter"?
     createMlirOperationAtEnd(
@@ -77,6 +155,11 @@ MlirValue IValueImporter::importModule(torch::jit::Module currentModule) {
         toMlirNamedAttribute(
             "name", mlirStringAttrGet(
                         context, toMlirStringRef(classAttribute.getName()))));
+    attributeNameStack.pop_back();
+  }
+
+  if (rootModuleName.has_value()) {
+    rootModuleName = c10::nullopt;
   }
 
   for (torch::jit::Function *function : currentModule.type()->methods()) {
@@ -90,6 +173,31 @@ MlirValue IValueImporter::importModule(torch::jit::Module currentModule) {
 }
 
 MlirValue IValueImporter::importIValue(c10::IValue ivalue) {
+  auto it = valueMap.find(ivalue);
+  if (it != valueMap.end()) {
+    return it->second;
+  }
+  // Reject potentially aliased tensors.
+  if (ivalue.isTensor()) {
+    c10::StorageImpl *storageImpl =
+        ivalue.toTensor().storage().unsafeGetStorageImpl();
+    if (!seenStorageImpls.insert(storageImpl).second) {
+      std::stringstream msg;
+      msg << "Unhandled tensor that shares storage with another tensor.";
+      if (rootModuleName) {
+        msg << "\nFound at path '<root>."
+            << c10::QualifiedName(attributeNameStack).qualifiedName()
+            << "' from root object '" << *rootModuleName << "'";
+      }
+      throw std::invalid_argument(msg.str());
+    }
+  }
+  MlirValue value = rawImportIValue(ivalue);
+  valueMap[ivalue] = value;
+  return value;
+}
+
+MlirValue IValueImporter::rawImportIValue(c10::IValue ivalue) {
   // TODO: Can we do better?
   MlirLocation loc = mlirLocationUnknownGet(context);
 
@@ -115,6 +223,17 @@ MlirValue IValueImporter::importIValue(c10::IValue ivalue) {
         importBlock, "basicpy.numeric_constant", loc, type,
         toMlirNamedAttribute("value",
                              mlirIntegerAttrGet(type, ivalue.toInt())));
+    return mlirOperationGetResult(operation, 0);
+  }
+  if (ivalue.isList()) {
+    c10::List<c10::IValue> list = ivalue.toList();
+    std::vector<MlirValue> elems;
+    for (const c10::IValue &elem : list) {
+      elems.push_back(importIValue(elem));
+    }
+    MlirOperation operation =
+        createMlirOperationAtEnd(importBlock, "basicpy.build_list", loc,
+                                 npcompListTypeGet(context), elems);
     return mlirOperationGetResult(operation, 0);
   }
   if (ivalue.isTensor()) {

--- a/frontends/pytorch/csrc/builder/mlir_utils.h
+++ b/frontends/pytorch/csrc/builder/mlir_utils.h
@@ -48,7 +48,7 @@ inline void addToMlirOperationState(MlirOperationState &state,
 }
 
 inline void addToMlirOperationState(MlirOperationState &state,
-                                    std::vector<MlirValue> &&values) {
+                                    const std::vector<MlirValue> &values) {
   mlirOperationStateAddOperands(&state, values.size(), values.data());
 }
 
@@ -58,17 +58,18 @@ inline void addToMlirOperationState(MlirOperationState &state,
 }
 
 inline void addToMlirOperationState(MlirOperationState &state,
-                                    std::vector<MlirType> &&resultTypes) {
+                                    const std::vector<MlirType> &resultTypes) {
   mlirOperationStateAddResults(&state, resultTypes.size(), resultTypes.data());
 }
 
-template <typename T, typename... Ts>
-void addToMlirOperationState(MlirOperationState &state, T &&t, Ts &&...ts) {
-  addToMlirOperationState(state, std::forward<T>(t));
-  addToMlirOperationState(state, std::forward<Ts>(ts)...);
-}
-
 inline void addToMlirOperationState(MlirOperationState &state) {}
+
+template <typename T, typename U, typename... Ts>
+void addToMlirOperationState(MlirOperationState &state, T &&t, U &&u,
+                             Ts &&...ts) {
+  addToMlirOperationState(state, std::forward<T>(t));
+  addToMlirOperationState(state, std::forward<U>(u), std::forward<Ts>(ts)...);
+}
 
 template <typename... Ts>
 MlirOperation createMlirOperation(std::string name, MlirLocation loc,

--- a/frontends/pytorch/csrc/builder/op_builder.cpp
+++ b/frontends/pytorch/csrc/builder/op_builder.cpp
@@ -27,6 +27,14 @@ MlirOperation OpBuilder::createBoolConstant(MlirLocation loc, bool value) {
       toMlirNamedAttribute("value", mlirBoolAttrGet(context, value)));
 }
 
+MlirOperation OpBuilder::createBytesConstant(MlirLocation loc,
+                                             const std::string &value) {
+  return createMlirOperation(
+      "basicpy.bytes_constant", loc, npcompBytesTypeGet(context),
+      toMlirNamedAttribute("value",
+                           mlirStringAttrGet(context, toMlirStringRef(value))));
+}
+
 MlirOperation OpBuilder::createStdConstant(MlirLocation loc,
                                            MlirAttribute value) {
   return createMlirOperation("std.constant", loc, mlirAttributeGetType(value),

--- a/frontends/pytorch/csrc/builder/op_builder.h
+++ b/frontends/pytorch/csrc/builder/op_builder.h
@@ -29,6 +29,7 @@ public:
   OpBuilder(MlirContext context);
   MlirOperation createNoneConstant(MlirLocation loc);
   MlirOperation createBoolConstant(MlirLocation loc, bool value);
+  MlirOperation createBytesConstant(MlirLocation loc, const std::string &value);
   MlirOperation createStdConstant(MlirLocation loc, MlirAttribute value);
 
 private:

--- a/frontends/pytorch/test/module_import/object-identity-error-submodule.py
+++ b/frontends/pytorch/test/module_import/object-identity-error-submodule.py
@@ -1,0 +1,33 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See frontends/pytorch/LICENSE for license information.
+
+import typing
+
+import torch
+import torch_mlir
+
+# RUN: not %PYTHON %s 2>&1 | FileCheck %s
+
+mb = torch_mlir.ModuleBuilder()
+
+class Submodule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.t1 = torch.tensor([10., 20.])
+        # Test a nontrivial recursive case of the diagnostic.
+        # CHECK: Unhandled tensor that shares storage with another tensor.
+        # CHECK-NEXT: Found at path '<root>.m.t2' from root object '__torch__.TestModule'
+        self.t2 = self.t1[0]
+
+class TestModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.m = Submodule()
+
+
+test_module = TestModule()
+recursivescriptmodule = torch.jit.script(test_module)
+# TODO: Automatically handle unpacking Python class RecursiveScriptModule into the underlying ScriptModule.
+mb.import_module(recursivescriptmodule._c)
+mb.module.operation.print()

--- a/frontends/pytorch/test/module_import/object-identity-error.py
+++ b/frontends/pytorch/test/module_import/object-identity-error.py
@@ -1,0 +1,27 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See frontends/pytorch/LICENSE for license information.
+
+import typing
+
+import torch
+import torch_mlir
+
+# RUN: not %PYTHON %s 2>&1 | FileCheck %s
+
+mb = torch_mlir.ModuleBuilder()
+
+class TestModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        # CHECK: Unhandled tensor that shares storage with another tensor.
+        # CHECK-NEXT: Found at path '<root>.t2' from root object '__torch__.TestModule'
+        self.t1 = torch.tensor([10., 20.])
+        self.t2 = self.t1[0]
+
+
+test_module = TestModule()
+recursivescriptmodule = torch.jit.script(test_module)
+# TODO: Automatically handle unpacking Python class RecursiveScriptModule into the underlying ScriptModule.
+mb.import_module(recursivescriptmodule._c)
+mb.module.operation.print()

--- a/frontends/pytorch/test/module_import/object-identity-torch-bug.py
+++ b/frontends/pytorch/test/module_import/object-identity-torch-bug.py
@@ -1,0 +1,43 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See frontends/pytorch/LICENSE for license information.
+
+import typing
+
+import torch
+import torch_mlir
+
+# RUN: %PYTHON %s | npcomp-opt | FileCheck %s
+
+mb = torch_mlir.ModuleBuilder()
+
+# TorchScript doesn't model object identity correctly!!!
+#
+# As of February 2021, the way that TorchScript imports modules does not
+# respect object identity. It happens to work for Tensor because a
+# `torch.Tensor` is just a pointer to a TensorImpl under the hood, and so
+# naively duplicating a Tensor retains the identity of the TensorImpl.
+
+class TestModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        # CHECK: %[[L2:.*]] = basicpy.build_list
+        # CHECK: %[[L1:.*]] = basicpy.build_list
+        # CHECK: torch.nn_module {
+        # CHECK:   torch.attr "l2", %[[L2]]
+        # CHECK:   torch.attr "l1", %[[L1]]
+        self.l2 = self.l1 = [1]
+
+    # This can be uncommented when the graph importer supports it.
+    # def forward(self):
+    #     self.l1.append(2)
+    #     self.l2.append(3)
+    #     print('l1', self.l1) # TorchScript prints [1, 2]
+    #     print('l2', self.l2) # TorchScript prints [1, 3] (should be [1, 2, 3])
+
+
+test_module = TestModule()
+recursivescriptmodule = torch.jit.script(test_module)
+# TODO: Automatically handle unpacking Python class RecursiveScriptModule into the underlying ScriptModule.
+mb.import_module(recursivescriptmodule._c)
+mb.module.operation.print()

--- a/frontends/pytorch/test/module_import/object-identity.py
+++ b/frontends/pytorch/test/module_import/object-identity.py
@@ -1,0 +1,28 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See frontends/pytorch/LICENSE for license information.
+
+import typing
+
+import torch
+import torch_mlir
+
+# RUN: %PYTHON %s | npcomp-opt | FileCheck %s
+
+mb = torch_mlir.ModuleBuilder()
+
+class TestModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        # CHECK: %[[A:.*]] = numpy.create_array_from_tensor
+        # CHECK: torch.nn_module {
+        # CHECK:   torch.attr "t1", %[[A]]
+        # CHECK:   torch.attr "t2", %[[A]]
+        self.t1 = self.t2 = torch.tensor([10., 20.])
+
+
+test_module = TestModule()
+recursivescriptmodule = torch.jit.script(test_module)
+# TODO: Automatically handle unpacking Python class RecursiveScriptModule into the underlying ScriptModule.
+mb.import_module(recursivescriptmodule._c)
+mb.module.operation.print()

--- a/frontends/pytorch/test/module_import/prim.py
+++ b/frontends/pytorch/test/module_import/prim.py
@@ -23,9 +23,16 @@ class TestModule(torch.nn.Module):
         # CHECK: %[[T2:.*]] = torch.prim.GetAttr %[[SELF]]["t2"]
         # CHECK: torch.prim.SetAttr %[[SELF]]["t1"] = %[[T2]]
         self.t1 = self.t2
-        # CHECK: torch.prim.CallMethod %arg0["callee"]
-        self.callee()
-    def callee(self):
+        # CHECK: torch.prim.CallMethod %[[SELF]]["callee"] (%{{.*}}, %{{.*}})
+        self.callee(self.t1, self.t2)
+    # CHECK-LABEL:   func{{.*}}TestModule.callee{{.*}}(
+    # CHECK-SAME:         %[[SELF:.*]]: !torch.nn.Module,
+    # CHECK-SAME:         %[[X:.*]]: !numpy.ndarray<*:!numpy.any_dtype>,
+    # CHECK-SAME:         %[[Y:.*]]: !numpy.ndarray<*:!numpy.any_dtype>
+    def callee(self, x, y):
+        # CHECK: %[[BYTES:.*]] = basicpy.bytes_constant "x"
+        # CHECK: torch.prim.Print(%[[BYTES]], %[[X]]) : !basicpy.BytesType, !numpy.ndarray<*:!numpy.any_dtype>
+        print("x", x)
         pass
 
 test_module = TestModule()

--- a/frontends/pytorch/test/module_import/submodules.py
+++ b/frontends/pytorch/test/module_import/submodules.py
@@ -24,17 +24,15 @@ class TestModule(torch.nn.Module):
 
 # CHECK:         %[[T:.*]] = basicpy.bool_constant true
 
-# CHECK:         %[[T1:.*]] = basicpy.bool_constant true
 # CHECK:         %[[N0:.*]] = basicpy.numeric_constant 0 : i64
 # CHECK:         %[[S0:.*]] = torch.nn_module  {
-# CHECK:           torch.attr "training", %[[T1]] : !basicpy.BoolType
+# CHECK:           torch.attr "training", %[[T]] : !basicpy.BoolType
 # CHECK:           torch.attr "n", %[[N0]] : i64
 # CHECK:         }
 
-# CHECK:         %[[T2:.*]] = basicpy.bool_constant true
 # CHECK:         %[[N1:.*]] = basicpy.numeric_constant 1 : i64
 # CHECK:         %[[S1:.*]] = torch.nn_module  {
-# CHECK:           torch.attr "training", %[[T2]] : !basicpy.BoolType
+# CHECK:           torch.attr "training", %[[T]] : !basicpy.BoolType
 # CHECK:           torch.attr "n", %[[N1]] : i64
 # CHECK:         }
 

--- a/include/npcomp-c/Types.h
+++ b/include/npcomp-c/Types.h
@@ -38,6 +38,16 @@ int npcompTypeIsABool(MlirType t);
 MlirType npcompBoolTypeGet(MlirContext context);
 
 /*============================================================================*/
+/* Bytes type.                                                                */
+/*============================================================================*/
+
+/** Checks whether the given type is the Python "bytes" type. */
+int npcompTypeIsABytes(MlirType t);
+
+/** Gets the Python "bytes" type. */
+MlirType npcompBytesTypeGet(MlirContext context);
+
+/*============================================================================*/
 /* Dict type.                                                                 */
 /*============================================================================*/
 

--- a/include/npcomp/Dialect/Torch/IR/TorchOps.td
+++ b/include/npcomp/Dialect/Torch/IR/TorchOps.td
@@ -164,11 +164,26 @@ def Torch_PrimSetAttrOp : Torch_Op<"prim.SetAttr", []> {
 def Torch_PrimCallMethodOp : Torch_Op<"prim.CallMethod", []> {
   let summary = "TorchScript prim::CallMethod op";
 
-  let arguments = (ins StrAttr:$name, Torch_NnModuleType:$receiver);
+  let arguments = (ins
+    StrAttr:$name,
+    Torch_NnModuleType:$receiver,
+    Variadic<AnyTorchType>:$operands
+  );
   let results = (outs AnyTorchType:$result);
 
   let assemblyFormat = [{
-    $receiver `[` $name `]` attr-dict `:` type($result)
+    $receiver `[` $name `]` `(` $operands `)` attr-dict `:` type($operands) `->` type($result)
+  }];
+}
+
+def Torch_PrintOp : Torch_Op<"prim.Print", []> {
+  let summary = "TorchScript prim::Print op";
+
+  let arguments = (ins Variadic<AnyTorchType>:$operands);
+  let results = (outs);
+
+  let assemblyFormat = [{
+    `(` $operands `)` attr-dict `:` type($operands)
   }];
 }
 

--- a/include/npcomp/Dialect/Torch/IR/TorchTypes.td
+++ b/include/npcomp/Dialect/Torch/IR/TorchTypes.td
@@ -112,6 +112,7 @@ def AnyTorchType : AnyTypeOf<[
     AnyTorchTensorType,
     Basicpy_ListType,
     Basicpy_NoneType,
+    Basicpy_BytesType,
     Torch_NnModuleType,
   ], "Any type that is legal to pass to a Torch kernel">;
 

--- a/lib/CAPI/Types.cpp
+++ b/lib/CAPI/Types.cpp
@@ -41,6 +41,18 @@ MlirType npcompBoolTypeGet(MlirContext context) {
 }
 
 /*============================================================================*/
+/* Bytes type.                                                                */
+/*============================================================================*/
+
+int npcompTypeIsABytes(MlirType t) {
+  return unwrap(t).isa<Basicpy::BytesType>();
+}
+
+MlirType npcompBytesTypeGet(MlirContext context) {
+  return wrap(Basicpy::BytesType::get(unwrap(context)));
+}
+
+/*============================================================================*/
 /* Dict type.                                                                 */
 /*============================================================================*/
 

--- a/test/CAPI/ir.c
+++ b/test/CAPI/ir.c
@@ -30,6 +30,13 @@ static int printStandardTypes(MlirContext ctx) {
   mlirTypeDump(boolType);
   fprintf(stderr, "\n");
 
+  // Bytes type.
+  MlirType bytesType = npcompBytesTypeGet(ctx);
+  if (!npcompTypeIsABytes(bytesType))
+    return 1;
+  mlirTypeDump(bytesType);
+  fprintf(stderr, "\n");
+
   // Any dtype.
   MlirType anyDtype = npcompAnyDtypeTypeGet(ctx);
   if (!npcompTypeIsAAnyDtype(anyDtype))
@@ -56,6 +63,7 @@ int main() {
   // clang-format off
   // CHECK-LABEL: @types
   // CHECK: !basicpy.BoolType
+  // CHECK: !basicpy.BytesType
   // CHECK: !numpy.any_dtype
   // CHECK: !numpy.ndarray<[4]:!basicpy.BoolType>
   // CHECK: 0


### PR DESCRIPTION
Handle object identity properly. Adds support for list to help testing non-Tensor cases where object identity matters.

Turns out TorchScript doesn't model it right (`object-identity-torch-bug.py`). If they fix their stuff our code will import it correctly though.

Recommend reviewing commits separately.