### PR TITLE
Add flatten op recognition + shape refinement.

### DIFF
--- a/include/npcomp/Dialect/ATen/IR/ATenOps.td
+++ b/include/npcomp/Dialect/ATen/IR/ATenOps.td
@@ -39,23 +39,6 @@ def aten_ConstantOp: aten_Op<"constant", [NoSideEffect]>,
 
 }
 
-def aten_FlattenOp: aten_Op<"flatten", [NoSideEffect, StatisticsOpInterface]>,
-                    Results<(outs AnyTensor)> {
-  let arguments = (
-    ins AnyType:$arg0,
-        AnyType:$arg1,
-        AnyType:$arg2
-  );
-
-  let summary = "Flatten operator";
-  let description = [{
-    Flatten operator
-  }];
-  let extraClassDeclaration = [{
-    std::map<std::string, uint64_t> getStatistics();
-  }];
-}
-
 def aten_TypeCastOp : aten_Op<"type_cast", [NoSideEffect]>,
                       Results<(outs AnyType)> {
   let summary = "TypeCast operator";

--- a/include/npcomp/Dialect/ATen/IR/GeneratedATenOps.cpp.inc
+++ b/include/npcomp/Dialect/ATen/IR/GeneratedATenOps.cpp.inc
@@ -1291,6 +1291,28 @@ const Torch::BuildKernelMetadata &NllLoss2dBackwardOp::getTorchBuildKernelMetada
   return metadata;
 }
 
+// -----------------------------------------------------------------------------
+// Mutable/view-like ops
+// -----------------------------------------------------------------------------
+
+Torch::KernelMetadata FlattenOp::getTorchKernelMetadata() {
+  return getTorchBuildKernelMetadata();
+}
+
+const Torch::BuildKernelMetadata &FlattenOp::getTorchBuildKernelMetadata() {
+  using KVC = Torch::KernelValueConversion::BitMask;
+  static Torch::BuildKernelMetadata metadata = ([]() {
+    Torch::BuildKernelMetadata m;
+    m.kernelName = "aten::flatten";
+    m.addArgTypes({"Tensor", "int", "int"});
+    m.addArgConversions({KVC::kMutableTensor, KVC::kNone, KVC::kNone});
+    m.addReturnTypes({"Tensor"});
+    m.addReturnConversions({KVC::kMutableTensor});
+    return m;
+  })();
+  return metadata;
+}
+
 Torch::KernelMetadata CopyInplaceOp::getTorchKernelMetadata() {
   return getTorchBuildKernelMetadata();
 }

--- a/include/npcomp/Dialect/ATen/IR/GeneratedATenOps.td
+++ b/include/npcomp/Dialect/ATen/IR/GeneratedATenOps.td
@@ -759,6 +759,22 @@ def aten_NllLoss2dBackwardOp: aten_Op<"nll_loss2d_backward", [NoSideEffect, Decl
   );
 }
 
+// -----------------------------------------------------------------------------
+// Mutable/view-like ops
+// -----------------------------------------------------------------------------
+
+def aten_FlattenOp: aten_Op<"flatten", [DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>, AllowsTypeRefinement]> {
+  let summary = "Recognized op for kernel aten::flatten";
+  let arguments = (ins
+    AnyTorchMutableTensor:$self,
+    AnyTorchIntType:$start_dim,
+    AnyTorchIntType:$end_dim
+  );
+  let results = (outs
+    AnyTorchMutableTensor
+  );
+}
+
 def aten_CopyInplaceOp: aten_Op<"copy.inplace", [DeclareOpInterfaceMethods<TorchBuildableKernelOpInterface>, DeclareOpInterfaceMethods<TorchKernelOpInterface>, AllowsTypeRefinement]> {
   let summary = "Recognized op for kernel aten::copy_";
   let arguments = (ins

--- a/lib/Dialect/ATen/IR/ATenDialectOpStats.cpp
+++ b/lib/Dialect/ATen/IR/ATenDialectOpStats.cpp
@@ -157,14 +157,6 @@ std::map<std::string, uint64_t> ExpandOp::getStatistics() {
   return toReturn;
 }
 
-// flatten can be zero overhead
-std::map<std::string, uint64_t> FlattenOp::getStatistics() {
-  std::map<std::string, uint64_t> toReturn;
-  toReturn["reads"] = toReturn["operand:0:activation_in"] = 0;
-  toReturn["writes"] = toReturn["result:0:activation_out"] = 0;
-  return toReturn;
-}
-
 std::map<std::string, uint64_t> GatherOp::getStatistics() {
   std::map<std::string, uint64_t> toReturn;
   // FIXME: unimplemented

--- a/lib/Dialect/Basicpy/IR/BasicpyDialect.cpp
+++ b/lib/Dialect/Basicpy/IR/BasicpyDialect.cpp
@@ -86,6 +86,9 @@ Operation *BasicpyDialect::materializeConstant(OpBuilder &builder,
       return builder.create<StrConstantOp>(loc, type, strValue);
   }
 
+  if (auto typeAttr = value.dyn_cast<TypeAttr>())
+    return builder.create<SingletonOp>(loc, typeAttr.getValue());
+
   return nullptr;
 }
 

--- a/test/Dialect/ATen/recognize_aten_kernels.mlir
+++ b/test/Dialect/ATen/recognize_aten_kernels.mlir
@@ -147,3 +147,18 @@ func @inplace_variant(%arg0: !numpy.ndarray<[2,2]:f32>, %arg1: !numpy.ndarray<[2
   // CHECK:           return %[[LHS_OUT]], %[[LHS_OUT]] : !numpy.ndarray<[2,2]:f32>, !numpy.ndarray<[2,2]:f32>
   return %0, %arg0 : !numpy.ndarray<[2,2]:f32>, !numpy.ndarray<[2,2]:f32>
 }
+
+// -----
+
+// CHECK-LABEL:   func @mutable_tensor(
+// CHECK-SAME:                  %[[ARG:.*]]: !numpy.ndarray<*:!numpy.any_dtype>) -> !numpy.ndarray<*:!numpy.any_dtype> {
+// CHECK:           %[[CM1:.*]] = constant -1 : i64
+// CHECK:           %[[C1:.*]] = constant 1 : i64
+// CHECK:           %[[RET:.*]] = "aten.flatten"(%[[ARG]], %[[C1]], %[[CM1]]) : (!numpy.ndarray<*:!numpy.any_dtype>, i64, i64) -> !numpy.ndarray<*:!numpy.any_dtype>
+// CHECK:           return %[[RET]] : !numpy.ndarray<*:!numpy.any_dtype>
+func @mutable_tensor(%arg0: !numpy.ndarray<*:!numpy.any_dtype>) -> !numpy.ndarray<*:!numpy.any_dtype> {
+  %c-1_i64 = constant -1 : i64
+  %c1_i64 = constant 1 : i64
+  %0 = torch.kernel_call "aten::flatten" %arg0, %c1_i64, %c-1_i64 : (!numpy.ndarray<*:!numpy.any_dtype>, i64, i64) -> !numpy.ndarray<*:!numpy.any_dtype> {sigArgTypes = ["Tensor", "int", "int"], sigIsMutable = false, sigIsVararg = false, sigIsVarret = false, sigRetTypes = ["Tensor"]}
+  return %0 : !numpy.ndarray<*:!numpy.any_dtype>
+}

--- a/test/Dialect/Basicpy/canonicalize.mlir
+++ b/test/Dialect/Basicpy/canonicalize.mlir
@@ -1,4 +1,4 @@
-// RUN: npcomp-opt -split-input-file %s | npcomp-opt -canonicalize | FileCheck --dump-input=fail %s
+// RUN: npcomp-opt -split-input-file -canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: func @unknown_cast_elide
 func @unknown_cast_elide(%arg0 : i32) -> i32 {
@@ -79,4 +79,14 @@ func @bool_cast() -> i1 {
   %1 = basicpy.bool_cast %0 : !basicpy.BoolType -> i1
   // CHECK: return %[[CTRUE]] : i1
   return %1 : i1
+}
+
+// -----
+// CHECK-LABEL: func @singleton_coalesce
+func @singleton_coalesce() -> (!basicpy.NoneType, !basicpy.NoneType) {
+  %0 = basicpy.singleton : !basicpy.NoneType
+  %1 = basicpy.singleton : !basicpy.NoneType
+  // CHECK-NEXT: %[[RET:.*]] = basicpy.singleton
+  // CHECK-NEXT: return %[[RET]], %[[RET]]
+  return %0, %1 : !basicpy.NoneType, !basicpy.NoneType
 }

--- a/test/Dialect/Torch/refine-types.mlir
+++ b/test/Dialect/Torch/refine-types.mlir
@@ -109,6 +109,38 @@ func @f(%arg0: tensor<?x?x?x?xf32>) -> tensor<*x!numpy.any_dtype> {
 
 // -----
 
+// Also test cast insertion for array types.
+// CHECK-LABEL:   func @flatten_all(
+// CHECK:           %[[FLATTENED:.*]] = "aten.flatten"{{.*}}-> !numpy.ndarray<[?]:f32>
+// CHECK:           %[[SHAPE_ERASED:.*]] = numpy.static_info_cast %[[FLATTENED]] : !numpy.ndarray<[?]:f32> to !numpy.ndarray<*:!numpy.any_dtype>
+// CHECK:           return %[[SHAPE_ERASED]]
+func @flatten_all(%arg0: !numpy.ndarray<[3,2,?,5]:f32>) -> !numpy.ndarray<*:!numpy.any_dtype> {
+  %end = constant -1 : i64
+  %start = constant 0 : i64
+  %0 = "aten.flatten"(%arg0, %start, %end) : (!numpy.ndarray<[3,2,?,5]:f32>, i64, i64) -> !numpy.ndarray<*:!numpy.any_dtype>
+  return %0 : !numpy.ndarray<*:!numpy.any_dtype>
+}
+
+// CHECK-LABEL:   func @flatten_some(
+// CHECK:           "aten.flatten"{{.*}}-> !numpy.ndarray<[3,?,5]:f32>
+func @flatten_some(%arg0: !numpy.ndarray<[3,2,?,5]:f32>) -> !numpy.ndarray<*:!numpy.any_dtype> {
+  %end = constant -2 : i64
+  %start = constant 1 : i64
+  %0 = "aten.flatten"(%arg0, %start, %end) : (!numpy.ndarray<[3,2,?,5]:f32>, i64, i64) -> !numpy.ndarray<*:!numpy.any_dtype>
+  return %0 : !numpy.ndarray<*:!numpy.any_dtype>
+}
+
+// CHECK-LABEL:   func @flatten_rank0(
+// CHECK:           "aten.flatten"{{.*}}-> !numpy.ndarray<[?]:f32>
+func @flatten_rank0(%arg0: !numpy.ndarray<[]:f32>) -> !numpy.ndarray<*:!numpy.any_dtype> {
+  %end = constant -1 : i64
+  %start = constant 0 : i64
+  %0 = "aten.flatten"(%arg0, %start, %end) : (!numpy.ndarray<[]:f32>, i64, i64) -> !numpy.ndarray<*:!numpy.any_dtype>
+  return %0 : !numpy.ndarray<*:!numpy.any_dtype>
+}
+
+// -----
+
 // CHECK-LABEL: func @f
 func @f(%arg0: tensor<4x6x3xf32>, %arg1: tensor<1x1x3xf32>, %arg2: tensor<?x3xf32>) {
   %c1_i64 = constant 1 : i64


### PR DESCRIPTION
This op has complex aliasing semantics, so it is kept mutable for now.

With this, we reduce ResNet18 to a single BB with all aten operators
having rank + dtype:
https://gist.github.com/silvasean/2fcb1c6e4d4ae27461204a43ae9c5031