### PR TITLE
Declare TCP dialect dependency in TCFToTCP conversion

### DIFF
--- a/lib/Conversion/TCFToTCP/CMakeLists.txt
+++ b/lib/Conversion/TCFToTCP/CMakeLists.txt
@@ -16,4 +16,5 @@ add_npcomp_conversion_library(NPCOMPTCFToTCP
   MLIRTransforms
   MLIRShape
   NPCOMPTCFDialect
+  NPCOMPTCPDialect
 )


### PR DESCRIPTION
Trivial fix to a build error caused by `cmake` visiting TCF->TCP conversion before the TCP dialect.