### PR TITLE
Extend GlobalizeObjectGraph to handle torch.prim.GetAttr returning NnModuleType

### DIFF
--- a/frontends/pytorch/csrc/builder/ivalue_importer.cpp
+++ b/frontends/pytorch/csrc/builder/ivalue_importer.cpp
@@ -335,7 +335,7 @@ void torch_mlir::importIValue(c10::IValue ivalue, MlirBlock block,
                               MlirContext context) {
   // When debugging module importing, it can be useful to dump as so:
   // if (ivalue.isModule())
-  //   ivalue.toModule().dump(true, true, true);
+  //   ivalue.toModule().dump(true, false, false);
   IValueImporter importer(block, context);
   importer.importIValue(ivalue);
 }

--- a/frontends/pytorch/csrc/builder/node_importer.cpp
+++ b/frontends/pytorch/csrc/builder/node_importer.cpp
@@ -15,6 +15,7 @@
 #include "mlir-c/BuiltinAttributes.h"
 #include "mlir-c/BuiltinTypes.h"
 #include "mlir-c/Diagnostics.h"
+#include "npcomp-c/Types.h"
 
 namespace py = pybind11;
 using namespace torch_mlir;
@@ -110,6 +111,14 @@ void NodeImporter::importPrimNode(Node *node, MlirBlock appendToBlock) {
     MlirOperation operation =
         createMlirOperationAtEnd(appendToBlock, "torch.prim.Print", loc,
                                  lookupMappedValues(node->inputs()));
+    mapResults(node, operation);
+    return;
+  }
+
+  if (kind == c10::prim::TupleConstruct) {
+    MlirOperation operation = createMlirOperationAtEnd(
+        appendToBlock, "basicpy.build_tuple", loc, npcompTupleTypeGet(context),
+        lookupMappedValues(node->inputs()));
     mapResults(node, operation);
     return;
   }

--- a/frontends/pytorch/csrc/builder/torch_to_mlir_utils.cpp
+++ b/frontends/pytorch/csrc/builder/torch_to_mlir_utils.cpp
@@ -132,6 +132,10 @@ MlirType TypeMapper::mapFromTorchType(MlirLocation loc,
     // TODO: Don't lose the element type information.
     return npcompListTypeGet(context);
   }
+  case TypeKind::TupleType: {
+    // TODO: Don't lose the element type information.
+    return npcompTupleTypeGet(context);
+  }
   default: {
     std::stringstream message;
     message << "unable to map Torch type " << *torchType << " to MLIR type";
@@ -244,6 +248,8 @@ MlirAttribute torch_mlir::importAttribute(MlirLocation loc,
                                   node->f(symbol));
   case torch::jit::AttributeKind::s:
     return mlirStringAttrGet(context, toMlirStringRef(node->s(symbol)));
+  case torch::jit::AttributeKind::t:
+    return converTensorToMlirElementsAttr(node->t(symbol), loc);
   default: {
     std::stringstream msg;
     msg << "unhandled: value attribute kind " << toString(kind);

--- a/frontends/pytorch/test/graph_import/tuple.py
+++ b/frontends/pytorch/test/graph_import/tuple.py
@@ -1,0 +1,25 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See frontends/pytorch/LICENSE for license information.
+
+import torch
+import torch_mlir
+
+# RUN: %PYTHON %s | npcomp-opt | FileCheck %s
+
+mb = torch_mlir.ModuleBuilder()
+
+# CHECK-LABEL:   func @f(
+# CHECK-SAME:            %[[T0:.*]]: !numpy.ndarray<*:!numpy.any_dtype>,
+# CHECK-SAME:            %[[T1:.*]]: !numpy.ndarray<*:!numpy.any_dtype>) -> !basicpy.TupleType {
+# CHECK:           %[[RET:.*]] = basicpy.build_tuple %[[T0]], %[[T1]] : (!numpy.ndarray<*:!numpy.any_dtype>, !numpy.ndarray<*:!numpy.any_dtype>) -> !basicpy.TupleType
+# CHECK:           return %[[RET]] : !basicpy.TupleType
+
+@mb.import_function
+@torch.jit.script
+def f(t0, t1):
+  return t0, t1
+
+assert isinstance(f, torch.jit.ScriptFunction)
+mb.module.operation.print()
+print()

--- a/test/Dialect/Torch/globalize-object-graph-error.mlir
+++ b/test/Dialect/Torch/globalize-object-graph-error.mlir
@@ -29,20 +29,6 @@ torch.class_type @parent {
 
 // -----
 
-torch.class_type @c {
-  torch.method "f", @f
-}
-// expected-error @+1 {{func argument at index 1 has uses that were not able to be converted}}
-func private @f(%arg0: !torch.nn.Module<"c">, %arg1: !torch.nn.Module<"c">) {
-  // expected-note @+1 {{see user here}}
-  %0 = basicpy.build_list %arg1 : (!torch.nn.Module<"c">) -> !basicpy.ListType
-  return
-}
-
-torch.nn_module {} : !torch.nn.Module<"c">
-
-// -----
-
 // expected-error @+1 {{reachable by multiple paths from root object: '<root>.m' and '<root>.m2'}}
 torch.class_type @child {
   torch.attr "float" : f64

--- a/test/Dialect/Torch/globalize-object-graph-module-uses-error.mlir
+++ b/test/Dialect/Torch/globalize-object-graph-module-uses-error.mlir
@@ -1,0 +1,13 @@
+// RUN: npcomp-opt -torch-globalize-object-graph -split-input-file -verify-diagnostics %s
+
+torch.class_type @parent {
+  torch.method "module_type_return", @module_type_return
+}
+
+func private @module_type_return(%arg0: !torch.nn.Module<"parent">) {
+  // expected-error @+1 {{unsupported use of a torch.nn.Module. Expected only method calls or attribute get/set}}
+  basicpy.build_list %arg0 : (!torch.nn.Module<"parent">) -> !basicpy.ListType
+  return
+}
+
+torch.nn_module {} : !torch.nn.Module<"parent">

--- a/test/Dialect/Torch/globalize-object-graph-module-uses.mlir
+++ b/test/Dialect/Torch/globalize-object-graph-module-uses.mlir
@@ -1,0 +1,48 @@
+// RUN: npcomp-opt -torch-globalize-object-graph -split-input-file %s | FileCheck %s
+
+torch.class_type @child {
+  torch.attr "float" : f64
+}
+torch.class_type @parent {
+  torch.attr "m" : !torch.nn.Module<"child">
+  torch.method "get_attr_returns_module_type", @get_attr_returns_module_type
+  torch.method "module_type_argument", @module_type_argument
+  torch.method "method_call", @method_call
+}
+
+// CHECK-LABEL:   func @get_attr_returns_module_type() -> f64 {
+func private @get_attr_returns_module_type(%arg0: !torch.nn.Module<"parent">) -> f64 {
+  %0 = torch.prim.GetAttr %arg0["m"] : !torch.nn.Module<"parent"> -> !torch.nn.Module<"child">
+  // CHECK-NEXT: %[[V:.*]] = torch.global_slot.get @m.float : f64
+  %1 = torch.prim.GetAttr %0["float"] : !torch.nn.Module<"child"> -> f64
+  // CHECK-NEXT: torch.global_slot.set @m.float = %[[V]] : f64
+  torch.prim.SetAttr %0["float"] = %1 : !torch.nn.Module<"child">, f64
+  // CHECK-NEXT: return %[[V]] : f64
+  return %1 : f64
+}
+
+// CHECK-LABEL:   func @module_type_argument(
+// CHECK-SAME:                               %[[F:.*]]: f64) -> !basicpy.NoneType {
+func private @module_type_argument(%arg0: !torch.nn.Module<"parent">, %arg1: f64, %arg2: !torch.nn.Module<"parent">) -> !basicpy.NoneType {
+  %0 = basicpy.singleton : !basicpy.NoneType
+  return %0 : !basicpy.NoneType
+}
+
+// CHECK-LABEL:   func @method_call() -> !basicpy.NoneType {
+func private @method_call(%arg0: !torch.nn.Module<"parent">) -> !basicpy.NoneType {
+  // CHECK-NEXT: %[[C:.*]] = constant 4.300000e+01 : f64
+  %c = constant 43.0 : f64
+  // CHECK-NEXT: %[[F:.*]] = call @module_type_argument(%[[C]]) : (f64) -> !basicpy.NoneType
+  %0 = torch.prim.CallMethod %arg0["module_type_argument"] (%arg0, %c, %arg0) : !torch.nn.Module<"parent">, (!torch.nn.Module<"parent">, f64, !torch.nn.Module<"parent">) -> (!basicpy.NoneType)
+  // CHECK-NEXT: return %[[F]] : !basicpy.NoneType
+  return %0 : !basicpy.NoneType
+}
+
+%c42 = constant 42.0 : f64
+%child = torch.nn_module {
+  torch.slot "float", %c42 : f64
+} : !torch.nn.Module<"child">
+
+torch.nn_module {
+  torch.slot "m", %child : !torch.nn.Module<"child">
+} : !torch.nn.Module<"parent">


### PR DESCRIPTION
This happens in practice. With this, we can globalize slots for the
non-trivial classifier layer obtained from
https://github.com/NVIDIA/NeMo/blob/main/tutorials/nlp/Joint_Intent_and_Slot_Classification.ipynb