### PR TITLE
Get Silero speech-to-text model imported and globalized

### DIFF
--- a/frontends/pytorch/csrc/builder/node_importer.cpp
+++ b/frontends/pytorch/csrc/builder/node_importer.cpp
@@ -273,6 +273,15 @@ void NodeImporter::importPrimNode(Node *node, MlirBlock appendToBlock) {
     return;
   }
 
+  if (kind == c10::prim::dtype) {
+    MlirOperation operation =
+        createMlirOperationAtEnd(appendToBlock, "torch.prim.dtype", loc,
+                                 getMlirTypesFromValues(loc, node->outputs()),
+                                 lookupMappedValues(node->inputs()));
+    mapResults(node, operation);
+    return;
+  }
+
   // Unhandled.
   {
     std::stringstream msg;

--- a/frontends/pytorch/csrc/builder/torch_to_mlir_utils.cpp
+++ b/frontends/pytorch/csrc/builder/torch_to_mlir_utils.cpp
@@ -139,6 +139,9 @@ MlirType TypeMapper::mapFromTorchType(MlirLocation loc,
   case TypeKind::StringType: {
     return npcompBytesTypeGet(context);
   }
+  case TypeKind::DeviceObjType: {
+    return npcompDeviceTypeGet(context);
+  }
   default: {
     std::stringstream message;
     message << "unable to map Torch type '" << *torchType << "' to MLIR type";

--- a/frontends/pytorch/test/ivalue_import/methods-derefine.py
+++ b/frontends/pytorch/test/ivalue_import/methods-derefine.py
@@ -1,0 +1,35 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See frontends/pytorch/LICENSE for license information.
+
+import typing
+
+import torch
+import torch_mlir
+
+# RUN: %PYTHON %s | npcomp-opt | FileCheck %s
+
+mb = torch_mlir.ModuleBuilder()
+
+
+
+class TestModule(torch.nn.Module):
+  def __init__(self):
+    super().__init__()
+
+  # CHECK-LABEL:   func private @__torch__.TestModule.forward(
+  # CHECK-SAME:                                               %[[SELF:.*]]: !torch.nn.Module<"__torch__.TestModule">) -> !torch.optional<i64> {
+  # CHECK:           %[[NONE:.*]] = basicpy.singleton : !basicpy.NoneType
+  # CHECK:           %[[DEREFINED:.*]] = torch.derefine %[[NONE]] : !basicpy.NoneType -> !torch.optional<i64>
+  # CHECK:           %[[RET:.*]] = torch.prim.CallMethod %[[SELF]]["callee"] (%[[DEREFINED]]) : !torch.nn.Module<"__torch__.TestModule">, (!torch.optional<i64>) -> !torch.optional<i64>
+  # CHECK:           return %[[RET]] : !torch.optional<i64>
+  def forward(self):
+    return self.callee(None)
+  def callee(self, o: typing.Optional[int]):
+    return o
+
+test_module = TestModule()
+recursivescriptmodule = torch.jit.script(test_module)
+# TODO: Automatically handle unpacking Python class RecursiveScriptModule into the underlying ScriptModule.
+mb.import_module(recursivescriptmodule._c)
+mb.module.operation.print()

--- a/frontends/pytorch/test/node_import/prim.py
+++ b/frontends/pytorch/test/node_import/prim.py
@@ -93,5 +93,14 @@ def prim_ListUnpack(l: typing.List[int]):
     _, val, _ = l
     return val
 
+# CHECK-LABEL:   func @__torch__.prim_dtype(
+# CHECK-SAME:                               %[[ARG:.*]]: !numpy.ndarray<*:!numpy.any_dtype>) -> i64 {
+# CHECK:           %[[RET:.*]] = torch.prim.dtype %[[ARG]] : !numpy.ndarray<*:!numpy.any_dtype> -> i64
+# CHECK:           return %[[RET]] : i64
+@mb.import_function
+@torch.jit.script
+def prim_dtype(x):
+    return x.dtype
+
 mb.module.operation.print()
 print()

--- a/frontends/pytorch/test/node_import/prim.py
+++ b/frontends/pytorch/test/node_import/prim.py
@@ -45,15 +45,15 @@ def prim_RaiseException():
     raise Exception("Error")
 
 # CHECK-LABEL:   func @__torch__.prim_unchecked_cast(
-# CHECK-SAME:                              %[[VAL_0:.*]]: !torch.optional<i64>) -> i64 {
+# CHECK-SAME:                              %[[ARG:.*]]: !torch.optional<i64>) -> i64 {
 # CHECK:           %[[NONE:.*]] = basicpy.singleton : !basicpy.NoneType
 # CHECK:           %[[C3:.*]] = constant 3 : i64
-# CHECK:           %[[IS_NONE:.*]] = torch.kernel_call "aten::__is__" %[[VAL_0]], %[[NONE]] : (!torch.optional<i64>, !basicpy.NoneType) -> !basicpy.BoolType
+# CHECK:           %[[IS_NONE:.*]] = torch.kernel_call "aten::__is__" %[[ARG]], %[[NONE]] : (!torch.optional<i64>, !basicpy.NoneType) -> !basicpy.BoolType
 # CHECK:           %[[COND:.*]] = basicpy.bool_cast %[[IS_NONE]] : !basicpy.BoolType -> i1
 # CHECK:           %[[RESULT:.*]] = scf.if %[[COND]] -> (i64) {
 # CHECK:             scf.yield %[[C3]] : i64
 # CHECK:           } else {
-# CHECK:             %[[CASTED:.*]] = torch.prim.unchecked_cast %[[VAL_0]] : !torch.optional<i64> -> i64
+# CHECK:             %[[CASTED:.*]] = torch.prim.unchecked_cast %[[ARG]] : !torch.optional<i64> -> i64
 # CHECK:             scf.yield %[[CASTED]] : i64
 # CHECK:           }
 # CHECK:           return %[[RESULT:.*]] : i64
@@ -101,6 +101,15 @@ def prim_ListUnpack(l: typing.List[int]):
 @torch.jit.script
 def prim_dtype(x):
     return x.dtype
+
+# CHECK-LABEL:   func @__torch__.prim_device(
+# CHECK-SAME:                                %[[ARG:.*]]: !numpy.ndarray<*:!numpy.any_dtype>) -> !torch.Device {
+# CHECK:           %[[RET:.*]] = torch.prim.device %[[ARG]] : !numpy.ndarray<*:!numpy.any_dtype> -> !torch.Device
+# CHECK:           return %[[RET]] : !torch.Device
+@mb.import_function
+@torch.jit.script
+def prim_device(x):
+    return x.device
 
 mb.module.operation.print()
 print()

--- a/include/npcomp-c/Types.h
+++ b/include/npcomp-c/Types.h
@@ -137,6 +137,16 @@ int npcompTypeIsAOptional(MlirType t);
 /** Gets the !torch.optional<T> type with subtype T. */
 MlirType npcompOptionalTypeGet(MlirType containedType);
 
+/*============================================================================*/
+/* torch.Device type.                                                         */
+/*============================================================================*/
+
+/** Checks whether the given type is a !torch.Device type */
+int npcompTypeIsADevice(MlirType t);
+
+/** Gets the !torch.Device type. */
+MlirType npcompDeviceTypeGet(MlirContext context);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/npcomp/Dialect/Torch/IR/TorchOps.td
+++ b/include/npcomp/Dialect/Torch/IR/TorchOps.td
@@ -561,4 +561,13 @@ def Torch_PrimdtypeOp : Torch_Op<"prim.dtype", []> {
   }];
 }
 
+def Torch_PrimdeviceOp : Torch_Op<"prim.device", []> {
+  let summary = "TorchScript prim::device op";
+  let arguments = (ins AnyTorchTensorType:$tensor);
+  let results = (outs Torch_DeviceType:$result);
+  let assemblyFormat = [{
+    $tensor attr-dict `:` type($tensor) `->` type($result)
+  }];
+}
+
 #endif // TORCH_OPS

--- a/include/npcomp/Dialect/Torch/IR/TorchOps.td
+++ b/include/npcomp/Dialect/Torch/IR/TorchOps.td
@@ -552,4 +552,13 @@ def Torch_PrimTupleIndexOp : Torch_Op<"prim.TupleIndex", []> {
   }];
 }
 
+def Torch_PrimdtypeOp : Torch_Op<"prim.dtype", []> {
+  let summary = "TorchScript prim::dtype op";
+  let arguments = (ins AnyTorchTensorType:$tensor);
+  let results = (outs AnyTorchNumberType:$result);
+  let assemblyFormat = [{
+    $tensor attr-dict `:` type($tensor) `->` type($result)
+  }];
+}
+
 #endif // TORCH_OPS

--- a/include/npcomp/Dialect/Torch/IR/TorchTypes.td
+++ b/include/npcomp/Dialect/Torch/IR/TorchTypes.td
@@ -79,6 +79,10 @@ def Torch_OptionalType : Torch_Type<"Optional", "optional"> {
   ];
 }
 
+def Torch_DeviceType : Torch_Type<"Device", "Device"> {
+  let summary = "Torch device";
+}
+
 //===----------------------------------------------------------------------===//
 // Type predicates
 //===----------------------------------------------------------------------===//
@@ -178,6 +182,7 @@ def AnyTorchType : AnyTypeOf<[
     Basicpy_BytesType,
     Torch_NnModuleType,
     Torch_OptionalType,
+    Torch_DeviceType,
   ], "Any type that is legal to pass to a Torch kernel">;
 
 #endif // TORCH_TYPES

--- a/lib/CAPI/Types.cpp
+++ b/lib/CAPI/Types.cpp
@@ -174,3 +174,17 @@ int npcompTypeIsAOptional(MlirType t) {
 MlirType npcompOptionalTypeGet(MlirType containedType) {
   return wrap(Torch::OptionalType::get(unwrap(containedType)));
 }
+
+/*============================================================================*/
+/* torch.Device type.                                                         */
+/*============================================================================*/
+
+/** Checks whether the given type is a !torch.Device type */
+int npcompTypeIsADevice(MlirType t) {
+  return unwrap(t).isa<Torch::DeviceType>();
+}
+
+/** Gets the !torch.Device type. */
+MlirType npcompDeviceTypeGet(MlirContext context) {
+  return wrap(Torch::DeviceType::get(unwrap(context)));
+}


### PR DESCRIPTION
Model obtained from here: https://pytorch.org/hub/snakers4_silero-models_stt/

With https://github.com/llvm/mlir-npcomp/pull/184 we also can globalize it. IR: https://gist.github.com/silvasean/8ee109f2289cf721c679d0623a48bfca
The current inliner's cost model results in about 8x bloat, so the IR shown there has lots of missing inlining opportunities. Need to add a better cost model (even just "inline it if it is private and only one call" would probably do a lot of good).

Recommended review order: commit by commit