### PR TITLE
Add ability to compile from object graph ir.

### DIFF
--- a/lib/CAPI/Registration.cpp
+++ b/lib/CAPI/Registration.cpp
@@ -25,6 +25,7 @@ void npcompRegisterAllPasses() {
   ::mlir::NPCOMP::registerAllPasses();
 
   // Upstream passes we depend on.
+  ::mlir::registerSymbolDCEPass();
   ::mlir::registerCanonicalizerPass();
   ::mlir::registerSCFToStandardPass();
 }


### PR DESCRIPTION
Simple rejiggering of the python code to layer `"object graph" -> "acap-like" -> "tcf" -> ...`

Tested/developed locally on my e2e spike (unary tanh).