### PR TITLE
Update .getAttrs to ->getAttrs as it is deprecated.

### DIFF
--- a/lib/Dialect/Basicpy/IR/BasicpyOps.cpp
+++ b/lib/Dialect/Basicpy/IR/BasicpyOps.cpp
@@ -73,9 +73,9 @@ static ParseResult parseNumericConstantOp(OpAsmParser &parser,
 
 static void print(OpAsmPrinter &p, NumericConstantOp op) {
   p << "basicpy.numeric_constant ";
-  p.printOptionalAttrDict(op.getAttrs(), /*elidedAttrs=*/{"value"});
+  p.printOptionalAttrDict(op->getAttrs(), /*elidedAttrs=*/{"value"});
 
-  if (op.getAttrs().size() > 1)
+  if (op->getAttrs().size() > 1)
     p << ' ';
   p << op.value();
 
@@ -169,7 +169,7 @@ static ParseResult parseExecOp(OpAsmParser &parser, OperationState *result) {
 
 static void print(OpAsmPrinter &p, ExecOp op) {
   p << op.getOperationName();
-  p.printOptionalAttrDictWithKeyword(op.getAttrs());
+  p.printOptionalAttrDictWithKeyword(op->getAttrs());
   p.printRegion(op.body());
 }
 
@@ -224,7 +224,7 @@ static ParseResult parseFuncTemplateOp(OpAsmParser &parser,
 static void print(OpAsmPrinter &p, FuncTemplateOp op) {
   p << op.getOperationName() << " ";
   p.printSymbolName(op.getName());
-  p.printOptionalAttrDictWithKeyword(op.getAttrs(),
+  p.printOptionalAttrDictWithKeyword(op->getAttrs(),
                                      {SymbolTable::getSymbolAttrName()});
   p.printRegion(op.body());
 }
@@ -289,7 +289,7 @@ static void print(OpAsmPrinter &p, SlotObjectMakeOp op) {
   p << op.getOperationName() << "(";
   p.printOperands(op.slots());
   p << ")";
-  p.printOptionalAttrDict(op.getAttrs(), {"className"});
+  p.printOptionalAttrDict(op->getAttrs(), {"className"});
 
   // Not really a symbol but satisfies same rules.
   p.printArrowTypeList(op.getOperation()->getResultTypes());
@@ -353,7 +353,7 @@ static void print(OpAsmPrinter &p, SlotObjectGetOp op) {
   p << op.getOperationName() << " ";
   p.printOperand(op.object());
   p << "[" << op.index() << "]";
-  p.printOptionalAttrDict(op.getAttrs(), {"index"});
+  p.printOptionalAttrDict(op->getAttrs(), {"index"});
   p << " : ";
   p.printType(op.object().getType());
 }

--- a/lib/Dialect/Refbackrt/IR/RefbackrtOps.cpp
+++ b/lib/Dialect/Refbackrt/IR/RefbackrtOps.cpp
@@ -22,7 +22,7 @@ using namespace mlir::NPCOMP::refbackrt;
 
 static void printModuleMetadataOp(OpAsmPrinter &p, ModuleMetadataOp &op) {
   p << "refbackrt.module_metadata";
-  p.printOptionalAttrDictWithKeyword(op.getAttrs());
+  p.printOptionalAttrDictWithKeyword(op->getAttrs());
   p.printRegion(op.metadatas(), /*printEntryBlockArgs=*/false,
                 /*printBlockTerminators=*/false);
 }

--- a/lib/RefBackend/Runtime/Runtime.cpp
+++ b/lib/RefBackend/Runtime/Runtime.cpp
@@ -8,6 +8,8 @@
 
 #include "npcomp/RefBackend/Runtime/UserAPI.h"
 
+#include "llvm/Support/ErrorHandling.h"
+
 #include <array>
 #include <cassert>
 #include <cstdint>
@@ -119,6 +121,7 @@ std::int32_t refbackrt::getElementTypeByteSize(ElementType type) {
   case ElementType::F32:
     return 4;
   }
+  llvm_unreachable("unsupported dtype");
 }
 
 Ref<Tensor> Tensor::create(ArrayRef<std::int32_t> extents, ElementType type,

--- a/tools/npcomp-run-mlir/npcomp-run-mlir.cpp
+++ b/tools/npcomp-run-mlir/npcomp-run-mlir.cpp
@@ -80,6 +80,7 @@ static Type convertToMLIRType(refbackrt::ElementType type, Builder &builder) {
   case refbackrt::ElementType::F32:
     return builder.getF32Type();
   }
+  llvm_unreachable("unsupported dtype");
 }
 
 static RankedTensorType getCorrespondingMLIRTensorType(refbackrt::Tensor &tensor,
@@ -103,6 +104,7 @@ static Attribute convertToMLIRAttribute(refbackrt::Tensor &tensor,
     return DenseFPElementsAttr::get(type, values);
   }
   }
+  llvm_unreachable("unsupported dtype");
 }
 
 static void printOutput(refbackrt::Tensor &tensor, llvm::raw_ostream &os) {


### PR DESCRIPTION
Motivated by https://github.com/llvm/circt/pull/749/commits/4bdd468179423cb860ee62294f3e90877261c797