### PR TITLE
Progress on e2e lowering

### DIFF
--- a/include/npcomp/Dialect/Numpy/IR/NumpyOps.h
+++ b/include/npcomp/Dialect/Numpy/IR/NumpyOps.h
@@ -15,6 +15,7 @@
 #include "mlir/IR/FunctionSupport.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/CastInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "npcomp/Typing/Analysis/CPA/Interfaces.h"
 

--- a/include/npcomp/Dialect/Numpy/IR/NumpyOps.td
+++ b/include/npcomp/Dialect/Numpy/IR/NumpyOps.td
@@ -12,6 +12,7 @@
 include "npcomp/Dialect/Numpy/IR/NumpyDialect.td"
 include "npcomp/Typing/Analysis/CPA/Interfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/CastInterfaces.td"
 include "mlir/IR/SymbolInterfaces.td"
 
 //----------------------------------------------------------------------------//
@@ -32,6 +33,25 @@ def Numpy_NarrowOp : Numpy_Op<"narrow", []> {
   );
   let assemblyFormat = [{
     $operand attr-dict `:` functional-type($operand, $result)
+  }];
+}
+
+def Numpy_StaticInfoCastOp : Numpy_Op<"static_info_cast", [
+    DeclareOpInterfaceMethods<CastOpInterface>,
+    NoSideEffect]> {
+  let summary = "Adds/removes static information from an array type.";
+  let description = [{
+    This op does not imply any runtime code. Semantically it is an identity
+    function.
+  }];
+  let arguments = (ins
+    Numpy_AnyArray:$operand
+  );
+  let results = (outs
+    Numpy_AnyArray:$result
+  );
+  let assemblyFormat = [{
+    $operand attr-dict `:` type($operand) `to` type($result)
   }];
 }
 

--- a/include/npcomp/Dialect/Numpy/IR/NumpyOps.td
+++ b/include/npcomp/Dialect/Numpy/IR/NumpyOps.td
@@ -53,6 +53,33 @@ def Numpy_StaticInfoCastOp : Numpy_Op<"static_info_cast", [
   let assemblyFormat = [{
     $operand attr-dict `:` type($operand) `to` type($result)
   }];
+  let hasCanonicalizer = 1;
+}
+
+def Numpy_TensorStaticInfoCastOp : Numpy_Op<"tensor_static_info_cast", [
+    DeclareOpInterfaceMethods<CastOpInterface>,
+    NoSideEffect]> {
+  let summary = "Adds/removes static information from a tensor type.";
+  let description = [{
+    This op does not imply any runtime code. Semantically it is an identity
+    function.
+
+    Unlike `tensor.cast`, this op allows changing dtype, following the
+    rules of numpy arrays where no runtime code is implied. In particular,
+    `!numpy.any_dtype` is compatible with all other element types, but otherwise
+    the element types must be the same. An element type of `!numpy.any_dtype`
+    represents the absence of static knowledge of the dtype. It does not
+    itself represent a concrete runtime element type.
+  }];
+  let arguments = (ins
+    Numpy_AnyTensor:$operand
+  );
+  let results = (outs
+    Numpy_AnyTensor:$result
+  );
+  let assemblyFormat = [{
+    $operand attr-dict `:` type($operand) `to` type($result)
+  }];
 }
 
 //----------------------------------------------------------------------------//

--- a/include/npcomp/Dialect/Numpy/Transforms/Passes.h
+++ b/include/npcomp/Dialect/Numpy/Transforms/Passes.h
@@ -18,6 +18,7 @@ namespace NPCOMP {
 namespace Numpy {
 
 std::unique_ptr<OperationPass<ModuleOp>> createPublicFunctionsToTensorPass();
+std::unique_ptr<OperationPass<FuncOp>> createArrayToTensorPass();
 
 } // namespace Numpy
 

--- a/include/npcomp/Dialect/Numpy/Transforms/Passes.td
+++ b/include/npcomp/Dialect/Numpy/Transforms/Passes.td
@@ -20,4 +20,22 @@ def NumpyPublicFunctionsToTensor : Pass<"numpy-public-functions-to-tensor", "Mod
   let constructor = "mlir::NPCOMP::Numpy::createPublicFunctionsToTensorPass()";
 }
 
+def NumpyArrayToTensor : Pass<"numpy-array-to-tensor", "FuncOp"> {
+  let summary = "Replace arrays with tensors where possible (optimization only).";
+  let description = [{
+    This pass is analogous to an SSA-formation pass in a
+    traditional compiler, with the added complication that arrays can alias
+    each other in interesting ways.
+
+    The current code doesn't implement any fancy algorithm, and is intended
+    to be just sufficient for a first e2e spike. An algorithm inspired by the
+    SSA formation literature will need to be implemented.
+
+    Also, this pass doesn't currently handle interprocedural rewriting
+    (of private functions), which is even more complex.
+  }];
+  let constructor = "mlir::NPCOMP::Numpy::createArrayToTensorPass()";
+}
+
+
 #endif // NPCOMP_NUMPY_PASSES

--- a/include/npcomp/Dialect/Torch/Transforms/Passes.h
+++ b/include/npcomp/Dialect/Torch/Transforms/Passes.h
@@ -26,6 +26,8 @@ createPrepareForGlobalizeObjectGraphPass();
 /// See the documentation on torch-globalize-object-graph for more details.
 void createGlobalizePipeline(OpPassManager &pm);
 
+std::unique_ptr<OperationPass<ModuleOp>> createAdjustCallingConventionsPass();
+
 } // namespace Torch
 
 /// Registers all Torch transformation passes.

--- a/include/npcomp/Dialect/Torch/Transforms/Passes.td
+++ b/include/npcomp/Dialect/Torch/Transforms/Passes.td
@@ -101,4 +101,28 @@ def PrepareForGlobalizeObjectGraph
   }];
 }
 
+def AdjustCallingConventions
+  : Pass<"torch-adjust-calling-conventions", "ModuleOp"> {
+  let summary = "Adjust the calling conventions of functions";
+  let constructor = "mlir::NPCOMP::Torch::createAdjustCallingConventionsPass()";
+  let description = [{
+    Adjusts the calling conventions of functions in the module, with the aim of
+    preparing them for backends and further lowering passes. As this changes
+    the module calling convention, it should be considered a legalization
+    step towards reaching IR that is suitable for an appropriate backend.
+    All transformations are context-free and suitable for documenting
+    at the user level if needed to clarify the eventual calling convention
+    of compiled artifacts.
+    This is not an optimization.
+
+    The transformations performed are:
+    - `torch.type_bound` annotations are incorporated into the type of the
+      function arguments, which should be `!numpy.ndarray<...>`'s.
+    - Python-isms are rewritten to MLIR-isms
+      - NoneType return is rewritten to the absence of a return value.
+      - (Not implemented yet) Tuple return is rewritten to multiple return
+        values
+  }];
+}
+
 #endif // NPCOMP_TORCH_PASSES

--- a/lib/Dialect/Numpy/Transforms/ArrayToTensor.cpp
+++ b/lib/Dialect/Numpy/Transforms/ArrayToTensor.cpp
@@ -1,0 +1,43 @@
+//===- ArrayToTensor.cpp -----------------------------------------*- C++-*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "npcomp/Dialect/Numpy/IR/NumpyDialect.h"
+#include "npcomp/Dialect/Numpy/IR/NumpyOps.h"
+#include "npcomp/Dialect/Numpy/Transforms/Passes.h"
+
+using namespace mlir;
+using namespace mlir::NPCOMP;
+using namespace mlir::NPCOMP::Numpy;
+
+namespace {
+
+class ArrayToTensorPass : public NumpyArrayToTensorBase<ArrayToTensorPass> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    auto func = getOperation();
+
+    RewritePatternSet patterns(context);
+    CopyToTensorOp::getCanonicalizationPatterns(patterns, context);
+    StaticInfoCastOp::getCanonicalizationPatterns(patterns, context);
+    (void)applyPatternsAndFoldGreedily(func, std::move(patterns));
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<FuncOp>>
+mlir::NPCOMP::Numpy::createArrayToTensorPass() {
+  return std::make_unique<ArrayToTensorPass>();
+}

--- a/lib/Dialect/Numpy/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Numpy/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_npcomp_conversion_library(NPCOMPNumpyPasses
+  ArrayToTensor.cpp
   Passes.cpp
   PublicFunctionToTensor.cpp
 

--- a/lib/Dialect/Torch/Transforms/AdjustCallingConventions.cpp
+++ b/lib/Dialect/Torch/Transforms/AdjustCallingConventions.cpp
@@ -1,0 +1,250 @@
+//===- AdjustCallingConventions.cpp ------------------------*- C++-*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "npcomp/Dialect/Basicpy/IR/BasicpyDialect.h"
+#include "npcomp/Dialect/Basicpy/IR/BasicpyOps.h"
+#include "npcomp/Dialect/Numpy/IR/NumpyDialect.h"
+#include "npcomp/Dialect/Numpy/IR/NumpyOps.h"
+#include "npcomp/Dialect/Torch/IR/TorchDialect.h"
+#include "npcomp/Dialect/Torch/IR/TorchOps.h"
+#include "npcomp/Dialect/Torch/Transforms/Passes.h"
+
+using namespace mlir;
+using namespace mlir::NPCOMP;
+using namespace mlir::NPCOMP::Torch;
+
+// Map from func name and arg index to the type bound for that arg.
+// This is needed because to rewrite calls, we need the non-local information
+// from the func definition.
+// We also benefit from populating this all at once, which avoids ordering
+// issues between rewriting of func ops vs call ops.
+using TypeBoundMap = DenseMap<std::pair<StringRef, int>, Type> ;
+
+namespace {
+class AdjustCallingConventionForFunc : public OpConversionPattern<FuncOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(FuncOp func, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    MLIRContext *context = func.getContext();
+    auto typeBoundIdent = Identifier::get("torch.type_bound", context);
+    TypeConverter::SignatureConversion conversion(func.getNumArguments());
+
+    // The TypeConverter hooks for type conversion are "context free", so we
+    // cannot use the usual helpers here for populating SignatureConversion and
+    // new result types.
+    //
+    // The incoporation of the torch.type_bound arg attr is context-dependent.
+
+    for (auto type : llvm::enumerate(func.getArgumentTypes())) {
+      if (auto ndarray = type.value().dyn_cast<Numpy::NdArrayType>()) {
+        auto typeBoundAttr =
+            func.getArgAttrOfType<TypeAttr>(type.index(), typeBoundIdent);
+        conversion.addInputs(type.index(), typeBoundAttr
+                                               ? typeBoundAttr.getValue()
+                                               : type.value());
+        continue;
+        // type is attached to ndarray type.
+        // TODO: check if more specific?
+      } else if (auto none = type.value().dyn_cast<Basicpy::NoneType>()) {
+        continue;
+      }
+      // TODO: add tuple type.
+      conversion.addInputs(type.index(), type.value());
+    }
+    SmallVector<Type> newResultTypes;
+    for (auto type : func.getType().getResults()) {
+      if (auto none = type.dyn_cast<Basicpy::NoneType>()) {
+        continue;
+      }
+      newResultTypes.push_back(type);
+    }
+    rewriter.applySignatureConversion(&func.getBody(), conversion,
+                                      typeConverter);
+    rewriter.updateRootInPlace(func, [&] {
+      func.setType(FunctionType::get(
+          getContext(), conversion.getConvertedTypes(), newResultTypes));
+      // Clear out the type bounds, now that the type incorporates them.
+      for (int i = 0, e = func.getNumArguments(); i != e; i++)
+        func.removeArgAttr(i, typeBoundIdent);
+    });
+    return success();
+  }
+};
+} // namespace
+
+namespace {
+class AdjustCallingConventionForCall : public OpConversionPattern<CallOp> {
+public:
+  AdjustCallingConventionForCall(TypeConverter &converter, MLIRContext *context,
+                                 TypeBoundMap &typeBoundMap)
+      : OpConversionPattern<CallOp>(converter, context),
+        typeBoundMap(typeBoundMap) {}
+  LogicalResult
+  matchAndRewrite(CallOp call, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> convertedResults;
+    if (failed(typeConverter->convertTypes(call.getResultTypes(),
+                                           convertedResults)))
+      return failure();
+
+    SmallVector<Value> newOperands;
+    for (auto operand : llvm::enumerate(operands)) {
+      if (operand.value().getType().isa<Basicpy::NoneType>())
+        continue;
+      auto it = typeBoundMap.find({call.callee(), operand.index()});
+      if (it != typeBoundMap.end()) {
+        newOperands.push_back(rewriter.create<Numpy::StaticInfoCastOp>(
+            call.getLoc(), it->second, operand.value()));
+        continue;
+      }
+      newOperands.push_back(operand.value());
+    }
+
+    CallOp newCall = rewriter.create<CallOp>(call.getLoc(), call.callee(),
+                                             convertedResults, newOperands);
+    int newOpResultIdx = 0;
+    SmallVector<Value> newResults;
+    for (auto type : call.getResultTypes()) {
+      if (type.isa<Basicpy::NoneType>()) {
+        newResults.push_back(
+            rewriter.create<Basicpy::SingletonOp>(call.getLoc(), type));
+        continue;
+      }
+      newResults.push_back(newCall.getResult(newOpResultIdx++));
+    }
+    rewriter.replaceOp(call, newResults);
+    return success();
+  }
+
+  private:
+    TypeBoundMap &typeBoundMap;
+};
+} // namespace
+
+namespace {
+class AdjustCallingConventionForReturn : public OpConversionPattern<ReturnOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(ReturnOp op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    SmallVector<Value> newOperands;
+    for (auto operand : llvm::enumerate(operands)) {
+      if (!operand.value())
+        continue;
+      if (operand.value().getType().isa<Basicpy::NoneType>())
+        continue;
+      newOperands.push_back(operand.value());
+    }
+    rewriter.replaceOpWithNewOp<ReturnOp>(op, newOperands);
+    return success();
+  }
+};
+} // namespace
+
+static LogicalResult adjustCallingConventions(FuncOp func,
+                                              TypeBoundMap &typeBoundMap) {
+  MLIRContext *context = func.getContext();
+  RewritePatternSet patterns(context);
+  // TODO: TupleTypes
+  TypeConverter typeConverter;
+  typeConverter.addConversion([](Type type) { return type; });
+  typeConverter.addConversion(
+      [](Basicpy::NoneType type,
+         SmallVectorImpl<Type> &types) -> Optional<LogicalResult> {
+        return success();
+      });
+
+  typeConverter.addArgumentMaterialization(
+      [](OpBuilder &builder, Numpy::NdArrayType type, ValueRange inputs,
+         Location loc) -> Value {
+        assert(inputs.size() == 1);
+        assert(inputs[0].getType().isa<Numpy::NdArrayType>());
+        return builder.create<Numpy::StaticInfoCastOp>(loc, type, inputs[0]);
+      });
+  patterns.add<AdjustCallingConventionForFunc>(typeConverter, context);
+  patterns.add<AdjustCallingConventionForCall>(typeConverter, context,
+                                               typeBoundMap);
+  patterns.add<AdjustCallingConventionForReturn>(typeConverter, context);
+
+  ConversionTarget target(*context);
+  target.addDynamicallyLegalOp<FuncOp>([](FuncOp func) {
+    for (int i = 0, e = func.getNumArguments(); i != e; i++) {
+      if (func.getArgAttr(i, "torch.type_bound"))
+        return false;
+      if (func.getArgumentTypes()[i].isa<Basicpy::NoneType>())
+        return false;
+    }
+    for (int i = 0, e = func.getNumResults(); i != e; i++) {
+      if (func.getType().getResults()[i].isa<Basicpy::NoneType>())
+        return false;
+    }
+    return true;
+  });
+  // The dynamic legality conditions for call and return are a pain to write...
+  // Just run the patterns once and call it a day.
+  //
+  // Bug for doing this better https://bugs.llvm.org/show_bug.cgi?id=49812
+  DenseSet<Operation *> opsInOriginalProgram;
+  func.walk([&](CallOp op) { opsInOriginalProgram.insert(op.getOperation()); });
+  func.walk(
+      [&](ReturnOp op) { opsInOriginalProgram.insert(op.getOperation()); });
+  target.addDynamicallyLegalOp<CallOp>([&](CallOp op) {
+    return !opsInOriginalProgram.contains(op.getOperation());
+  });
+  target.addDynamicallyLegalOp<ReturnOp>([&](ReturnOp op) {
+    return !opsInOriginalProgram.contains(op.getOperation());
+  });
+  target.addLegalOp<Numpy::StaticInfoCastOp>();
+  target.addLegalOp<Basicpy::SingletonOp>();
+  // We don't know how to rewrite it, so mark it as illegal.
+  target.addIllegalOp<CallIndirectOp>();
+  if (failed(applyPartialConversion(func.getOperation(), target,
+                                    std::move(patterns))))
+    return failure();
+  return success();
+}
+
+namespace {
+class AdjustCallingConventionsPass
+    : public AdjustCallingConventionsBase<AdjustCallingConventionsPass> {
+  void runOnOperation() override {
+    auto module = getOperation();
+    TypeBoundMap typeBoundMap;
+    for (auto func : module.getOps<FuncOp>()) {
+      for (int i = 0, e = func.getNumArguments(); i != e; i++) {
+        auto typeBoundAttr =
+            func.getArgAttrOfType<TypeAttr>(i, "torch.type_bound");
+        if (!typeBoundAttr)
+          continue;
+        typeBoundMap[{func.getName(), i}] = typeBoundAttr.getValue();
+      }
+    }
+    for (auto func : module.getOps<FuncOp>()) {
+      if (failed(adjustCallingConventions(func, typeBoundMap)))
+        return signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::NPCOMP::Torch::createAdjustCallingConventionsPass() {
+  return std::make_unique<AdjustCallingConventionsPass>();
+}

--- a/lib/Dialect/Torch/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Torch/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_npcomp_conversion_library(NPCOMPTorchPasses
+  AdjustCallingConventions.cpp
   Passes.cpp
   GlobalizeObjectGraph.cpp
   PrepareForGlobalizeObjectGraph.cpp

--- a/lib/Dialect/Torch/Transforms/GlobalizeObjectGraph.cpp
+++ b/lib/Dialect/Torch/Transforms/GlobalizeObjectGraph.cpp
@@ -625,7 +625,7 @@ static LogicalResult globalizeObjectGraph(ModuleOp module) {
     liveFuncs.insert(kv.second);
   }
   for (auto &op : llvm::make_early_inc_range(module.getOps())) {
-    if (isa<GlobalSlotOp, ModuleTerminatorOp>(&op))
+    if (isa<GlobalSlotOp>(&op))
       continue;
     if (auto func = dyn_cast<FuncOp>(op)) {
       if (liveFuncs.contains(func))

--- a/lib/RefBackend/LowerToLLVM.cpp
+++ b/lib/RefBackend/LowerToLLVM.cpp
@@ -699,7 +699,7 @@ class LowerToLLVM : public LowerToLLVMBase<LowerToLLVM> {
     RewritePatternSet patterns(context);
     LLVMConversionTarget target(*context);
     populateCompilerRuntimePatterns(module, patterns, converter);
-    target.addLegalOp<ModuleOp, ModuleTerminatorOp>();
+    target.addLegalOp<ModuleOp>();
     populateStdToLLVMConversionPatterns(converter, patterns);
     patterns.add<LowerModuleMetadata>(context);
 

--- a/python/npcomp/compiler/numpy/frontend.py
+++ b/python/npcomp/compiler/numpy/frontend.py
@@ -90,7 +90,7 @@ class ImportFrontend:
                                      context=ic.context)
 
     ic.set_file_line_col(filename, ast_fd.lineno, ast_fd.col_offset)
-    ic.insert_before_terminator(ic.module.body)
+    ic.insert_end_of_block(ic.module.body)
     ir_f, entry_block = ic.FuncOp(ast_fd.name,
                                   ir_f_type,
                                   create_entry_block=True)

--- a/python/npcomp/compiler/pytorch/backend/refjit.py
+++ b/python/npcomp/compiler/pytorch/backend/refjit.py
@@ -27,6 +27,7 @@ OBJECT_GRAPH_LOWERING_PASSES = (
     # bothersome because we don't currently have a lowering for them.
     # TODO: Support global slots in backends.
     "symbol-dce",
+    "torch-adjust-calling-conventions",
 )
 
 TORCH_TO_TCF_PASSES = (

--- a/python/npcomp/tracing/mlir_trace.py
+++ b/python/npcomp/tracing/mlir_trace.py
@@ -170,7 +170,7 @@ class FunctionTracer(TraceContext):
         for ap in self._args_array_params
     ]
     f_types = [_ir.Type.parse(self._result_array_params.mlir_tensor_type_asm)]
-    ic.insert_before_terminator(ic.module.body)
+    ic.insert_end_of_block(ic.module.body)
     f_type = _ir.FunctionType.get(f_args, f_types)
     f, _ = ic.FuncOp(epf.__name__, f_type, create_entry_block=True)
     return f, f_types

--- a/test/Dialect/Numpy/array-to-tensor.mlir
+++ b/test/Dialect/Numpy/array-to-tensor.mlir
@@ -1,0 +1,24 @@
+// RUN: npcomp-opt -split-input-file %s -numpy-array-to-tensor | FileCheck --dump-input=fail %s
+
+// Basic case that can be resolved with local reasoning.
+// This pass will eventually need to learn about aliasing relationships.
+//
+// This is taken from a test case from an e2e spike, and isn't intended to be
+// particularly minimal or specifically test one thing, since the pass is
+// currently just a handful of canonicalization patterns that are already
+// tested elsewhere.
+
+// CHECK-LABEL:   func @local(
+// CHECK-SAME:                  %[[ARG:.*]]: tensor<2x3x?xf32>) -> tensor<*x!numpy.any_dtype> {
+// CHECK:           %[[ERASED:.*]] = numpy.tensor_static_info_cast %[[ARG]] : tensor<2x3x?xf32> to tensor<*x!numpy.any_dtype>
+// CHECK:           %[[RET:.*]] = "aten.tanh"(%[[ERASED]]) : (tensor<*x!numpy.any_dtype>) -> tensor<*x!numpy.any_dtype>
+// CHECK:           return %[[RET]] : tensor<*x!numpy.any_dtype>
+func @local(%arg0: tensor<2x3x?xf32>) -> tensor<*x!numpy.any_dtype> {
+  %0 = numpy.create_array_from_tensor %arg0 : (tensor<2x3x?xf32>) -> !numpy.ndarray<[2,3,?]:f32>
+  %1 = numpy.static_info_cast %0 : !numpy.ndarray<[2,3,?]:f32> to !numpy.ndarray<*:!numpy.any_dtype>
+  %2 = numpy.copy_to_tensor %1 : (!numpy.ndarray<*:!numpy.any_dtype>) -> tensor<*x!numpy.any_dtype>
+  %3 = "aten.tanh"(%2) : (tensor<*x!numpy.any_dtype>) -> tensor<*x!numpy.any_dtype>
+  %4 = numpy.create_array_from_tensor %3 : (tensor<*x!numpy.any_dtype>) -> !numpy.ndarray<*:!numpy.any_dtype>
+  %5 = numpy.copy_to_tensor %4 : (!numpy.ndarray<*:!numpy.any_dtype>) -> tensor<*x!numpy.any_dtype>
+  return %5 : tensor<*x!numpy.any_dtype>
+}

--- a/test/Dialect/Numpy/canonicalizers.mlir
+++ b/test/Dialect/Numpy/canonicalizers.mlir
@@ -25,3 +25,14 @@ func @elideCreateRedundantArrayFromTensorNonTrivial() -> (tensor<2xf64>, tensor<
   %2 = numpy.copy_to_tensor %0 : (!numpy.ndarray<[2]:f64>) -> tensor<2xf64>
   return %1, %2 : tensor<2xf64>, tensor<2xf64>
 }
+
+// CHECK-LABEL:   func @commuteStaticInfoCastOpWithCreateArrayFromTensorOp(
+// CHECK-SAME:                                                             %[[TENSOR:.*]]: tensor<2x3x?xf32>) -> !numpy.ndarray<*:!numpy.any_dtype> {
+// CHECK:           %[[ERASED_TENSOR:.*]] = numpy.tensor_static_info_cast %[[TENSOR]] : tensor<2x3x?xf32> to tensor<*x!numpy.any_dtype>
+// CHECK:           %[[ERASED_ARRAY:.*]] = numpy.create_array_from_tensor %[[ERASED_TENSOR]] : (tensor<*x!numpy.any_dtype>) -> !numpy.ndarray<*:!numpy.any_dtype>
+// CHECK:           return %[[ERASED_ARRAY]] : !numpy.ndarray<*:!numpy.any_dtype>
+func @commuteStaticInfoCastOpWithCreateArrayFromTensorOp(%arg0: tensor<2x3x?xf32>) -> !numpy.ndarray<*:!numpy.any_dtype> {
+  %0 = numpy.create_array_from_tensor %arg0 : (tensor<2x3x?xf32>) -> !numpy.ndarray<[2,3,?]:f32>
+  %1 = numpy.static_info_cast %0 : !numpy.ndarray<[2,3,?]:f32> to !numpy.ndarray<*:!numpy.any_dtype>
+  return %1 : !numpy.ndarray<*:!numpy.any_dtype>
+}

--- a/test/Dialect/Numpy/ops.mlir
+++ b/test/Dialect/Numpy/ops.mlir
@@ -28,3 +28,14 @@ func @static_info_cast(%arg0: !numpy.ndarray<[2,3]:f32>, %arg1: !numpy.ndarray<[
   %2 = numpy.static_info_cast %arg2 : !numpy.ndarray<*:f32> to !numpy.ndarray<[?,?]:f32>
   return
 }
+
+// CHECK-LABEL: @tensor_static_info_cast
+func @tensor_static_info_cast(%arg0: tensor<2x3xf32>, %arg1: tensor<?x3xf32>, %arg2: tensor<*xf32>) {
+  // CHECK-NEXT: numpy.tensor_static_info_cast %arg0 : tensor<2x3xf32> to tensor<*x!numpy.any_dtype>
+  %0 = numpy.tensor_static_info_cast %arg0 : tensor<2x3xf32> to tensor<*x!numpy.any_dtype>
+  // CHECK-NEXT: numpy.tensor_static_info_cast %arg1 : tensor<?x3xf32> to tensor<7x3xf32>
+  %1 = numpy.tensor_static_info_cast %arg1 : tensor<?x3xf32> to tensor<7x3xf32>
+  // CHECK-NEXT: numpy.tensor_static_info_cast %arg2 : tensor<*xf32> to tensor<?x?xf32>
+  %2 = numpy.tensor_static_info_cast %arg2 : tensor<*xf32> to tensor<?x?xf32>
+  return
+}

--- a/test/Dialect/Numpy/ops.mlir
+++ b/test/Dialect/Numpy/ops.mlir
@@ -17,3 +17,14 @@ func @ndarray_tensor_bridging(%arg0: !numpy.ndarray<[2,3]:f32>, %arg1: !numpy.nd
   numpy.overwrite_array %arg2 overwrites %arg0 : tensor<2x3xf32>, !numpy.ndarray<[2,3]:f32>
   return
 }
+
+// CHECK-LABEL: @static_info_cast
+func @static_info_cast(%arg0: !numpy.ndarray<[2,3]:f32>, %arg1: !numpy.ndarray<[?,3]:f32>, %arg2: !numpy.ndarray<*:f32>) {
+  // CHECK-NEXT: numpy.static_info_cast %arg0 : !numpy.ndarray<[2,3]:f32> to !numpy.ndarray<*:!numpy.any_dtype>
+  %0 = numpy.static_info_cast %arg0 : !numpy.ndarray<[2,3]:f32> to !numpy.ndarray<*:!numpy.any_dtype>
+  // CHECK-NEXT: numpy.static_info_cast %arg1 : !numpy.ndarray<[?,3]:f32> to !numpy.ndarray<[7,3]:f32>
+  %1 = numpy.static_info_cast %arg1 : !numpy.ndarray<[?,3]:f32> to !numpy.ndarray<[7,3]:f32>
+  // CHECK-NEXT: numpy.static_info_cast %arg2 : !numpy.ndarray<*:f32> to !numpy.ndarray<[?,?]:f32>
+  %2 = numpy.static_info_cast %arg2 : !numpy.ndarray<*:f32> to !numpy.ndarray<[?,?]:f32>
+  return
+}

--- a/test/Dialect/Torch/adjust-calling-conventions.mlir
+++ b/test/Dialect/Torch/adjust-calling-conventions.mlir
@@ -1,0 +1,46 @@
+// RUN: npcomp-opt -torch-adjust-calling-conventions -allow-unregistered-dialect -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL:   func @basic(
+// CHECK-SAME:                %[[ARG:.*]]: !numpy.ndarray<[2,3,?]:f32>) -> !numpy.ndarray<*:!numpy.any_dtype> {
+// CHECK:           %[[RET:.*]] = numpy.static_info_cast %[[ARG]] : !numpy.ndarray<[2,3,?]:f32> to !numpy.ndarray<*:!numpy.any_dtype>
+// CHECK:           return %[[RET]] : !numpy.ndarray<*:!numpy.any_dtype>
+func @basic(%arg0: !numpy.ndarray<*:!numpy.any_dtype> {torch.type_bound = !numpy.ndarray<[2,3,?]:f32>}) -> !numpy.ndarray<*:!numpy.any_dtype> {
+  return %arg0 : !numpy.ndarray<*:!numpy.any_dtype>
+}
+
+// CHECK-LABEL:   func @no_type_bound(
+// CHECK-SAME:                        %[[ARG:.*]]: !numpy.ndarray<*:!numpy.any_dtype>) -> !numpy.ndarray<*:!numpy.any_dtype> {
+// CHECK:           return %[[ARG]] : !numpy.ndarray<*:!numpy.any_dtype>
+func @no_type_bound(%arg0: !numpy.ndarray<*:!numpy.any_dtype>) -> !numpy.ndarray<*:!numpy.any_dtype> {
+  return %arg0 : !numpy.ndarray<*:!numpy.any_dtype>
+}
+
+// CHECK-LABEL:   func @call(
+// CHECK-SAME:               %[[ARG:.*]]: !numpy.ndarray<[2,3,?]:f32>) -> !numpy.ndarray<*:!numpy.any_dtype> {
+// CHECK:           %[[SHAPE_ERASED:.*]] = numpy.static_info_cast %[[ARG]] : !numpy.ndarray<[2,3,?]:f32> to !numpy.ndarray<*:!numpy.any_dtype>
+// CHECK:           %[[SHAPED:.*]] = numpy.static_info_cast %[[SHAPE_ERASED]] : !numpy.ndarray<*:!numpy.any_dtype> to !numpy.ndarray<[2,3,?]:f32>
+// CHECK:           %[[RES:.*]] = call @call(%[[SHAPED]]) : (!numpy.ndarray<[2,3,?]:f32>) -> !numpy.ndarray<*:!numpy.any_dtype>
+// CHECK:           return %[[SHAPE_ERASED]] : !numpy.ndarray<*:!numpy.any_dtype>
+func @call(%arg0: !numpy.ndarray<*:!numpy.any_dtype> {torch.type_bound = !numpy.ndarray<[2,3,?]:f32>}) -> !numpy.ndarray<*:!numpy.any_dtype> {
+  %0 = call @call(%arg0) : (!numpy.ndarray<*:!numpy.any_dtype>) -> !numpy.ndarray<*:!numpy.any_dtype>
+  return %arg0 : !numpy.ndarray<*:!numpy.any_dtype>
+}
+
+// CHECK-LABEL:   func @none_return() {
+// CHECK:           %[[NONE:.*]] = basicpy.singleton : !basicpy.NoneType
+// CHECK:           return
+func @none_return() -> !basicpy.NoneType {
+  %1 = basicpy.singleton : !basicpy.NoneType
+  return %1 : !basicpy.NoneType
+}
+
+// CHECK-LABEL:   func @none_call_return() {
+// CHECK:           call @none_return() : () -> ()
+// CHECK:           %[[NONE:.*]] = basicpy.singleton : !basicpy.NoneType
+// CHECK:           "test.use"(%[[NONE]]) : (!basicpy.NoneType) -> ()
+// CHECK:           return
+func @none_call_return() {
+  %0 = call @none_return() : () -> !basicpy.NoneType
+  "test.use"(%0) : (!basicpy.NoneType) -> ()
+  return
+}


### PR DESCRIPTION
Recommended review order: commit by commit.

Two main changes:
- pass that adjusts calling conventions to incorporate torch.type_bound (and eliminate dummy NoneType returns + tuples eventually)
- primitive ArrayToTensor pass

Next steps are to write shape/dtype refinement stuff and then we can run on refbackend (immediately after will pull in IREE an run e2e with that).