### PR TITLE
[refbackrt] Update Invoke API to support more than just Tensor's

### DIFF
--- a/include/npcomp/RefBackend/JITHelpers/JITModule.h
+++ b/include/npcomp/RefBackend/JITHelpers/JITModule.h
@@ -40,9 +40,9 @@ public:
   fromCompiledModule(mlir::ModuleOp module,
                      llvm::ArrayRef<llvm::StringRef> sharedLibs);
 
-  llvm::Expected<llvm::SmallVector<refbackrt::Ref<refbackrt::Tensor>, 6>>
+  llvm::Expected<llvm::SmallVector<refbackrt::RuntimeValue, 6>>
   invoke(llvm::StringRef functionName,
-         llvm::ArrayRef<refbackrt::Ref<refbackrt::Tensor>> inputs);
+         llvm::ArrayRef<refbackrt::RuntimeValue> inputs);
 
 private:
   JITModule();

--- a/include/npcomp/RefBackend/JITHelpers/JITModule.h
+++ b/include/npcomp/RefBackend/JITHelpers/JITModule.h
@@ -40,9 +40,9 @@ public:
   fromCompiledModule(mlir::ModuleOp module,
                      llvm::ArrayRef<llvm::StringRef> sharedLibs);
 
-  llvm::Expected<llvm::SmallVector<refbackrt::RuntimeValue, 6>>
+  llvm::Expected<llvm::SmallVector<refbackrt::RtValue, 6>>
   invoke(llvm::StringRef functionName,
-         llvm::ArrayRef<refbackrt::RuntimeValue> inputs);
+         llvm::ArrayRef<refbackrt::RtValue> inputs);
 
 private:
   JITModule();

--- a/include/npcomp/RefBackend/Runtime/UserAPI.h
+++ b/include/npcomp/RefBackend/Runtime/UserAPI.h
@@ -118,9 +118,6 @@ public:
 
 private:
   void releaseResources() {
-    if (ptr == nullptr) {
-      assert(false && "ptr is nullptr");
-    }
     ptr->~T();
     std::free(ptr);
   }

--- a/include/npcomp/RefBackend/Runtime/UserAPI.h
+++ b/include/npcomp/RefBackend/Runtime/UserAPI.h
@@ -24,6 +24,7 @@
 #include "npcomp/RefBackend/Runtime/Support.h"
 #include <atomic>
 #include <cstdlib>
+#include <string>
 
 namespace refbackrt {
 
@@ -31,45 +32,70 @@ struct RtValue;
 
 // Base class for any RefCounted object type
 class RefTarget {
-protected:
-  template <typename T> friend class Ref;
-  mutable std::atomic<size_t> refCount;
+  mutable std::atomic<size_t> refcount;
 
-  constexpr RefTarget() noexcept : refCount(0) {}
+  template <typename T> friend class Ref;
+  friend struct RtValue;
+  inline void incref() const { this->refcount += 1; }
+
+  template <typename T> friend class Ref;
+  friend struct RtValue;
+  inline bool decref() const {
+    if (this->refcount.fetch_sub(1) == 1)
+      return true;
+    return false;
+  }
+
+public:
+  size_t refCount() const { return refcount; }
+
+protected:
+  void setRefCount(uint32_t val) { refcount = val; }
+
+  constexpr RefTarget() noexcept : refcount(0) {}
 };
 
 // Reference-counted handle to a type with a `refCount` member.
+// T is expected to be a RefTarget
 template <typename T> class Ref {
 public:
   Ref() { ptr = nullptr; }
   // Creates a Ref and increments the refcount by 1.
   // rawPtr must be allocated with std::malloc.
   Ref(T *rawPtr) {
-    assert(rawPtr->refCount >= 0 && "expected non-negative refcount to start!");
+    assert(rawPtr->refCount() >= 0 &&
+           "expected non-negative refcount to start!");
     ptr = rawPtr;
-    incref(ptr);
+    ptr->incref();
   }
   Ref(const Ref &other) {
     ptr = other.ptr;
-    incref(ptr);
+    ptr->incref();
   }
   Ref(Ref &&other) { ptr = other.takePtr(); }
   Ref &operator=(const Ref &other) {
     if (&other == this)
       return *this;
-    decref(ptr);
+    if (ptr != nullptr && ptr->decref())
+      releaseResources();
     ptr = other.ptr;
-    incref(ptr);
+    ptr->incref();
     return *this;
   }
   Ref &operator=(Ref &&other) {
     if (&other == this)
       return *this;
-    decref(ptr);
+    if (ptr != nullptr && ptr->decref()) {
+      releaseResources();
+    }
     ptr = other.takePtr();
     return *this;
   }
-  ~Ref() { decref(ptr); }
+  ~Ref() {
+    if (ptr != nullptr && ptr->decref()) {
+      releaseResources();
+    }
+  }
 
   T &operator*() const { return *ptr; }
   T *operator->() const { return ptr; }
@@ -81,25 +107,21 @@ public:
     return ret;
   }
 
-  int debugGetRefCount() { return ptr->refCount; }
+  static Ref reclaimPtr(T *otherPtr) {
+    assert(otherPtr->refCount() >= 1);
+    auto ret = Ref();
+    ret.ptr = otherPtr;
+    return ret;
+  }
+
+  int debugGetRefCount() { return ptr->refCount(); }
 
 private:
-  friend struct RtValue;
-  static void incref(T *ptr) {
-    if (!ptr)
-      return;
-    ptr->refCount += 1;
+  void releaseResources() {
+    ptr->~T();
+    std::free(ptr);
   }
 
-  friend struct RtValue;
-  static void decref(T *ptr) {
-    if (!ptr)
-      return;
-    if (ptr->refCount.fetch_sub(1) == 1) {
-      ptr->~T();
-      std::free(static_cast<void *>(ptr));
-    }
-  }
   T *ptr;
 };
 
@@ -146,6 +168,10 @@ private:
     auto *tail = reinterpret_cast<std::int32_t *>(this + 1);
     return MutableArrayRef<std::int32_t>(tail, rank);
   }
+  // Reference count management.
+  // template <typename T> friend class Ref;
+  // friend struct RtValue;
+  // std::atomic<int> refCount{0};
 
   ElementType elementType;
   // The number of dimensions of this Tensor.
@@ -165,17 +191,12 @@ private:
 // The tag determines the type, and the payload represents the stored
 // contents of an object. If an object is not trivially destructible,
 // then it must be refcounted and must have a refCount.
-#define NPCOMP_FORALL_PRIM_TAGS(_)                                             \
+#define NPCOMP_FORALL_TAGS(_)                                                  \
   _(None)                                                                      \
   _(Bool)                                                                      \
   _(Int)                                                                       \
-  _(Double)
-
-#define NPCOMP_FORALL_REF_TAGS(_) _(Tensor)
-
-#define NPCOMP_FORALL_TAGS(_)                                                  \
-  NPCOMP_FORALL_PRIM_TAGS(_)                                                   \
-  NPCOMP_FORALL_REF_TAGS(_)
+  _(Double)                                                                    \
+  _(Tensor)
 
 struct RtValue final {
 
@@ -208,31 +229,23 @@ struct RtValue final {
 
   // Tensor
   RtValue(Ref<Tensor> tensor) : tag(Tag::Tensor) {
-    payload.asVoidPtr = reinterpret_cast<void *>(tensor.takePtr());
+    payload.asRefTargetPtr = reinterpret_cast<RefTarget *>(tensor.takePtr());
   }
   bool isTensor() const { return Tag::Tensor == tag; }
   Ref<Tensor> toTensor() const {
     assert(isTensor());
-    return Ref<Tensor>(reinterpret_cast<Tensor *>(payload.asVoidPtr));
+    return Ref<Tensor>(reinterpret_cast<Tensor *>(payload.asRefTargetPtr));
   }
 
   // Ref
-  bool isRef() const {
-#define DEFINE_IS_REF(x)                                                       \
-  if (is##x()) {                                                               \
-    return true;                                                               \
-  }
-    NPCOMP_FORALL_REF_TAGS(DEFINE_IS_REF)
-#undef DEFINE_IS_REF
-    return false;
-  }
+  bool isRef() const { return isTensor(); }
 
   // RtValue (downcast)
   const RtValue &toRtValue() const { return *this; }
   RtValue &toRtValue() { return *this; }
 
   // Stringify tag for debugging.
-  StringRef tagKind() const {
+  std::string tagKind() const {
     switch (tag) {
 #define DEFINE_CASE(x)                                                         \
   case Tag::x:                                                                 \
@@ -246,14 +259,7 @@ struct RtValue final {
 
   RtValue(const RtValue &rhs) : RtValue(rhs.payload, rhs.tag) {
     if (isRef()) {
-#define DEFINE_INCREF(x)                                                       \
-  if (is##x()) {                                                               \
-    Ref<x>::incref(static_cast<x *>(payload.asVoidPtr));                       \
-    return;                                                                    \
-  }
-      NPCOMP_FORALL_REF_TAGS(DEFINE_INCREF)
-#undef DEFINE_INCREF
-      assert(false && "Unsupported RtValue type");
+      payload.asRefTargetPtr->incref();
     }
   }
   RtValue(RtValue &&rhs) noexcept : RtValue() { swap(rhs); }
@@ -269,13 +275,11 @@ struct RtValue final {
 
   ~RtValue() {
     if (isRef()) {
-#define DEFINE_DECREF(x)                                                       \
-  if (is##x()) {                                                               \
-    Ref<x>::decref(static_cast<x *>(payload.asVoidPtr));                       \
-    return;                                                                    \
-  }
-      NPCOMP_FORALL_REF_TAGS(DEFINE_DECREF)
-#undef DEFINE_DECREF
+      if (isTensor()) {
+        auto raii = Ref<Tensor>::reclaimPtr(
+            reinterpret_cast<Tensor *>(payload.asRefTargetPtr));
+        return;
+      }
       assert(false && "Unsupported RtValue type");
     }
   }
@@ -299,7 +303,7 @@ private:
     bool asBool;
     int64_t asInt;
     double asDouble;
-    void *asVoidPtr;
+    RefTarget *asRefTargetPtr;
   };
 
   RtValue(Payload pl, Tag tag) : payload(pl), tag(tag) {}

--- a/lib/Backend/RefJIT/PythonModule.cpp
+++ b/lib/Backend/RefJIT/PythonModule.cpp
@@ -22,6 +22,7 @@ using llvm::Twine;
 using refback::JITModule;
 using refbackrt::Ref;
 using refbackrt::Tensor;
+using refbackrt::RuntimeValue;
 
 template <typename T>
 static T checkError(llvm::Expected<T> &&expected, Twine banner = {}) {
@@ -106,18 +107,18 @@ void npcomp::python::defineBackendRefJitModule(py::module &m) {
           [](JITModule &self, std::string functionName,
              std::vector<py::buffer> inputs) {
             // Prepare inputs.
-            llvm::SmallVector<Ref<Tensor>, 4> inputTensors;
-            inputTensors.reserve(inputs.size());
+            llvm::SmallVector<RuntimeValue, 4> inputValues;
+            inputValues.reserve(inputs.size());
             for (py::buffer &inputBuffer : inputs) {
-              inputTensors.push_back(copyBufferToTensor(inputBuffer));
+              inputValues.push_back(copyBufferToTensor(inputBuffer));
             }
 
-            auto outputs = checkError(self.invoke(functionName, inputTensors),
+            auto outputs = checkError(self.invoke(functionName, inputValues),
                                       "error invoking JIT function: ");
             std::vector<py::array> outputArrays;
             outputArrays.reserve(outputs.size());
-            for (Ref<Tensor> &outputTensor : outputs) {
-              outputArrays.push_back(wrapTensorAsArray(outputTensor));
+            for (RuntimeValue &outputTensor : outputs) {
+              outputArrays.push_back(wrapTensorAsArray(outputTensor.toTensor()));
             }
             return outputArrays;
           },

--- a/lib/Backend/RefJIT/PythonModule.cpp
+++ b/lib/Backend/RefJIT/PythonModule.cpp
@@ -22,7 +22,7 @@ using llvm::Twine;
 using refback::JITModule;
 using refbackrt::Ref;
 using refbackrt::Tensor;
-using refbackrt::RuntimeValue;
+using refbackrt::RtValue;
 
 template <typename T>
 static T checkError(llvm::Expected<T> &&expected, Twine banner = {}) {
@@ -107,7 +107,7 @@ void npcomp::python::defineBackendRefJitModule(py::module &m) {
           [](JITModule &self, std::string functionName,
              std::vector<py::buffer> inputs) {
             // Prepare inputs.
-            llvm::SmallVector<RuntimeValue, 4> inputValues;
+            llvm::SmallVector<RtValue, 4> inputValues;
             inputValues.reserve(inputs.size());
             for (py::buffer &inputBuffer : inputs) {
               inputValues.push_back(copyBufferToTensor(inputBuffer));
@@ -117,7 +117,7 @@ void npcomp::python::defineBackendRefJitModule(py::module &m) {
                                       "error invoking JIT function: ");
             std::vector<py::array> outputArrays;
             outputArrays.reserve(outputs.size());
-            for (RuntimeValue &outputTensor : outputs) {
+            for (RtValue &outputTensor : outputs) {
               outputArrays.push_back(wrapTensorAsArray(outputTensor.toTensor()));
             }
             return outputArrays;

--- a/lib/RefBackend/JITHelpers/JITModule.cpp
+++ b/lib/RefBackend/JITHelpers/JITModule.cpp
@@ -73,14 +73,14 @@ static refbackrt::MutableArrayRef<T> toRefbackrt(llvm::MutableArrayRef<T> a) {
   return refbackrt::MutableArrayRef<T>(a.data(), a.size());
 }
 
-llvm::Expected<llvm::SmallVector<refbackrt::Ref<refbackrt::Tensor>, 6>>
+llvm::Expected<llvm::SmallVector<refbackrt::RuntimeValue, 6>>
 JITModule::invoke(llvm::StringRef functionName,
-                  llvm::ArrayRef<refbackrt::Ref<refbackrt::Tensor>> inputs) {
+                  llvm::ArrayRef<refbackrt::RuntimeValue> inputs) {
   refbackrt::FunctionMetadata metadata;
   if (refbackrt::failed(refbackrt::getMetadata(
           descriptor, toRefbackrt(functionName), metadata)))
     return make_string_error("unknown function: " + Twine(functionName));
-  SmallVector<refbackrt::Ref<refbackrt::Tensor>, 6> outputs(
+  SmallVector<refbackrt::RuntimeValue, 6> outputs(
       metadata.numOutputs);
   if (metadata.numInputs != static_cast<std::int32_t>(inputs.size()))
     return make_string_error("invoking '" + Twine(functionName) +

--- a/lib/RefBackend/JITHelpers/JITModule.cpp
+++ b/lib/RefBackend/JITHelpers/JITModule.cpp
@@ -73,14 +73,14 @@ static refbackrt::MutableArrayRef<T> toRefbackrt(llvm::MutableArrayRef<T> a) {
   return refbackrt::MutableArrayRef<T>(a.data(), a.size());
 }
 
-llvm::Expected<llvm::SmallVector<refbackrt::RuntimeValue, 6>>
+llvm::Expected<llvm::SmallVector<refbackrt::RtValue, 6>>
 JITModule::invoke(llvm::StringRef functionName,
-                  llvm::ArrayRef<refbackrt::RuntimeValue> inputs) {
+                  llvm::ArrayRef<refbackrt::RtValue> inputs) {
   refbackrt::FunctionMetadata metadata;
   if (refbackrt::failed(refbackrt::getMetadata(
           descriptor, toRefbackrt(functionName), metadata)))
     return make_string_error("unknown function: " + Twine(functionName));
-  SmallVector<refbackrt::RuntimeValue, 6> outputs(
+  SmallVector<refbackrt::RtValue, 6> outputs(
       metadata.numOutputs);
   if (metadata.numInputs != static_cast<std::int32_t>(inputs.size()))
     return make_string_error("invoking '" + Twine(functionName) +

--- a/lib/RefBackend/Runtime/Runtime.cpp
+++ b/lib/RefBackend/Runtime/Runtime.cpp
@@ -131,7 +131,7 @@ Tensor *Tensor::createRaw(ArrayRef<std::int32_t> extents, ElementType type,
   auto *tensor = static_cast<Tensor *>(
       std::malloc(sizeof(Tensor) + extents.size() * sizeof(std::int32_t)));
 
-  tensor->setRefCount(0);
+  tensor->refCount = 0;
   tensor->elementType = type;
   tensor->rank = extents.size();
   auto byteSize = getElementTypeByteSize(type) * totalElements(extents);

--- a/lib/RefBackend/Runtime/Runtime.cpp
+++ b/lib/RefBackend/Runtime/Runtime.cpp
@@ -131,7 +131,7 @@ Tensor *Tensor::createRaw(ArrayRef<std::int32_t> extents, ElementType type,
   auto *tensor = static_cast<Tensor *>(
       std::malloc(sizeof(Tensor) + extents.size() * sizeof(std::int32_t)));
 
-  tensor->refCount = 0;
+  tensor->setRefCount(0);
   tensor->elementType = type;
   tensor->rank = extents.size();
   auto byteSize = getElementTypeByteSize(type) * totalElements(extents);

--- a/lib/RefBackend/Runtime/Runtime.cpp
+++ b/lib/RefBackend/Runtime/Runtime.cpp
@@ -131,7 +131,7 @@ Tensor *Tensor::createRaw(ArrayRef<std::int32_t> extents, ElementType type,
   auto *tensor = static_cast<Tensor *>(
       std::malloc(sizeof(Tensor) + extents.size() * sizeof(std::int32_t)));
 
-  tensor->refCount.store(0);
+  tensor->setRefCount(0);
   tensor->elementType = type;
   tensor->rank = extents.size();
   auto byteSize = getElementTypeByteSize(type) * totalElements(extents);

--- a/lib/RefBackend/Runtime/Runtime.cpp
+++ b/lib/RefBackend/Runtime/Runtime.cpp
@@ -172,8 +172,8 @@ static FuncDescriptor *getFuncDescriptor(ModuleDescriptor *moduleDescriptor,
 }
 
 void refbackrt::invoke(ModuleDescriptor *moduleDescriptor,
-                       StringRef functionName, ArrayRef<RuntimeValue> inputs,
-                       MutableArrayRef<RuntimeValue> outputs) {
+                       StringRef functionName, ArrayRef<RtValue> inputs,
+                       MutableArrayRef<RtValue> outputs) {
   auto *descriptor = getFuncDescriptor(moduleDescriptor, functionName);
   assert(descriptor && "unknown function name");
   assert(inputs.size() < kMaxArity && "number of inputs exceeds kMaxArity");
@@ -224,7 +224,7 @@ void refbackrt::invoke(ModuleDescriptor *moduleDescriptor,
     Tensor *tensor = convertUnrankedMemrefToRefbackrtTensor(
         outputUnrankedMemrefs[i].rank, outputUnrankedMemrefs[i].descriptor,
         elementType);
-    outputs[i] = RuntimeValue(Ref<Tensor>(tensor));
+    outputs[i] = RtValue(Ref<Tensor>(tensor));
   }
 
   // Now, we just need to free all the UnrankedMemref's that we created.

--- a/lib/RefBackend/Runtime/Runtime.cpp
+++ b/lib/RefBackend/Runtime/Runtime.cpp
@@ -172,8 +172,8 @@ static FuncDescriptor *getFuncDescriptor(ModuleDescriptor *moduleDescriptor,
 }
 
 void refbackrt::invoke(ModuleDescriptor *moduleDescriptor,
-                       StringRef functionName, ArrayRef<Ref<Tensor>> inputs,
-                       MutableArrayRef<Ref<Tensor>> outputs) {
+                       StringRef functionName, ArrayRef<RuntimeValue> inputs,
+                       MutableArrayRef<RuntimeValue> outputs) {
   auto *descriptor = getFuncDescriptor(moduleDescriptor, functionName);
   assert(descriptor && "unknown function name");
   assert(inputs.size() < kMaxArity && "number of inputs exceeds kMaxArity");
@@ -191,7 +191,7 @@ void refbackrt::invoke(ModuleDescriptor *moduleDescriptor,
   // more complex though (and maybe impossible given the current abstractions).
   for (int i = 0, e = inputs.size(); i < e; i++) {
     inputUnrankedMemrefs[i] =
-        convertRefbackrtTensorToUnrankedMemref(inputs[i].get());
+        convertRefbackrtTensorToUnrankedMemref(inputs[i].toTensor().get());
   }
   // Create a type-erased list of "packed inputs" to pass to the
   // LLVM/C ABI wrapper function. Each packedInput pointer corresponds to
@@ -224,7 +224,7 @@ void refbackrt::invoke(ModuleDescriptor *moduleDescriptor,
     Tensor *tensor = convertUnrankedMemrefToRefbackrtTensor(
         outputUnrankedMemrefs[i].rank, outputUnrankedMemrefs[i].descriptor,
         elementType);
-    outputs[i] = Ref<Tensor>(tensor);
+    outputs[i] = RuntimeValue(Ref<Tensor>(tensor));
   }
 
   // Now, we just need to free all the UnrankedMemref's that we created.

--- a/tools/npcomp-run-mlir/npcomp-run-mlir.cpp
+++ b/tools/npcomp-run-mlir/npcomp-run-mlir.cpp
@@ -58,10 +58,10 @@ convertAttrToTensor(Attribute attr) {
   return make_string_error("unhandled argument");
 }
 
-static Expected<SmallVector<refbackrt::RuntimeValue, 6>>
+static Expected<SmallVector<refbackrt::RtValue, 6>>
 createInputs(ArrayRef<StringRef> argValues) {
   MLIRContext context;
-  SmallVector<refbackrt::RuntimeValue, 6> ret;
+  SmallVector<refbackrt::RtValue, 6> ret;
   for (auto argValue : argValues) {
     auto attr = parseAttribute(argValue, &context);
     if (!attr)
@@ -112,10 +112,10 @@ static void printOutput(refbackrt::Tensor &tensor, llvm::raw_ostream &os) {
   attr.print(os);
 }
 
-static void printOutputs(ArrayRef<refbackrt::RuntimeValue> outputs,
+static void printOutputs(ArrayRef<refbackrt::RtValue> outputs,
                          llvm::raw_ostream &os) {
   for (auto output : llvm::enumerate(outputs)) {
-    assert(output.isTensor() && "only tensor outputs are supported.");
+    assert(output.value().isTensor() && "only tensor outputs are supported.");
     os << "output #" << output.index() << ": ";
     printOutput(*output.value().toTensor().get(), os);
     os << "\n";

--- a/tools/npcomp-run-mlir/npcomp-run-mlir.cpp
+++ b/tools/npcomp-run-mlir/npcomp-run-mlir.cpp
@@ -58,14 +58,15 @@ convertAttrToTensor(Attribute attr) {
   return make_string_error("unhandled argument");
 }
 
-static Expected<SmallVector<refbackrt::Ref<refbackrt::Tensor>, 6>>
+static Expected<SmallVector<refbackrt::RuntimeValue, 6>>
 createInputs(ArrayRef<StringRef> argValues) {
   MLIRContext context;
-  SmallVector<refbackrt::Ref<refbackrt::Tensor>, 6> ret;
+  SmallVector<refbackrt::RuntimeValue, 6> ret;
   for (auto argValue : argValues) {
     auto attr = parseAttribute(argValue, &context);
     if (!attr)
       return make_string_error(Twine("could not parse arg value: ") + argValue);
+    // TODO(brycearden): Handle multiple input types
     auto expectedTensor = convertAttrToTensor(attr);
     if (!expectedTensor)
       return expectedTensor.takeError();
@@ -111,11 +112,12 @@ static void printOutput(refbackrt::Tensor &tensor, llvm::raw_ostream &os) {
   attr.print(os);
 }
 
-static void printOutputs(ArrayRef<refbackrt::Ref<refbackrt::Tensor>> outputs,
+static void printOutputs(ArrayRef<refbackrt::RuntimeValue> outputs,
                          llvm::raw_ostream &os) {
   for (auto output : llvm::enumerate(outputs)) {
+    assert(output.isTensor() && "only tensor outputs are supported.");
     os << "output #" << output.index() << ": ";
-    printOutput(*output.value(), os);
+    printOutput(*output.value().toTensor().get(), os);
     os << "\n";
   }
 }


### PR DESCRIPTION
* Adds a new `RuntimeValue` struct at the Runtime abstraction (very similar to `torch::jit::IValue`)
* Adds the boilerplate to support more than just `Tensor`'s (still a TODO, but the api shouldn't need to change for each argument type now)
* Updates all the uses of `invoke` to use the new API.

Recommended review order:
- UserAPI.h for definition of the `RuntimeValue` struct and changes to invoke interface
- npcomp-run-mlir.cpp for changes to how `invoke` is called
- JITModule.h / Runtime.cpp for other updates to using `RuntimeValue` 