### PR TITLE
MILESTONE: TorchScript unary tanh runs on RefBackend

### DIFF
--- a/frontends/pytorch/examples/test_utils.py
+++ b/frontends/pytorch/examples/test_utils.py
@@ -15,15 +15,16 @@ def _indent(value):
 
 
 def compare_outputs(torch_func, jit_func, *args):
-  print('—' * 80)
+  print('-' * 80)
 
   print(f"Input args:\n{_indent(args)}", file=sys.stderr)
   result = torch_func(*args)
   jit_result = jit_func(*args)
 
-  np.testing.assert_allclose(result.numpy(), jit_result)
+  np.testing.assert_allclose(result.numpy(), jit_result, rtol=1e-05, atol=1e-08)
 
   # Only print these if the test passes, as np.testing will print them if it
   # fails.
+  print("SUCCESS", file=sys.stderr)
   print(f"PyTorch Result:\n{_indent(result.numpy())}", file=sys.stderr)
   print(f"JIT Result:\n{_indent(jit_result)}", file=sys.stderr)

--- a/frontends/pytorch/examples/torchscript_tanh_e2e.py
+++ b/frontends/pytorch/examples/torchscript_tanh_e2e.py
@@ -1,0 +1,49 @@
+# -*- Python -*-
+# This file is licensed under a pytorch-style license
+# See frontends/pytorch/LICENSE for license information.
+
+import typing
+
+import torch
+import torch_mlir
+
+import npcomp
+from npcomp.compiler.pytorch.backend import refjit
+from npcomp.compiler.utils import logging
+
+import test_utils
+
+#logging.enable()
+
+# RUN: %PYTHON %s | npcomp-opt | FileCheck %s
+
+mb = torch_mlir.ModuleBuilder()
+
+class TestModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    def forward(self, x):
+        return torch.tanh(x)
+
+test_module = TestModule()
+class_annotator = torch_mlir.ClassAnnotator()
+recursivescriptmodule = torch.jit.script(test_module)
+torch.jit.save(recursivescriptmodule, '/tmp/foo.pt')
+
+class_annotator.exportNone(recursivescriptmodule._c._type())
+class_annotator.exportPath(recursivescriptmodule._c._type(), ['forward'])
+class_annotator.annotateShapesAndDtypes(recursivescriptmodule._c._type(), ['forward'], [
+    None,
+    ([2, 3, -1], torch.float32)
+])
+# TODO: Automatically handle unpacking Python class RecursiveScriptModule into the underlying ScriptModule.
+mb.import_module(recursivescriptmodule._c, class_annotator)
+#mb.module.operation.print()
+
+backend = refjit.CompilerBackend()
+compiled = backend.compile_object_graph(mb.module)
+jit_module = backend.load(compiled)
+
+torch.manual_seed(0)
+input = torch.rand(2, 3, 1)
+test_utils.compare_outputs(test_module.forward, jit_module.forward, input)

--- a/include/npcomp/Dialect/Numpy/Transforms/Passes.h
+++ b/include/npcomp/Dialect/Numpy/Transforms/Passes.h
@@ -19,6 +19,7 @@ namespace Numpy {
 
 std::unique_ptr<OperationPass<ModuleOp>> createPublicFunctionsToTensorPass();
 std::unique_ptr<OperationPass<FuncOp>> createArrayToTensorPass();
+std::unique_ptr<OperationPass<ModuleOp>> createRefinePublicReturnPass();
 
 } // namespace Numpy
 

--- a/include/npcomp/Dialect/Numpy/Transforms/Passes.td
+++ b/include/npcomp/Dialect/Numpy/Transforms/Passes.td
@@ -38,4 +38,26 @@ def NumpyArrayToTensor : Pass<"numpy-array-to-tensor", "FuncOp"> {
 }
 
 
+def NumpyRefinePublicReturn : Pass<"numpy-refine-public-return", "ModuleOp"> {
+  let summary = "Refine public return";
+  let constructor = "mlir::NPCOMP::Numpy::createRefinePublicReturnPass()";
+  let description = [{
+    Refines types of values return from public functions based on
+    intraprocedural information.
+
+    This pass effectively encodes an assumption by the pass pipeline author that
+    the public calling convention of the module can have its types refined,
+    without causing ABI mismatches. This is frequently true -- for example, in
+    many systems, `tensor<?x?xf32>`, `tensor<3x3xf32>` and
+    `tensor<*x!numpy.any_dtype>` are all the same data structure on calling
+    convention boundaries.
+
+    This pass is expected to run after shape refinement has occurred to
+    otherwise resolve shapes, and is currently mainly useful to convert
+    rank/dtype-erased function boundaries to ranked, dtyped code for
+    compiler backends.
+  }];
+}
+
+
 #endif // NPCOMP_NUMPY_PASSES

--- a/include/npcomp/Dialect/Torch/Transforms/Passes.h
+++ b/include/npcomp/Dialect/Torch/Transforms/Passes.h
@@ -28,6 +28,8 @@ void createGlobalizePipeline(OpPassManager &pm);
 
 std::unique_ptr<OperationPass<ModuleOp>> createAdjustCallingConventionsPass();
 
+std::unique_ptr<OperationPass<FuncOp>> createRefineTypesPass();
+
 } // namespace Torch
 
 /// Registers all Torch transformation passes.

--- a/include/npcomp/Dialect/Torch/Transforms/Passes.td
+++ b/include/npcomp/Dialect/Torch/Transforms/Passes.td
@@ -125,4 +125,13 @@ def AdjustCallingConventions
   }];
 }
 
+def RefineTypes : Pass<"torch-refine-types", "FuncOp"> {
+  let summary = "Refine types";
+  let constructor = "mlir::NPCOMP::Torch::createRefineTypesPass()";
+  let description = [{
+    Refines types of the program. Currently, this means shapes and dtypes of
+    tensors/arrays.
+  }];
+}
+
 #endif // NPCOMP_TORCH_PASSES

--- a/lib/Dialect/Numpy/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Numpy/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_npcomp_conversion_library(NPCOMPNumpyPasses
   ArrayToTensor.cpp
   Passes.cpp
   PublicFunctionToTensor.cpp
+  RefinePublicReturn.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/npcomp/Dialect/Numpy/Transforms

--- a/lib/Dialect/Numpy/Transforms/RefinePublicReturn.cpp
+++ b/lib/Dialect/Numpy/Transforms/RefinePublicReturn.cpp
@@ -1,0 +1,82 @@
+//===- RefinePublicReturn.cpp ------------------------------------*- C++-*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "npcomp/Dialect/Numpy/IR/NumpyOps.h"
+#include "npcomp/Dialect/Numpy/Transforms/Passes.h"
+
+using namespace mlir;
+using namespace mlir::NPCOMP;
+using namespace mlir::NPCOMP::Numpy;
+
+namespace {
+
+class RefinePublicReturnPass
+    : public NumpyRefinePublicReturnBase<RefinePublicReturnPass> {
+  void runOnOperation() override {
+    auto module = getOperation();
+    module.walk([&](FuncOp func) {
+      if (func.getVisibility() != SymbolTable::Visibility::Public)
+        return;
+      if (func.isExternal())
+        return;
+      auto uses = SymbolTable::getSymbolUses(func, module);
+      if (!uses || uses->begin() != uses->end()) {
+        func.emitError() << "unimplemented: cannot refine public return for "
+                         << "for public function with uses";
+        return signalPassFailure();
+      }
+      rewriteSignature(func);
+    });
+  }
+
+  void rewriteSignature(FuncOp func) {
+    // Find the unique return op.
+    ReturnOp returnOp;
+    WalkResult walkResult = func.walk([&](ReturnOp op) {
+      if (returnOp)
+        return WalkResult::interrupt();
+      returnOp = op;
+      return WalkResult::advance();
+    });
+    if (walkResult.wasInterrupted()) {
+      func.emitError() << "unimplemented: refining returns for function with "
+                          "more than one return op";
+      return signalPassFailure();
+    }
+
+    // Get the new operands. Either the original operand, or if there is a
+    // TensorStaticInfoCastOp then the pre-casted operand, which is presumed to
+    // have a more precise type.
+    SmallVector<Value> newOperands;
+    for (auto operand : returnOp.getOperands()) {
+      if (auto cast = operand.getDefiningOp<TensorStaticInfoCastOp>()) {
+        newOperands.push_back(cast.getOperand());
+      } else {
+        newOperands.push_back(operand);
+      }
+    }
+    returnOp->setOperands(newOperands);
+
+    // Update the function type.
+    auto funcType = func.getType();
+    func.setType(FunctionType::get(funcType.getContext(), funcType.getInputs(),
+                                   ValueRange(newOperands).getTypes()));
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::NPCOMP::Numpy::createRefinePublicReturnPass() {
+  return std::make_unique<RefinePublicReturnPass>();
+}

--- a/lib/Dialect/Torch/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Torch/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_npcomp_conversion_library(NPCOMPTorchPasses
   Passes.cpp
   GlobalizeObjectGraph.cpp
   PrepareForGlobalizeObjectGraph.cpp
+  RefineTypes.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/npcomp/Dialect/Torch/Transforms

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -1,0 +1,312 @@
+//===- RefineTypes.cpp ------------------------*- C++-*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "npcomp/Dialect/ATen/IR/ATenDialect.h"
+#include "npcomp/Dialect/Basicpy/IR/BasicpyDialect.h"
+#include "npcomp/Dialect/Basicpy/IR/BasicpyOps.h"
+#include "npcomp/Dialect/Numpy/IR/NumpyDialect.h"
+#include "npcomp/Dialect/Numpy/IR/NumpyOps.h"
+#include "npcomp/Dialect/Torch/IR/TorchDialect.h"
+#include "npcomp/Dialect/Torch/IR/TorchOps.h"
+#include "npcomp/Dialect/Torch/Transforms/Passes.h"
+
+using namespace mlir;
+using namespace mlir::NPCOMP;
+using namespace mlir::NPCOMP::Torch;
+
+// -----------------------------------------------------------------------------
+// Analysis.
+// -----------------------------------------------------------------------------
+
+constexpr int64_t kUnknownSize = -1;
+
+namespace {
+// Statically known information for a particular Value.
+//
+// This struct currently tracks only information relevant for tensor/array-like
+// shaped types. It is fine to associate a `ValueKnowledge` with a non-shaped
+// type as long as it is in the default "no knowledge" state returned by
+// `getMostConservativeKnowledge`. The important invariant is that we cannot
+// claim to know something about a value which is false.
+//
+// This class could also be called "dataflow facts", "lattice value", etc.
+struct ValueKnowledge {
+  ValueKnowledge() = delete;
+  // We enforce that `elementType` is always a valid type (possibly
+  // !numpy.any_dtype), and `sizes` is empty unless `hasRank`.
+  // So default constructing is prohibited.
+  ValueKnowledge(bool hasRank, std::vector<int64_t> sizes, Type elementType)
+      : hasRank(hasRank), sizes(sizes), elementType(elementType) {
+    assert(elementType != nullptr);
+    assert(sizes.size() == 0 || hasRank);
+  }
+
+  // Get a safe "most conservative knowledge" default state.
+  static ValueKnowledge getMostConservativeKnowledge(MLIRContext *context) {
+    return ValueKnowledge(false, {}, Numpy::AnyDtypeType::get(context));
+  }
+
+  // Whether the Value is known to have a rank.
+  bool hasRank;
+  // If `hasRank` the sizes along each rank. Unknown sizes are represented as
+  // `kUnknownSize`.
+  std::vector<int64_t> sizes;
+  // The element type of a shaped type.
+  // This is equal to !numpy.any_dtype if it is not a concrete type.
+  Type elementType;
+};
+} // namespace
+
+bool operator==(const ValueKnowledge &lhs, const ValueKnowledge &rhs) {
+  return std::make_tuple(lhs.hasRank, lhs.sizes, lhs.elementType) ==
+         std::make_tuple(rhs.hasRank, rhs.sizes, rhs.elementType);
+}
+
+// static llvm::raw_ostream &operator<<(llvm::raw_ostream &os, ValueKnowledge &knowledge) {
+//   os << "hasRank = " << knowledge.hasRank << ", sizes = [";
+//   llvm::interleaveComma(knowledge.sizes, os);
+//   os << "]"
+//      << ", elementType = " << knowledge.elementType;
+//   return os;
+// }
+
+// Given two pieces of static knowledge, calculate conservatively the
+// information we can be sure about.
+ValueKnowledge join(const ValueKnowledge &lhs, const ValueKnowledge &rhs) {
+  // Mental model: All conditions are checking how to change from the safe "no
+  // knowledge" default-initialized state to a state with more knowledge
+  // consistent with lhs and rhs.
+  ValueKnowledge result = ValueKnowledge::getMostConservativeKnowledge(
+      lhs.elementType.getContext());
+
+  if (lhs.hasRank && !rhs.hasRank) {
+    result.hasRank = true;
+    result.sizes = lhs.sizes;
+  } else if (!lhs.hasRank && rhs.hasRank) {
+    result.hasRank = true;
+    result.sizes = rhs.sizes;
+  } else if (lhs.hasRank && rhs.hasRank &&
+             lhs.sizes.size() == rhs.sizes.size()) {
+    result.hasRank = true;
+    result.sizes.resize(lhs.sizes.size(), kUnknownSize);
+    for (int i = 0, e = result.sizes.size(); i != e; i++) {
+      int64_t lhsSize = lhs.sizes[i];
+      int64_t rhsSize = rhs.sizes[i];
+      int64_t &resultSize = result.sizes[i];
+      if (lhsSize == kUnknownSize) {
+        resultSize = rhsSize;
+      } else if (rhsSize == kUnknownSize) {
+        resultSize = lhsSize;
+      } else if (lhsSize == rhsSize) {
+        resultSize = lhsSize;
+      }
+    }
+  }
+
+  if (!lhs.elementType || lhs.elementType.isa<Numpy::AnyDtypeType>()) {
+    result.elementType = rhs.elementType;
+  } else if (!rhs.elementType || rhs.elementType.isa<Numpy::AnyDtypeType>()) {
+    result.elementType = lhs.elementType;
+  } else if (lhs.elementType == rhs.elementType) {
+    result.elementType = lhs.elementType;
+  }
+  return result;
+}
+
+// Get the static knowledge intrinsic to `type`.
+ValueKnowledge getKnowledgeFromType(Type type) {
+  if (auto tensorType = type.dyn_cast<TensorType>()) {
+    ValueKnowledge result =
+        ValueKnowledge::getMostConservativeKnowledge(type.getContext());
+    if (tensorType.hasRank()) {
+      result.hasRank = true;
+      result.sizes = tensorType.getShape().vec();
+    }
+    result.elementType = tensorType.getElementType();
+    return result;
+  }
+  return ValueKnowledge::getMostConservativeKnowledge(type.getContext());
+}
+
+// Simple forward intraprocedural dataflow for type information.
+class TypeAnalyzer {
+public:
+  TypeAnalyzer(MLIRContext *context) : context(context) {}
+  void propagate(Region &region);
+  // Get the knowledge that is known about `v`.
+  ValueKnowledge &getKnowledge(Value v);
+
+private:
+  // Incorporate `knowledge` into what is known about `v`.
+  // Return true if new knowledge was obtained about `v`.
+  bool incorporateKnowledge(Value v, ValueKnowledge knowledge);
+  MLIRContext *context;
+  DenseMap<Value, ValueKnowledge> facts;
+};
+
+void TypeAnalyzer::propagate(Region &region) {
+  bool changed;
+  do {
+    changed = false;
+    // TODO: Find out why region.walk doesn't walk the blocks.
+    for (Block &block : region) {
+      for (Value v : block.getArguments())
+        changed |= incorporateKnowledge(v, getKnowledgeFromType(v.getType()));
+      for (Operation &op : block.getOperations()) {
+        for (Value v : op.getResults())
+          changed |= incorporateKnowledge(v, getKnowledgeFromType(v.getType()));
+        if (isa<Numpy::TensorStaticInfoCastOp, aten::TanhOp>(op)) {
+          changed |= incorporateKnowledge(op.getResult(0),
+                                          getKnowledge(op.getOperand(0)));
+        }
+      }
+    };
+  } while (changed);
+}
+
+ValueKnowledge &TypeAnalyzer::getKnowledge(Value v) {
+  auto p =
+      facts.insert({v, ValueKnowledge::getMostConservativeKnowledge(context)});
+  return p.first->second;
+}
+
+bool TypeAnalyzer::incorporateKnowledge(Value v, ValueKnowledge knowledge) {
+  ValueKnowledge &currentKnowledge = getKnowledge(v);
+  ValueKnowledge updatedKnowledge = join(currentKnowledge, knowledge);
+  assert(join(updatedKnowledge, knowledge) == updatedKnowledge &&
+         "nonmonotonic!");
+  assert(join(updatedKnowledge, currentKnowledge) == updatedKnowledge &&
+         "nonmonotonic!");
+  if (currentKnowledge == updatedKnowledge)
+    return false;
+  currentKnowledge = updatedKnowledge;
+  return true;
+}
+
+// -----------------------------------------------------------------------------
+// Transforms.
+// -----------------------------------------------------------------------------
+
+// Get the most refined TensorType compatible with ValueKnowledge.
+static TensorType getTensorTypeFromKnowledge(MLIRContext *context,
+                                             ValueKnowledge &knowledge) {
+  Type elementType = knowledge.elementType ? knowledge.elementType
+                                           : Numpy::AnyDtypeType::get(context);
+  if (!knowledge.hasRank)
+    return UnrankedTensorType::get(elementType);
+  return RankedTensorType::get(knowledge.sizes, elementType);
+}
+
+// Get a the most refined type compatible with ValueKnowledge, or null if that
+// is not possible.
+static Type getMostRefinedStaticType(Value v, TypeAnalyzer &analyzer) {
+  if (v.getType().isa<TensorType>())
+    return getTensorTypeFromKnowledge(v.getContext(), analyzer.getKnowledge(v));
+  // TODO: Support !numpy.ndarray type.
+  return nullptr;
+}
+
+// Return true whether a type `v` can have its type updated in place.
+// This is a function of the value itself and also its users.
+static bool canUpdateTypeInPlace(Value v) {
+  // TODO: There are really two different predicates here, which need to be
+  // properly interface-ized or otherwise make pluggable.
+  // 1. Whether an operation allows its result to be refined to a certain type.
+  // 2. Whether an operand of an operation can be refined to a certain
+  // type.
+  //
+  // A simple first step that probably is enough in practice is a simple trait
+  // AllowsTypeRefinement which answers yes to both questions. In general, an op
+  // might allow refinement of some operands/results but not others, but that
+  // seems unlikely.
+  //
+  // Currently, we answer both with the same logic, which is just enough for our
+  // e2e bringup.
+  Dialect *atenDialect = v.getContext()->getOrLoadDialect<aten::ATenDialect>();
+  auto canValueIntrinsicallyBeUpdated = [&](Value v) {
+    // TODO: Update block arguments.
+    if (v.isa<BlockArgument>())
+      return false;
+    Operation *op = v.cast<OpResult>().getOwner();
+    if (op->getDialect() == atenDialect)
+      return true;
+    if (isa<Numpy::TensorStaticInfoCastOp>(op))
+      return true;
+    return false;
+  };
+  // TODO: Handle BranchOpInterface and RegionBranchOpInterface ops.
+  return canValueIntrinsicallyBeUpdated(v) &&
+         llvm::all_of(v.getUses(), [&](OpOperand &use) {
+           Operation *user = use.getOwner();
+           if (user->getDialect() == atenDialect)
+             return true;
+           if (isa<Numpy::TensorStaticInfoCastOp>(user))
+             return true;
+           return false;
+         });
+}
+
+void optimize(FuncOp func, TypeAnalyzer &analyzer) {
+  func.walk([&](Operation *op) {
+    for (Value v : op->getResults()) {
+      Type refinedType = getMostRefinedStaticType(v, analyzer);
+      // No type? Nothing to do.
+      if (!refinedType)
+        return;
+      // Type is same as existing one? Nothing to do.
+      if (refinedType == v.getType())
+        return;
+      if (canUpdateTypeInPlace(v)) {
+        // Update type in place if possible.
+        v.setType(refinedType);
+      } else if (v.getType().isa<TensorType>() && v.isa<OpResult>()) {
+        // Update the type in place, and cast the information way explicitly so
+        // that users observe the original type.
+        // TODO: Support updating !numpy.ndarray type too.
+        // TODO: Support updating block arguments.
+        // TODO: This update could be more fine-grained (RAUW with per-use
+        // canUpdateTypeInPlace information), or to get we could get the same
+        // effect by implementing a canonicalization that uses the fine-grained
+        // information used by canUpdateTypeInPlace to bypass
+        // numpy.tensor_static_info_cast when the consuming op is ok with that.
+        Operation *op = v.cast<OpResult>().getOwner();
+        OpBuilder builder(op->getBlock(), std::next(op->getIterator()));
+        auto staticInfoCast = builder.create<Numpy::TensorStaticInfoCastOp>(
+            op->getLoc(), v.getType(), v);
+        SmallPtrSet<Operation *, 1> exceptions;
+        exceptions.insert(staticInfoCast);
+        v.replaceAllUsesExcept(staticInfoCast, exceptions);
+        v.setType(refinedType);
+      }
+    }
+  });
+}
+
+namespace {
+class RefineTypesPass : public RefineTypesBase<RefineTypesPass> {
+  void runOnOperation() override {
+    auto func = getOperation();
+    TypeAnalyzer analyzer(&getContext());
+    analyzer.propagate(func.getRegion());
+    optimize(func, analyzer);
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<FuncOp>>
+mlir::NPCOMP::Torch::createRefineTypesPass() {
+  return std::make_unique<RefineTypesPass>();
+}

--- a/python/npcomp/compiler/pytorch/backend/refjit.py
+++ b/python/npcomp/compiler/pytorch/backend/refjit.py
@@ -20,6 +20,9 @@ __all__ = [
 # to a module semantics where symbols correspond to dotted paths into the
 # module.
 OBJECT_GRAPH_LOWERING_PASSES = (
+    # Globalize the program. The rest of the compiler assumes a globalized
+    # program, which makes all analyses and transforms significantly easier
+    # to write.
     "torch-globalize-pipeline",
     # symbol-dce is currently needed for correctness, as we don't have a lowering
     # in the backend for torch.global_slot's.
@@ -27,14 +30,42 @@ OBJECT_GRAPH_LOWERING_PASSES = (
     # bothersome because we don't currently have a lowering for them.
     # TODO: Support global slots in backends.
     "symbol-dce",
+    # Incorporate user annotations and remove signature Python-isms.
     "torch-adjust-calling-conventions",
 )
 
+# TODO: Replace this with lowering to "TCP + guards" -- that's the real
+# backend interface. Put differently, add "TCF to TCP" to the end of this
+# pipeline.
 TORCH_TO_TCF_PASSES = (
+    # Recognize ATen kernels.
     "func(aten-recognize-kernels)",
-    "func(convert-aten-to-tcf)",
+
+    # Convert the bulk of the program to ranked tensors with known dtype.
+    # This is the input to the backend layer that we are aiming for.
+
+    # First, unilaterally convert public functions to tensor.
+    # The way this pass is currently written, this implies that
+    # as pipeline authors, we are restricting our users to not be able to see
+    # updates to "out params" on their public functions.
+    # This is deemed ok for now.
     "numpy-public-functions-to-tensor",
-    "canonicalize",
+    # Convert the bulk of non-ABI-visible arrays to tensors.
+    "func(numpy-array-to-tensor)",
+    # Do shape and dtype refinement.
+    # We could do it sooner, but the pass currently doesn't have transfer
+    # functions for array ops.
+    "func(torch-refine-types)",
+    # Propagate to ABI return types the shape/dtype information discovered by
+    # the previous pass. Doing this is ABI-compatible for our backends.
+    "numpy-refine-public-return",
+    # Clean up a few stray array/tensor conversion remnants.
+    "func(numpy-array-to-tensor)",
+
+    # Lower to TCF which is the input to RefBackend.
+    # Most of this pass should be subsumed by aten->linalg+guards conversions.
+    # (the guard generation will be automated from the linalg Op DSL)
+    "func(convert-aten-to-tcf)",
 )
 
 # Re-export.

--- a/test/Dialect/Numpy/refine-public-return.mlir
+++ b/test/Dialect/Numpy/refine-public-return.mlir
@@ -1,0 +1,51 @@
+// RUN: npcomp-opt -split-input-file %s -verify-diagnostics -allow-unregistered-dialect -numpy-refine-public-return | FileCheck %s
+
+// CHECK-LABEL:   func @basic(
+// CHECK-SAME:              %[[ARG:.*]]: tensor<?xf32>) -> (tensor<?xf32>, i1, tensor<?xf32>) {
+// CHECK:           %[[CTRUE:.*]] = constant true
+// CHECK:           %[[CAST:.*]] = numpy.tensor_static_info_cast %[[ARG]] : tensor<?xf32> to tensor<*x!numpy.any_dtype>
+// CHECK:           return %[[ARG]], %[[CTRUE]], %[[ARG]] : tensor<?xf32>, i1, tensor<?xf32>
+func @basic(%arg0: tensor<?xf32>) -> (tensor<?xf32>, i1, tensor<*x!numpy.any_dtype>) {
+  %ctrue = std.constant true
+  %cast = numpy.tensor_static_info_cast %arg0 : tensor<?xf32> to tensor<*x!numpy.any_dtype>
+  return %arg0, %ctrue, %cast : tensor<?xf32>, i1, tensor<*x!numpy.any_dtype>
+}
+
+// No conversion on private function.
+// CHECK-LABEL:   func private @basic_private(
+// CHECK-SAME:                                %[[ARG:.*]]: tensor<?xf32>) -> (tensor<?xf32>, i1, tensor<*x!numpy.any_dtype>) {
+// CHECK:           %[[CTRUE:.*]] = constant true
+// CHECK:           %[[CASTED:.*]] = numpy.tensor_static_info_cast %[[ARG]] : tensor<?xf32> to tensor<*x!numpy.any_dtype>
+// CHECK:           return %[[ARG]], %[[CTRUE]], %[[CASTED]] : tensor<?xf32>, i1, tensor<*x!numpy.any_dtype>
+func private @basic_private(%arg0: tensor<?xf32>) -> (tensor<?xf32>, i1, tensor<*x!numpy.any_dtype>) {
+  %ctrue = std.constant true
+  %cast = numpy.tensor_static_info_cast %arg0 : tensor<?xf32> to tensor<*x!numpy.any_dtype>
+  return %arg0, %ctrue, %cast : tensor<?xf32>, i1, tensor<*x!numpy.any_dtype>
+}
+
+
+// -----
+
+// Call to public function.
+// expected-error @+1 {{unimplemented}}
+func @called(%arg0: tensor<*xf32>) -> tensor<*xf32> {
+  return %arg0 : tensor<*xf32>
+}
+
+func private @caller(%arg0: tensor<*xf32>) -> tensor<*xf32> {
+  %0 = call @called(%arg0) : (tensor<*xf32>) -> tensor<*xf32>
+  return %0 : tensor<*xf32>
+}
+
+// -----
+
+// Multiple returns.
+// expected-error @+1 {{unimplemented}}
+func @called(%arg0: tensor<*xf32>) -> tensor<*xf32> {
+  %ctrue = constant true
+  cond_br %ctrue, ^bb1, ^bb2
+^bb1:
+  return %arg0 : tensor<*xf32>
+^bb2:
+  return %arg0 : tensor<*xf32>
+}

--- a/test/Dialect/Torch/refine-types.mlir
+++ b/test/Dialect/Torch/refine-types.mlir
@@ -1,0 +1,37 @@
+// RUN: npcomp-opt -torch-refine-types -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL:   func @f(
+// CHECK-SAME:            %[[ARG:.*]]: tensor<2x3x?xf32>) -> tensor<*x!numpy.any_dtype> {
+// CHECK:           %[[SHAPED:.*]] = numpy.tensor_static_info_cast %[[ARG]] : tensor<2x3x?xf32> to tensor<2x3x?xf32>
+// CHECK:           %[[SHAPE_ERASED:.*]] = numpy.tensor_static_info_cast %[[SHAPED]] : tensor<2x3x?xf32> to tensor<*x!numpy.any_dtype>
+// CHECK:           return %[[SHAPE_ERASED]] : tensor<*x!numpy.any_dtype>
+func @f(%arg0: tensor<2x3x?xf32>) -> tensor<*x!numpy.any_dtype> {
+  %0 = numpy.tensor_static_info_cast %arg0 : tensor<2x3x?xf32> to tensor<*x!numpy.any_dtype>
+  return %0 : tensor<*x!numpy.any_dtype>
+}
+
+// -----
+
+// CHECK-LABEL:   func @f(
+// CHECK-SAME:            %[[ARG:.*]]: tensor<2x3x?xf32>) -> tensor<*x!numpy.any_dtype> {
+// CHECK:           %[[SHAPED:.*]] = "aten.tanh"(%[[ARG]]) : (tensor<2x3x?xf32>) -> tensor<2x3x?xf32>
+// CHECK:           %[[SHAPE_ERASED:.*]] = numpy.tensor_static_info_cast %[[SHAPED]] : tensor<2x3x?xf32> to tensor<*x!numpy.any_dtype>
+// CHECK:           return %[[SHAPE_ERASED]] : tensor<*x!numpy.any_dtype>
+func @f(%arg0: tensor<2x3x?xf32>) -> tensor<*x!numpy.any_dtype> {
+  %1 = "aten.tanh"(%arg0) : (tensor<2x3x?xf32>) -> tensor<*x!numpy.any_dtype>
+  return %1 : tensor<*x!numpy.any_dtype>
+}
+
+// -----
+
+// CHECK-LABEL:   func @f
+func @f(%arg0: tensor<2x3x?xf32>) -> tensor<*x!numpy.any_dtype> {
+  // Check propagation through multiple ops.
+  // CHECK:           "aten.tanh"(%{{.*}}) : (tensor<2x3x?xf32>) -> tensor<2x3x?xf32>
+  // CHECK:           "aten.tanh"(%{{.*}}) : (tensor<2x3x?xf32>) -> tensor<2x3x?xf32>
+  // CHECK:           "aten.tanh"(%{{.*}}) : (tensor<2x3x?xf32>) -> tensor<2x3x?xf32>
+  %1 = "aten.tanh"(%arg0) : (tensor<2x3x?xf32>) -> tensor<*x!numpy.any_dtype>
+  %2 = "aten.tanh"(%1) : (tensor<*x!numpy.any_dtype>) -> tensor<*x!numpy.any_dtype>
+  %3 = "aten.tanh"(%2) : (tensor<*x!numpy.any_dtype>) -> tensor<*x!numpy.any_dtype>
+  return %3 : tensor<*x!numpy.any_dtype>
+}


### PR DESCRIPTION
Recommended review order: commit by commit

Two main changes:
- type refinement pass (only does shape/dtype refinement; simple intraprocedural forward dataflow)
- "refine public return" pass (see description for why needed; it adjusts public calling conventions so needs careful attention)

This is a huge milestone!

```
silvasean@silvasean0:~/pg/mlir-npcomp/mlir-npcomp$ npcpy frontends/pytorch/examples/torchscript_tanh_e2e.py 
ninja: Entering directory `/home/silvasean/pg/mlir-npcomp/mlir-npcomp/build'
[1/1] Running utility command for NPCOMPPythonResources
Input args:
  (tensor([[[0.4963],
           [0.7682],
           [0.0885]],

          [[0.1320],
           [0.3074],
           [0.6341]]]),)
SUCCESS
PyTorch Result:
  [[[0.45916808]
    [0.6458943 ]
    [0.08824728]]

   [[0.1312686 ]
    [0.29809073]
    [0.5608543 ]]]
JIT Result:
  [[[0.45916805]
    [0.6458943 ]
    [0.08824727]]

   [[0.13126862]
    [0.29809076]
    [0.5608544 ]]]
```