### PR TITLE
Add support for "trailing_" and "out" variants of various ops.

### DIFF
--- a/frontends/pytorch/examples/div_inplace_e2e.py
+++ b/frontends/pytorch/examples/div_inplace_e2e.py
@@ -1,0 +1,32 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See frontends/pytorch/LICENSE for license information.
+
+import torch
+import torch_mlir
+
+import npcomp
+from npcomp.compiler.pytorch.backend import refjit
+from npcomp.compiler.utils import logging
+
+import test_utils
+
+logging.enable()
+
+torch.manual_seed(0)
+
+arg0 = torch.ones(2, 2)
+arg1 = torch.ones(2, 2)
+
+def fun(a, b):
+  return a.div_(b)
+
+mb = torch_mlir.ModuleBuilder()
+with mb.capture_function("test", [arg0, arg1]) as f:
+  f.returns([fun(arg0, arg1)])
+
+backend = refjit.CompilerBackend()
+jit_module = backend.load(backend.compile(mb.module))
+
+test_utils.compare_outputs(torch.mm, jit_module.test, arg0, arg1)
+test_utils.compare_outputs(torch.mm, jit_module.test, arg0 + 1, arg1 + 1)

--- a/frontends/pytorch/examples/tanh_out_e2e.py
+++ b/frontends/pytorch/examples/tanh_out_e2e.py
@@ -1,0 +1,33 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See frontends/pytorch/LICENSE for license information.
+
+import torch
+import torch_mlir
+
+import npcomp
+from npcomp.compiler.pytorch.backend import refjit
+from npcomp.compiler.utils import logging
+
+import test_utils
+
+logging.enable()
+
+torch.manual_seed(0)
+
+arg0 = torch.ones(2, 2)
+
+def fun(a):
+  z = torch.zeros(2, 2)
+  torch.tanh(a, out=z)
+  return z
+
+mb = torch_mlir.ModuleBuilder()
+with mb.capture_function("test", [arg0]) as f:
+  f.returns([fun(arg0)])
+
+backend = refjit.CompilerBackend()
+jit_module = backend.load(backend.compile(mb.module))
+
+test_utils.compare_outputs(torch.mm, jit_module.test, arg0, arg1)
+test_utils.compare_outputs(torch.mm, jit_module.test, arg0 + 1, arg1 + 1)

--- a/include/npcomp/Dialect/ATen/IR/GeneratedATenOps.cpp.inc
+++ b/include/npcomp/Dialect/ATen/IR/GeneratedATenOps.cpp.inc
@@ -29,6 +29,7 @@ const Torch::BuildKernelMetadata &AddOp::getTorchBuildKernelMetadata() {
     Torch::BuildKernelMetadata m;
     m.kernelName = "aten::add";
     m.promoteTrailingOutTensor = true;
+    m.inplaceVariantKernelName = "aten::add_";
     m.addArgTypes({"Tensor", "Tensor", "Scalar"});
     m.addArgConversions({KVC::kImmutableTensor, KVC::kImmutableTensor|KVC::kPromoteScalar, KVC::kNone});
     m.addReturnTypes({"Tensor"});
@@ -48,6 +49,7 @@ const Torch::BuildKernelMetadata &Atan2Op::getTorchBuildKernelMetadata() {
     Torch::BuildKernelMetadata m;
     m.kernelName = "aten::atan2";
     m.promoteTrailingOutTensor = true;
+    m.inplaceVariantKernelName = "aten::atan2_";
     m.addArgTypes({"Tensor", "Tensor"});
     m.addArgConversions({KVC::kImmutableTensor, KVC::kImmutableTensor|KVC::kPromoteScalar});
     m.addReturnTypes({"Tensor"});
@@ -67,6 +69,7 @@ const Torch::BuildKernelMetadata &DivOp::getTorchBuildKernelMetadata() {
     Torch::BuildKernelMetadata m;
     m.kernelName = "aten::div";
     m.promoteTrailingOutTensor = true;
+    m.inplaceVariantKernelName = "aten::div_";
     m.addArgTypes({"Tensor", "Tensor"});
     m.addArgConversions({KVC::kImmutableTensor, KVC::kImmutableTensor|KVC::kPromoteScalar});
     m.addReturnTypes({"Tensor"});
@@ -86,6 +89,7 @@ const Torch::BuildKernelMetadata &FloorDivideOp::getTorchBuildKernelMetadata() {
     Torch::BuildKernelMetadata m;
     m.kernelName = "aten::floor_divide";
     m.promoteTrailingOutTensor = true;
+    m.inplaceVariantKernelName = "aten::floor_divide_";
     m.addArgTypes({"Tensor", "Tensor"});
     m.addArgConversions({KVC::kImmutableTensor, KVC::kImmutableTensor|KVC::kPromoteScalar});
     m.addReturnTypes({"Tensor"});
@@ -105,6 +109,7 @@ const Torch::BuildKernelMetadata &MulOp::getTorchBuildKernelMetadata() {
     Torch::BuildKernelMetadata m;
     m.kernelName = "aten::mul";
     m.promoteTrailingOutTensor = true;
+    m.inplaceVariantKernelName = "aten::mul_";
     m.addArgTypes({"Tensor", "Tensor"});
     m.addArgConversions({KVC::kImmutableTensor, KVC::kImmutableTensor|KVC::kPromoteScalar});
     m.addReturnTypes({"Tensor"});
@@ -124,6 +129,7 @@ const Torch::BuildKernelMetadata &RemainderOp::getTorchBuildKernelMetadata() {
     Torch::BuildKernelMetadata m;
     m.kernelName = "aten::remainder";
     m.promoteTrailingOutTensor = true;
+    m.inplaceVariantKernelName = "aten::remainder_";
     m.addArgTypes({"Tensor", "Tensor"});
     m.addArgConversions({KVC::kImmutableTensor, KVC::kImmutableTensor|KVC::kPromoteScalar});
     m.addReturnTypes({"Tensor"});
@@ -143,6 +149,7 @@ const Torch::BuildKernelMetadata &TrueDivideOp::getTorchBuildKernelMetadata() {
     Torch::BuildKernelMetadata m;
     m.kernelName = "aten::true_divide";
     m.promoteTrailingOutTensor = true;
+    m.inplaceVariantKernelName = "aten::true_divide_";
     m.addArgTypes({"Tensor", "Tensor"});
     m.addArgConversions({KVC::kImmutableTensor, KVC::kImmutableTensor|KVC::kPromoteScalar});
     m.addReturnTypes({"Tensor"});
@@ -162,6 +169,7 @@ const Torch::BuildKernelMetadata &MaximumOp::getTorchBuildKernelMetadata() {
     Torch::BuildKernelMetadata m;
     m.kernelName = "aten::maximum";
     m.promoteTrailingOutTensor = true;
+    m.inplaceVariantKernelName = "aten::maximum_";
     m.addArgTypes({"Tensor", "Tensor"});
     m.addArgConversions({KVC::kImmutableTensor, KVC::kImmutableTensor|KVC::kPromoteScalar});
     m.addReturnTypes({"Tensor"});
@@ -181,6 +189,7 @@ const Torch::BuildKernelMetadata &MinimumOp::getTorchBuildKernelMetadata() {
     Torch::BuildKernelMetadata m;
     m.kernelName = "aten::minimum";
     m.promoteTrailingOutTensor = true;
+    m.inplaceVariantKernelName = "aten::minimum_";
     m.addArgTypes({"Tensor", "Tensor"});
     m.addArgConversions({KVC::kImmutableTensor, KVC::kImmutableTensor|KVC::kPromoteScalar});
     m.addReturnTypes({"Tensor"});

--- a/include/npcomp/Dialect/Numpy/IR/NumpyOps.td
+++ b/include/npcomp/Dialect/Numpy/IR/NumpyOps.td
@@ -79,6 +79,30 @@ def Numpy_CopyToTensorOp : Numpy_Op<"copy_to_tensor", [
   let hasCanonicalizer = 1;
 }
 
+def Numpy_OverwriteArrayOp : Numpy_Op<"overwrite_array", []> {
+  let summary = "Ovewrite the contents of array with a tensor.";
+  let description = [{
+    Replaces the contents of `array` with corresponding values from `tensor`.
+
+    Immediately after this op has completed, indexing `array` will result
+    in identical values as indexing into `tensor`. Of course, later ops
+    might mutate `array`, so this relationship need not hold for the entire
+    program.
+
+    This op has undefined behavior if the tensor and array have different
+    shapes or dtypes.
+  }];
+  let arguments = (ins
+    Numpy_AnyTensor:$tensor,
+    Numpy_NdArrayType:$array
+  );
+  let results = (outs
+  );
+  let assemblyFormat = [{
+    $tensor `overwrites` $array attr-dict `:` type($tensor) `,` type($array)
+  }];
+}
+
 //----------------------------------------------------------------------------//
 // Universal function ops (ufunc)
 // See: https://docs.scipy.org/doc/numpy/reference/ufuncs.html

--- a/include/npcomp/Dialect/Torch/IR/OpInterfaces.h
+++ b/include/npcomp/Dialect/Torch/IR/OpInterfaces.h
@@ -80,6 +80,11 @@ struct BuildKernelMetadata : public KernelMetadata {
   /// all be handled with this flag.
   bool promoteTrailingOutTensor = false;
 
+  /// Many ops have variant that treats the first (self) argument as an out
+  /// param (usually denoted with a trailing `_`, such as `aten::div_`).
+  /// When this string is set, it indicates the name of such a variant op.
+  Optional<StringRef> inplaceVariantKernelName = None;
+
   SmallVector<KernelValueConversion::BitMask, 4> argConversions;
   SmallVector<KernelValueConversion::BitMask, 4> returnConversions;
 

--- a/python/npcomp/compiler/pytorch/backend/refjit.py
+++ b/python/npcomp/compiler/pytorch/backend/refjit.py
@@ -61,13 +61,15 @@ class CompilerBackend:
       for IREE, it is a serialized VM flatbuffer) but the contract is that
       it is operated on by methods on this class.
     """
-    # TODO: Once transitioned to new Python API, don't reparse the module.
-    with Context() as context:
+    with imported_module.context as context:
       if self._debug:
         logging.debug("Initial PyTorch IR:\n{}", imported_module)
 
       # Frontend.
-      pm = PassManager.parse(",".join(TORCH_TO_TCF_PASSES))
+      pipeline_str = ",".join(TORCH_TO_TCF_PASSES)
+      if self._debug:
+        logging.debug("Running Torch->TCF pipeline '{}'", pipeline_str)
+      pm = PassManager.parse(pipeline_str)
       pm.run(imported_module)
       if self._debug:
         logging.debug("TCF IR:\n{}", imported_module)

--- a/test/Dialect/Numpy/ops.mlir
+++ b/test/Dialect/Numpy/ops.mlir
@@ -6,3 +6,14 @@ func @builtin_ufunc(%arg0 : tensor<3xf64>, %arg1 : tensor<3xf64>) -> tensor<3xf6
   %0 = numpy.builtin_ufunc_call<"numpy.add"> (%arg0, %arg1) : (tensor<3xf64>, tensor<3xf64>) -> tensor<3xf64>
   return %0 : tensor<3xf64>
 }
+
+// CHECK-LABEL: @ndarray_tensor_bridging
+func @ndarray_tensor_bridging(%arg0: !numpy.ndarray<[2,3]:f32>, %arg1: !numpy.ndarray<[2,3]:f32>, %arg2: tensor<2x3xf32>) {
+  // CHECK-NEXT: numpy.copy_to_tensor
+  %t = numpy.copy_to_tensor %arg1 : (!numpy.ndarray<[2,3]:f32>) -> tensor<2x3xf32>
+  // CHECK-NEXT: numpy.create_array_from_tensor
+  %a = numpy.create_array_from_tensor %arg2 : (tensor<2x3xf32>) -> !numpy.ndarray<[2,3]:f32>
+  // CHECK-NEXT: numpy.overwrite_array
+  numpy.overwrite_array %arg2 overwrites %arg0 : tensor<2x3xf32>, !numpy.ndarray<[2,3]:f32>
+  return
+}


### PR DESCRIPTION
We already had the `promoteTrailingOutTensor` flag, but weren't using
it. A inplaceVariantKernelName flag needed to be added.

This change is a little dissatisfying, as the conversions done by the
RecognizeKernelsPass are currently non-orthogonal. In particular,
`kDropResultAndAliasArg0` probably won't work as intended if mixed with
these (we probably need to promote kDropResultAndAliasArg0 to not be an
arg-level thing anyway, as we have done with promoteTrailingOutTensor).

This involved adding a new op `numpy.overwrite_array`.

```
numpy.overwrite_array %arg2 overwrites %arg0 : tensor<2x3xf32>, !numpy.ndarray<[2,3]:f32>
```

This models the destructive update behavior. Note that in the above op,
we cannot simply RAUW %arg0 with a suitably conveted %arg2 (for example,
%arg0 might have uses that are not dominated by %arg2, or might have an
alias relation with some other array in the program). In general, we
need a pass analogous to "SSA-formation" which knows how to see through
these to uncover an underlying tensor program.

Also, add tanh_out_e2e.py/div_inplace_e2e.py and fix some bitrot in
refjit.py which is my running example I'm trying to get working.