### PR TITLE
Introduce native `!torch.none` type.

### DIFF
--- a/frontends/pytorch/csrc/builder/acap_dispatch.cpp
+++ b/frontends/pytorch/csrc/builder/acap_dispatch.cpp
@@ -517,10 +517,10 @@ MlirType AcapController::mapIValueToMlirType(MlirLocation loc,
                 loc, ival.toList().elementType()));
   }
   if (ival.isNone()) {
-    return npcompNoneTypeGet(funcBuilder->getContext());
+    return npcompTorchNoneTypeGet(funcBuilder->getContext());
   }
   if (ival.isDevice()) {
-    return npcompNoneTypeGet(funcBuilder->getContext());
+    return npcompTorchNoneTypeGet(funcBuilder->getContext());
   }
   return {nullptr};
 }

--- a/frontends/pytorch/csrc/builder/ivalue_importer.cpp
+++ b/frontends/pytorch/csrc/builder/ivalue_importer.cpp
@@ -304,8 +304,9 @@ MlirValue IValueImporter::rawImportIValue(c10::IValue ivalue) {
     return mlirOperationGetResult(operation, 0);
   }
   if (ivalue.isNone()) {
-    MlirOperation operation = createMlirOperationAtEnd(
-        importBlock, "basicpy.singleton", loc, npcompNoneTypeGet(context));
+    MlirOperation operation =
+        createMlirOperationAtEnd(importBlock, "torch.constant.none", loc,
+                                 npcompTorchNoneTypeGet(context));
     return mlirOperationGetResult(operation, 0);
   }
   if (ivalue.isCustomClass()) {

--- a/frontends/pytorch/csrc/builder/op_builder.cpp
+++ b/frontends/pytorch/csrc/builder/op_builder.cpp
@@ -17,8 +17,8 @@ using namespace torch_mlir;
 OpBuilder::OpBuilder(MlirContext context) : context(context) {}
 
 MlirOperation OpBuilder::createNoneConstant(MlirLocation loc) {
-  return createMlirOperation("basicpy.singleton", loc,
-                             npcompNoneTypeGet(context));
+  return createMlirOperation("torch.constant.none", loc,
+                             npcompTorchNoneTypeGet(context));
 }
 
 MlirOperation OpBuilder::createBoolConstant(MlirLocation loc, bool value) {

--- a/frontends/pytorch/csrc/builder/torch_to_mlir_utils.cpp
+++ b/frontends/pytorch/csrc/builder/torch_to_mlir_utils.cpp
@@ -175,7 +175,7 @@ MlirType TypeMapper::mapFromTorchType(MlirLocation loc,
     return mlirIntegerTypeGet(context, 64);
   }
   case TypeKind::NoneType: {
-    return npcompNoneTypeGet(context);
+    return npcompTorchNoneTypeGet(context);
   }
   case TypeKind::BoolType: {
     return npcompBoolTypeGet(context);
@@ -208,7 +208,7 @@ MlirType TypeMapper::forwardTensorToType(at::Tensor tensor) {
   if (!tensor.defined()) {
     // Undefined tensors are equivalent to None.
     // This may need to be re-evaluated at some point.
-    return npcompNoneTypeGet(context);
+    return npcompTorchNoneTypeGet(context);
   }
 
   MlirType elementType = mapFromTorchScalarType(tensor.scalar_type());

--- a/frontends/pytorch/test/ivalue_import/annotations/arg-tensor-type-bound.py
+++ b/frontends/pytorch/test/ivalue_import/annotations/arg-tensor-type-bound.py
@@ -25,7 +25,7 @@ class_type = recursivescriptmodule._c._type()
 # CHECK: func private @__torch__.TestModule.forward(
 # CHECK-SAME: %arg0: !torch.nn.Module<"__torch__.TestModule">,
 # CHECK-SAME: %arg1: !torch.tensor {torch.type_bound = !torch.vtensor<[?,1024],si8>}
-# CHECK-SAME: ) -> !basicpy.NoneType             
+# CHECK-SAME: ) -> !torch.none
 annotator.annotateArgs(class_type, ['forward'], [
     None,
     ((-1, 1024), torch.int8, True),

--- a/frontends/pytorch/test/ivalue_import/functions-that-call-methods.py
+++ b/frontends/pytorch/test/ivalue_import/functions-that-call-methods.py
@@ -14,20 +14,20 @@ mb = torch_mlir.ModuleBuilder()
 # Interesting test case, where a function calls a method.
 
 # CHECK-LABEL:     func private @__torch__.TestModule.forward
-# CHECK-SAME:        (%[[ARG0:.*]]: !torch.nn.Module<"__torch__.TestModule">, %[[ARG1:.*]]: !torch.tensor) -> !basicpy.NoneType {
-# CHECK:             %[[F:.*]] = constant @__torch__.calls_method : (!torch.nn.Module<"__torch__.TestModule">, !torch.tensor) -> !basicpy.NoneType
-# CHECK:             %[[RET:.*]] = call_indirect %[[F]](%[[ARG0]], %[[ARG1]]) : (!torch.nn.Module<"__torch__.TestModule">, !torch.tensor) -> !basicpy.NoneType
-# CHECK:             return %[[RET]] : !basicpy.NoneType
+# CHECK-SAME:        (%[[ARG0:.*]]: !torch.nn.Module<"__torch__.TestModule">, %[[ARG1:.*]]: !torch.tensor) -> !torch.none {
+# CHECK:             %[[F:.*]] = constant @__torch__.calls_method : (!torch.nn.Module<"__torch__.TestModule">, !torch.tensor) -> !torch.none
+# CHECK:             %[[RET:.*]] = call_indirect %[[F]](%[[ARG0]], %[[ARG1]]) : (!torch.nn.Module<"__torch__.TestModule">, !torch.tensor) -> !torch.none
+# CHECK:             return %[[RET]] : !torch.none
 # CHECK:           }
 # CHECK-LABEL:     func private @__torch__.TestModule.method
-# CHECK-SAME:        (%[[ARG0:.*]]: !torch.nn.Module<"__torch__.TestModule">, %[[ARG1:.*]]: !torch.tensor) -> !basicpy.NoneType {
-# CHECK:             %[[RET:.*]] = basicpy.singleton : !basicpy.NoneType
-# CHECK:             return %[[RET]] : !basicpy.NoneType
+# CHECK-SAME:        (%[[ARG0:.*]]: !torch.nn.Module<"__torch__.TestModule">, %[[ARG1:.*]]: !torch.tensor) -> !torch.none {
+# CHECK:             %[[RET:.*]] = torch.constant.none
+# CHECK:             return %[[RET]] : !torch.none
 # CHECK:           }
 # CHECK-LABEL:     func private @__torch__.calls_method
-# CHECK-SAME:        (%[[ARG0:.*]]: !torch.nn.Module<"__torch__.TestModule">, %[[ARG1:.*]]: !torch.tensor) -> !basicpy.NoneType {
-# CHECK:             %[[RET:.*]] = torch.prim.CallMethod %[[ARG0]]["method"] (%[[ARG1]]) : !torch.nn.Module<"__torch__.TestModule">, (!torch.tensor) -> !basicpy.NoneType
-# CHECK:             return %[[RET]] : !basicpy.NoneType
+# CHECK-SAME:        (%[[ARG0:.*]]: !torch.nn.Module<"__torch__.TestModule">, %[[ARG1:.*]]: !torch.tensor) -> !torch.none {
+# CHECK:             %[[RET:.*]] = torch.prim.CallMethod %[[ARG0]]["method"] (%[[ARG1]]) : !torch.nn.Module<"__torch__.TestModule">, (!torch.tensor) -> !torch.none
+# CHECK:             return %[[RET]] : !torch.none
 # CHECK:           }
 
 def calls_method(c: 'TestModule', x):

--- a/frontends/pytorch/test/ivalue_import/methods-derefine.py
+++ b/frontends/pytorch/test/ivalue_import/methods-derefine.py
@@ -19,8 +19,8 @@ class TestModule(torch.nn.Module):
 
   # CHECK-LABEL:   func private @__torch__.TestModule.forward(
   # CHECK-SAME:                                               %[[SELF:.*]]: !torch.nn.Module<"__torch__.TestModule">) -> !torch.optional<i64> {
-  # CHECK:           %[[NONE:.*]] = basicpy.singleton : !basicpy.NoneType
-  # CHECK:           %[[DEREFINED:.*]] = torch.derefine %[[NONE]] : !basicpy.NoneType to !torch.optional<i64>
+  # CHECK:           %[[NONE:.*]] = torch.constant.none
+  # CHECK:           %[[DEREFINED:.*]] = torch.derefine %[[NONE]] : !torch.none to !torch.optional<i64>
   # CHECK:           %[[RET:.*]] = torch.prim.CallMethod %[[SELF]]["callee"] (%[[DEREFINED]]) : !torch.nn.Module<"__torch__.TestModule">, (!torch.optional<i64>) -> !torch.optional<i64>
   # CHECK:           return %[[RET]] : !torch.optional<i64>
   def forward(self):

--- a/frontends/pytorch/test/ivalue_import/prim.py
+++ b/frontends/pytorch/test/ivalue_import/prim.py
@@ -18,7 +18,7 @@ class TestModule(torch.nn.Module):
         self.t2 = torch.ones(1)
 
     # CHECK-LABEL:   func private @__torch__.TestModule.forward(
-    # CHECK-SAME:         %[[SELF:.*]]: !torch.nn.Module<"{{.*}}">) -> !basicpy.NoneType {
+    # CHECK-SAME:         %[[SELF:.*]]: !torch.nn.Module<"{{.*}}">) -> !torch.none {
     def forward(self):
         # CHECK: %[[T2:.*]] = torch.prim.GetAttr %[[SELF]]["t2"]
         # CHECK: torch.prim.SetAttr %[[SELF]]["t1"] = %[[T2]]

--- a/frontends/pytorch/test/node_import/function-derefine.py
+++ b/frontends/pytorch/test/node_import/function-derefine.py
@@ -21,17 +21,17 @@ def optional_return(i: int) -> typing.Optional[int]:
     return i
 
 # CHECK-LABEL:   func @__torch__.optional_arg(
-# CHECK-SAME:                                      %[[ARG:.*]]: !torch.optional<i64>) -> !basicpy.NoneType {
+# CHECK-SAME:                                      %[[ARG:.*]]: !torch.optional<i64>) -> !torch.none {
 @mb.import_function
 @torch.jit.script
 def optional_arg(i: typing.Optional[int]) -> None:
     return
 
 # CHECK-LABEL:   func @__torch__.calls_optional_arg(
-# CHECK-SAME:                                       %[[ARG:.*]]: i64) -> !basicpy.NoneType {
-# CHECK:           %[[CALLEE:.*]] = constant @__torch__.optional_arg : (!torch.optional<i64>) -> !basicpy.NoneType
+# CHECK-SAME:                                       %[[ARG:.*]]: i64) -> !torch.none {
+# CHECK:           %[[CALLEE:.*]] = constant @__torch__.optional_arg : (!torch.optional<i64>) -> !torch.none
 # CHECK:           %[[DEREFINED:.*]] = torch.derefine %[[ARG]] : i64 to !torch.optional<i64>
-# CHECK:           %{{.*}} = call_indirect %[[CALLEE]](%[[DEREFINED]]) : (!torch.optional<i64>) -> !basicpy.NoneType
+# CHECK:           %{{.*}} = call_indirect %[[CALLEE]](%[[DEREFINED]]) : (!torch.optional<i64>) -> !torch.none
 @mb.import_function
 @torch.jit.script
 def calls_optional_arg(i: int):

--- a/frontends/pytorch/test/node_import/if.py
+++ b/frontends/pytorch/test/node_import/if.py
@@ -33,10 +33,10 @@ def prim_If(b: bool, i: int):
 # CHECK-LABEL:   func @__torch__.prim_If_derefine(
 # CHECK-SAME:                           %[[B:.*]]: !basicpy.BoolType,
 # CHECK-SAME:                           %[[I:.*]]: i64) -> !torch.optional<i64> {
-# CHECK:           %[[NONE:.*]] = basicpy.singleton : !basicpy.NoneType
+# CHECK:           %[[NONE:.*]] = torch.constant.none
 # CHECK:           %[[PRED:.*]] = basicpy.bool_cast %[[B]] : !basicpy.BoolType -> i1
 # CHECK:           %[[RES:.*]] = scf.if %[[PRED]] -> (!torch.optional<i64>) {
-# CHECK:             %[[NONE_DEREFINED:.*]] = torch.derefine %[[NONE]] : !basicpy.NoneType to !torch.optional<i64>
+# CHECK:             %[[NONE_DEREFINED:.*]] = torch.derefine %[[NONE]] : !torch.none to !torch.optional<i64>
 # CHECK:             scf.yield %[[NONE_DEREFINED]] : !torch.optional<i64>
 # CHECK:           } else {
 # CHECK:             %[[I_DEREFINED:.*]] = torch.derefine %[[I]] : i64 to !torch.optional<i64>

--- a/frontends/pytorch/test/node_import/loop.py
+++ b/frontends/pytorch/test/node_import/loop.py
@@ -52,8 +52,8 @@ def prim_Loop_whilelike(n: int):
 # CHECK-LABEL:   func @__torch__.prim_Loop_derefine(
 # CHECK-SAME:                             %[[ARG:.*]]: i64) -> !torch.optional<i64> {
 # CHECK:           %[[TRUE:.*]] = basicpy.bool_constant true
-# CHECK:           %[[NONE:.*]] = basicpy.singleton : !basicpy.NoneType
-# CHECK:           %[[NONE_DEREFINED:.*]] = torch.derefine %[[NONE]] : !basicpy.NoneType to !torch.optional<i64>
+# CHECK:           %[[NONE:.*]] = torch.constant.none
+# CHECK:           %[[NONE_DEREFINED:.*]] = torch.derefine %[[NONE]] : !torch.none to !torch.optional<i64>
 # CHECK:           %[[RET:.*]] = torch.prim.Loop %[[ARG]], %[[TRUE]], init(%[[NONE_DEREFINED]])  {
 # CHECK:           ^bb0(%[[IV:.*]]: i64, %[[X_ITER:.*]]: !torch.optional<i64>):
 # CHECK:             %[[X_NEXT:.*]] = torch.derefine %[[ARG]] : i64 to !torch.optional<i64>

--- a/frontends/pytorch/test/node_import/prim.py
+++ b/frontends/pytorch/test/node_import/prim.py
@@ -26,7 +26,7 @@ def prim_NumToTensor(i: int):
     return _to_tensor(i)
 
 # CHECK-LABEL:   func @__torch__.prim_Print(
-# CHECK-SAME:                     %[[ARG:.*]]: !torch.tensor) -> !basicpy.NoneType {
+# CHECK-SAME:                     %[[ARG:.*]]: !torch.tensor) -> !torch.none {
 # CHECK:           %[[STR:.*]] = basicpy.bytes_constant "x"
 # CHECK:           torch.prim.Print(%[[STR]], %[[ARG]]) : !basicpy.BytesType, !torch.tensor
 @mb.import_function
@@ -34,11 +34,11 @@ def prim_NumToTensor(i: int):
 def prim_Print(x):
     print("x", x)
 
-# CHECK-LABEL:   func @__torch__.prim_RaiseException() -> !basicpy.NoneType {
+# CHECK-LABEL:   func @__torch__.prim_RaiseException() -> !torch.none {
 # CHECK:           %[[ERRORSTR:.*]] = basicpy.bytes_constant "Error"
-# CHECK:           %[[NONE:.*]] = torch.prim.Uninitialized : !basicpy.NoneType
+# CHECK:           %[[NONE:.*]] = torch.prim.Uninitialized : !torch.none
 # CHECK:           torch.prim.RaiseException %[[ERRORSTR]]
-# CHECK:           return %[[NONE]] : !basicpy.NoneType
+# CHECK:           return %[[NONE]] : !torch.none
 @mb.import_function
 @torch.jit.script
 def prim_RaiseException():
@@ -46,9 +46,9 @@ def prim_RaiseException():
 
 # CHECK-LABEL:   func @__torch__.prim_unchecked_cast(
 # CHECK-SAME:                              %[[ARG:.*]]: !torch.optional<i64>) -> i64 {
-# CHECK:           %[[NONE:.*]] = basicpy.singleton : !basicpy.NoneType
+# CHECK:           %[[NONE:.*]] = torch.constant.none
 # CHECK:           %[[C3:.*]] = constant 3 : i64
-# CHECK:           %[[IS_NONE:.*]] = torch.aten.__is__ %[[ARG]], %[[NONE]] : !torch.optional<i64>, !basicpy.NoneType -> !basicpy.BoolType
+# CHECK:           %[[IS_NONE:.*]] = torch.aten.__is__ %[[ARG]], %[[NONE]] : !torch.optional<i64>, !torch.none -> !basicpy.BoolType
 # CHECK:           %[[COND:.*]] = basicpy.bool_cast %[[IS_NONE]] : !basicpy.BoolType -> i1
 # CHECK:           %[[RESULT:.*]] = scf.if %[[COND]] -> (i64) {
 # CHECK:             scf.yield %[[C3]] : i64

--- a/frontends/pytorch/test/node_import/types-none.py
+++ b/frontends/pytorch/test/node_import/types-none.py
@@ -13,7 +13,7 @@ mb = torch_mlir.ModuleBuilder()
 @mb.import_function
 @torch.jit.script
 def returns_none():
-    # CHECK-NEXT: %[[NONE:.*]] = basicpy.singleton : !basicpy.NoneType
+    # CHECK-NEXT: %[[NONE:.*]] = torch.constant.none
     # CHECK-NEXT: return %[[NONE]]
     pass
 

--- a/include/npcomp-c/Types.h
+++ b/include/npcomp-c/Types.h
@@ -89,14 +89,14 @@ MlirType npcompNdArrayTypeGetFromShaped(MlirType shapedType);
 MlirType npcompNdArrayTypeToTensor(MlirType ndarrayType);
 
 /*============================================================================*/
-/* None type.                                                                 */
+/* !basicpy.NoneType type.                                                    */
 /*============================================================================*/
 
-/** Checks whether the given type is the type of the singleton 'None' value. */
-int npcompTypeIsANone(MlirType t);
+/** Checks whether the given type is a `!basicpy.NoneType`. */
+int npcompTypeIsABasicpyNone(MlirType t);
 
-/** Gets the type of the singleton 'None'. */
-MlirType npcompNoneTypeGet(MlirContext context);
+/** Gets the `!basicpy.NoneType` type. */
+MlirType npcompBasicpyNoneTypeGet(MlirContext context);
 
 /*============================================================================*/
 /* SlotObject type.                                                           */
@@ -228,6 +228,16 @@ npcompValueTensorTypeGetWithLeastStaticInformation(MlirContext context);
 
 /** Gets a !torch.tensor type, taking shape/dtype from a ShapedType `type`. */
 MlirType npcompValueTensorTypeGetFromShaped(MlirType type);
+
+/*============================================================================*/
+/* !torch.none type.                                                          */
+/*============================================================================*/
+
+/** Checks whether the given type is a !torch.none type */
+int npcompTypeIsATorchNone(MlirType t);
+
+/** Gets the !torch.none type. */
+MlirType npcompTorchNoneTypeGet(MlirContext context);
 
 #ifdef __cplusplus
 }

--- a/include/npcomp/Dialect/Torch/IR/TorchOps.td
+++ b/include/npcomp/Dialect/Torch/IR/TorchOps.td
@@ -688,5 +688,17 @@ def Torch_FromBuiltinTensorOp : Torch_Op<"from_builtin_tensor", [
   }];
 }
 
+def Torch_ConstantNoneOp : Torch_Op<"constant.none",
+    [ConstantLike, NoSideEffect]> {
+  let summary = "Get the singleton None value.";
+  let description = [{
+    Not to be confused with the `mlir::NoneType`. Be careful to use
+    `Torch::NoneType` to avoid namespace ambiguity.
+  }];
+  let arguments = (ins);
+  let results = (outs Torch_NoneType:$result);
+  let assemblyFormat = "attr-dict";
+  let hasFolder = 1;
+}
 
 #endif // TORCH_OPS

--- a/include/npcomp/Dialect/Torch/IR/TorchTypes.td
+++ b/include/npcomp/Dialect/Torch/IR/TorchTypes.td
@@ -236,6 +236,13 @@ def Torch_DeviceType : Torch_Type<"Device", "Device"> {
   let summary = "Torch device";
 }
 
+def Torch_NoneType : Torch_Type<"None", "none"> {
+  let summary = "Torch NoneType";
+  let description = [{
+    The singleton "None" type.
+  }];
+}
+
 def Torch_QInt8Type : Torch_Type<"QInt8", "qint8"> {
   let summary = "Type modeling `ScalarType::QInt8`";
   let description = [{
@@ -274,7 +281,7 @@ def Torch_LinearParamsType : Torch_Type<"LinearParams", "LinearParams"> {
 def AnyTorchOptionalTensor : AnyTypeOf<[
   AnyTorchTensorType,
   Torch_OptionalType,
-  Basicpy_NoneType,
+  Torch_NoneType,
 ], "optional torch tensor">;
 
 def AnyTorchScalarType : AnyTypeOf<[
@@ -282,7 +289,7 @@ def AnyTorchScalarType : AnyTypeOf<[
     AnyFloat,
     Basicpy_BoolType,
     Basicpy_StrType,
-    Basicpy_NoneType,
+    Torch_NoneType,
     // Allow signless integers for ease of conversions. In general, this
     // dialect uses signed integers.
     AnySignlessInteger,
@@ -323,9 +330,9 @@ def AnyTorchType : AnyTypeOf<[
     AnyTorchScalarType,
     AnyTorchTensorType,
     Basicpy_TupleType,
-    Basicpy_NoneType,
     Basicpy_BytesType,
     Torch_NnModuleType,
+    Torch_NoneType,
     Torch_OptionalType,
     Torch_ListType,
     Torch_DeviceType,

--- a/lib/CAPI/Types.cpp
+++ b/lib/CAPI/Types.cpp
@@ -104,14 +104,14 @@ MlirType npcompNdArrayTypeToTensor(MlirType ndarrayType) {
 }
 
 /*============================================================================*/
-/* None type.                                                                 */
+/* !basicpy.NoneType type.                                                    */
 /*============================================================================*/
 
-/** Checks whether the given type is the type of the singleton 'None' value. */
+/** Checks whether the given type is a `!basicpy.NoneType`. */
 int npcompTypeIsANone(MlirType t) { return unwrap(t).isa<Basicpy::NoneType>(); }
 
-/** Gets the type of the singleton 'None'. */
-MlirType npcompNoneTypeGet(MlirContext context) {
+/** Gets the `!basicpy.NoneType` type. */
+MlirType npcompBasicpyNoneTypeGet(MlirContext context) {
   return wrap(Basicpy::NoneType::get(unwrap(context)));
 }
 
@@ -286,4 +286,18 @@ npcompValueTensorTypeGetWithLeastStaticInformation(MlirContext context) {
 MlirType npcompValueTensorTypeGetFromShaped(MlirType type) {
   return wrap(
       Torch::ValueTensorType::getFromShaped(unwrap(type).cast<ShapedType>()));
+}
+
+/*============================================================================*/
+/* torch.none type.                                                           */
+/*============================================================================*/
+
+/** Checks whether the given type is a !torch.none type */
+int npcompTypeIsATorchNone(MlirType t) {
+  return unwrap(t).isa<Torch::NoneType>();
+}
+
+/** Gets the !torch.none type. */
+MlirType npcompTorchNoneTypeGet(MlirContext context) {
+  return wrap(Torch::NoneType::get(unwrap(context)));
 }

--- a/lib/Dialect/Torch/IR/TorchDialect.cpp
+++ b/lib/Dialect/Torch/IR/TorchDialect.cpp
@@ -140,5 +140,9 @@ Operation *TorchDialect::materializeConstant(OpBuilder &builder,
     if (integerType.getWidth() == 64)
       return builder.create<ConstantOp>(loc, value);
   }
+
+  if (type.isa<Torch::NoneType>())
+    return builder.create<ConstantNoneOp>(loc);
+
   return nullptr;
 }

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -93,7 +93,7 @@ bool isValidSubtype(Type subtype, Type type) {
     return true;
   if (auto optional = type.dyn_cast<OptionalType>())
     return subtype == optional.getContainedType() ||
-           subtype.isa<Basicpy::NoneType>();
+           subtype.isa<Torch::NoneType>();
   // TODO: This is not subtyping according to PEP 483. See description
   // of NonValueTensorType.
   if (subtype.isa<NonValueTensorType>() && type.isa<NonValueTensorType>() &&
@@ -234,11 +234,11 @@ OpFoldResult Aten__Is__Op::fold(ArrayRef<Attribute> operands) {
   auto lhsType = self().getType();
   auto rhsType = obj().getType();
   // If either type is a NoneType, make it be the lhsType.
-  if (rhsType.isa<Basicpy::NoneType>())
+  if (rhsType.isa<Torch::NoneType>())
     std::swap(lhsType, rhsType);
   // TODO: Implement and use subtype infra for this.
   // If neither type is a subtype of the other, then the result is false.
-  if (lhsType.isa<Basicpy::NoneType>() && !rhsType.isa<Torch::OptionalType>())
+  if (lhsType.isa<Torch::NoneType>() && !rhsType.isa<Torch::OptionalType>())
     return IntegerAttr::get(IntegerType::get(getContext(), 1), 0);
   return nullptr;
 }
@@ -439,6 +439,14 @@ LogicalResult FromBuiltinTensorOp::inferReturnTypes(
   inferredReturnTypes.push_back(
       ValueTensorType::getFromShaped(operands[0].getType().cast<TensorType>()));
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// ConstantNoneOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult ConstantNoneOp::fold(ArrayRef<Attribute> operands) {
+  return TypeAttr::get(Torch::NoneType::get(getContext()));
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Torch/Transforms/GlobalizeObjectGraph.cpp
+++ b/lib/Dialect/Torch/Transforms/GlobalizeObjectGraph.cpp
@@ -48,7 +48,7 @@ static FailureOr<NnModuleOp> findRootNnModule(ModuleOp module) {
 
 static bool hasMeaningfulObjectIdentity(Type type) {
   return !type.isa<IntegerType, FloatType, Basicpy::BoolType,
-                   Basicpy::BytesType, Basicpy::NoneType, TensorType>();
+                   Basicpy::BytesType, Torch::NoneType, TensorType>();
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/Dialect/Torch/GlobalizeObjectGraph/module-uses.mlir
+++ b/test/Dialect/Torch/GlobalizeObjectGraph/module-uses.mlir
@@ -22,20 +22,20 @@ func private @get_attr_returns_module_type(%arg0: !torch.nn.Module<"parent">) ->
 }
 
 // CHECK-LABEL:   func @module_type_argument(
-// CHECK-SAME:                               %[[F:.*]]: f64) -> !basicpy.NoneType {
-func private @module_type_argument(%arg0: !torch.nn.Module<"parent">, %arg1: !torch.nn.Module<"parent">, %arg2: f64, %arg3: !torch.nn.Module<"parent">) -> !basicpy.NoneType {
-  %0 = basicpy.singleton : !basicpy.NoneType
-  return %0 : !basicpy.NoneType
+// CHECK-SAME:                               %[[F:.*]]: f64) -> !torch.none {
+func private @module_type_argument(%arg0: !torch.nn.Module<"parent">, %arg1: !torch.nn.Module<"parent">, %arg2: f64, %arg3: !torch.nn.Module<"parent">) -> !torch.none {
+  %0 = torch.constant.none
+  return %0 : !torch.none
 }
 
-// CHECK-LABEL:   func @method_call() -> !basicpy.NoneType {
-func private @method_call(%arg0: !torch.nn.Module<"parent">) -> !basicpy.NoneType {
+// CHECK-LABEL:   func @method_call() -> !torch.none {
+func private @method_call(%arg0: !torch.nn.Module<"parent">) -> !torch.none {
   // CHECK-NEXT: %[[C:.*]] = constant 4.300000e+01 : f64
   %c = constant 43.0 : f64
-  // CHECK-NEXT: %[[F:.*]] = call @module_type_argument(%[[C]]) : (f64) -> !basicpy.NoneType
-  %0 = call @module_type_argument(%arg0, %arg0, %c, %arg0) : (!torch.nn.Module<"parent">, !torch.nn.Module<"parent">, f64, !torch.nn.Module<"parent">) -> (!basicpy.NoneType)
-  // CHECK-NEXT: return %[[F]] : !basicpy.NoneType
-  return %0 : !basicpy.NoneType
+  // CHECK-NEXT: %[[F:.*]] = call @module_type_argument(%[[C]]) : (f64) -> !torch.none
+  %0 = call @module_type_argument(%arg0, %arg0, %c, %arg0) : (!torch.nn.Module<"parent">, !torch.nn.Module<"parent">, f64, !torch.nn.Module<"parent">) -> (!torch.none)
+  // CHECK-NEXT: return %[[F]] : !torch.none
+  return %0 : !torch.none
 }
 
 %c42 = constant 42.0 : f64

--- a/test/Dialect/Torch/GlobalizeObjectGraph/multiple-instances-error.mlir
+++ b/test/Dialect/Torch/GlobalizeObjectGraph/multiple-instances-error.mlir
@@ -16,7 +16,7 @@ torch.class_type @__torch__.TestModule  {
   torch.method "forward", @__torch__.TestModule.forward
 }
 %bool_true = basicpy.bool_constant true
-%0 = basicpy.singleton : !basicpy.NoneType
+%0 = torch.constant.none
 torch.class_type @__torch__.Submodule  {
   torch.attr private "n" : i64
   // expected-error @+1 {{public function with multiple monomorphizations}}

--- a/test/Dialect/Torch/adjust-calling-conventions.mlir
+++ b/test/Dialect/Torch/adjust-calling-conventions.mlir
@@ -30,20 +30,20 @@ func @call(%arg0: !torch.tensor {torch.type_bound = !torch.vtensor<[2,3,?],f32>}
 }
 
 // CHECK-LABEL:   func @none_return() {
-// CHECK:           %[[NONE:.*]] = basicpy.singleton : !basicpy.NoneType
+// CHECK:           %[[NONE:.*]] = torch.constant.none
 // CHECK:           return
-func @none_return() -> !basicpy.NoneType {
-  %1 = basicpy.singleton : !basicpy.NoneType
-  return %1 : !basicpy.NoneType
+func @none_return() -> !torch.none {
+  %1 = torch.constant.none
+  return %1 : !torch.none
 }
 
 // CHECK-LABEL:   func @none_call_return() {
 // CHECK:           call @none_return() : () -> ()
-// CHECK:           %[[NONE:.*]] = basicpy.singleton : !basicpy.NoneType
-// CHECK:           "test.use"(%[[NONE]]) : (!basicpy.NoneType) -> ()
+// CHECK:           %[[NONE:.*]] = torch.constant.none
+// CHECK:           "test.use"(%[[NONE]]) : (!torch.none) -> ()
 // CHECK:           return
 func @none_call_return() {
-  %0 = call @none_return() : () -> !basicpy.NoneType
-  "test.use"(%0) : (!basicpy.NoneType) -> ()
+  %0 = call @none_return() : () -> !torch.none
+  "test.use"(%0) : (!torch.none) -> ()
   return
 }

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -3,8 +3,8 @@
 // CHECK-LABEL:   func @torch.aten.__is__
 // CHECK:           %[[FALSE:.*]] = basicpy.bool_constant false
 // CHECK:           return %[[FALSE]] : !basicpy.BoolType
-func @torch.aten.__is__(%arg0: !torch.list<i64>, %arg1: !basicpy.NoneType) -> !basicpy.BoolType{
-  %0 = torch.aten.__is__ %arg0, %arg1 : !torch.list<i64>, !basicpy.NoneType -> !basicpy.BoolType
+func @torch.aten.__is__(%arg0: !torch.list<i64>, %arg1: !torch.none) -> !basicpy.BoolType{
+  %0 = torch.aten.__is__ %arg0, %arg1 : !torch.list<i64>, !torch.none -> !basicpy.BoolType
   return %0 : !basicpy.BoolType
 }
 
@@ -112,4 +112,13 @@ func @torch.aten.__getitem__.t$no_change_test1(%arg0: !torch.list<i64>) -> i64 {
   %c5_i64 = constant 5 : i64
   %0 = torch.aten.__getitem__.t %arg0, %c5_i64 : !torch.list<i64>, i64 -> i64
   return %0 : i64
+}
+
+// CHECK-LABEL:   func @torch.constant.none$constantlike() -> (!torch.none, !torch.none) {
+// CHECK:           %[[C:.*]] = torch.constant.none
+// CHECK:           return %[[C]], %[[C]] : !torch.none, !torch.none
+func @torch.constant.none$constantlike() -> (!torch.none, !torch.none) {
+  %0 = torch.constant.none
+  %1 = torch.constant.none
+  return %0, %1 : !torch.none, !torch.none
 }

--- a/test/Dialect/Torch/ops.mlir
+++ b/test/Dialect/Torch/ops.mlir
@@ -59,7 +59,7 @@ func @derefine(%arg0: !torch.tensor) -> !torch.optional<!torch.tensor> {
 %num3_i64 = basicpy.numeric_constant 3 : i64
 %num = basicpy.numeric_constant 4.250000e+01 : f64
 %tensor = torch.tensor(dense<1.000000e+00> : tensor<1xf32>) : !torch.tensor
-%none = basicpy.singleton : !basicpy.NoneType
+%none = torch.constant.none
 func private @f(%arg0: !torch.nn.Module<"test">) {
   return
 }
@@ -82,5 +82,5 @@ torch.nn_module {
   torch.slot "f", %num : f64
   torch.slot "t", %tensor : !torch.tensor
   torch.slot "submodule", %submodule : !torch.nn.Module<"empty">
-  torch.slot "ob", %none : !basicpy.NoneType
+  torch.slot "ob", %none : !torch.none
 } : !torch.nn.Module<"test">


### PR DESCRIPTION
- Add `torch.constant.none` op to construct it (naming is chosen to be
  analogous to Torch's representation of a prim::Constant with
  NoneType, rather than using the "singleton" terminology of Basicpy).