### PR TITLE
Add `torch.prim.If`

### DIFF
--- a/frontends/pytorch/python/torch_mlir_utils/codegen/torch_ods_gen.py
+++ b/frontends/pytorch/python/torch_mlir_utils/codegen/torch_ods_gen.py
@@ -444,8 +444,8 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::size : (Tensor) -> (int[])", has_canonicalizer=True)
 
         # Primitive ops
-        emit("aten::gt.int : (int, int) -> (bool)")
-        emit("aten::ne.int : (int, int) -> (bool)")
+        emit("aten::gt.int : (int, int) -> (bool)", has_folder=True)
+        emit("aten::ne.int : (int, int) -> (bool)", has_folder=True)
         emit("aten::add.int : (int, int) -> (int)")
         emit("aten::mul.int : (int, int) -> (int)")
         emit("aten::add.float_int : (float, int) -> (float)")

--- a/frontends/pytorch/test/ivalue_import/submodules-select.py
+++ b/frontends/pytorch/test/ivalue_import/submodules-select.py
@@ -27,7 +27,7 @@ class TestModule(torch.nn.Module):
     # CHECK-LABEL: func private @{{.*}}TestModule.forward
     def forward(self, b: bool):
         # Modules with the same class can be selected between.
-        # CHECK: %[[MOD:.*]] = scf.if
+        # CHECK: %[[MOD:.*]] = torch.prim.If
         s = self.s1 if b else self.s2
         # CHECK: %[[N:.*]] = torch.prim.CallMethod %[[MOD]]["forward"] ()
         # CHECK: return %[[N]]

--- a/frontends/pytorch/test/node_import/elif.py
+++ b/frontends/pytorch/test/node_import/elif.py
@@ -13,10 +13,10 @@ mb = torch_mlir.ModuleBuilder()
 @mb.import_function
 @torch.jit.script
 def f(b: bool, i: int):
-    # elif is modeled as a nested if
-    # CHECK: scf.if{{.*}}{
+    # elif is modeled as a nested if, so we only need to do cursory checking.
+    # CHECK: torch.prim.If {{.*}} {
     # CHECK: } else {
-    # CHECK:   scf.if{{.*}}{
+    # CHECK:   torch.prim.If {{.*}} {
     # CHECK:   } else {
     # CHECK:   }
     # CHECK: }

--- a/frontends/pytorch/test/node_import/if.py
+++ b/frontends/pytorch/test/node_import/if.py
@@ -9,38 +9,39 @@ import torch_mlir
 
 mb = torch_mlir.ModuleBuilder()
 
+# Note: The "if without else" case is handled by yielding None from the
+# else branch and making all defined values optional, so no special handling
+# is needed.
+
 # CHECK-LABEL: @__torch__.prim_If(
 # CHECK-SAME:           %[[B:.*]]: !torch.bool,
 # CHECK-SAME:           %[[I:.*]]: i64) -> i64 {
 @mb.import_function
 @torch.jit.script
 def prim_If(b: bool, i: int):
-    # CHECK:           %[[I1:.*]] = torch.to_i1 %[[B]]
-    # CHECK:           %[[RES:.*]] = scf.if %[[I1]] -> (i64) {
+    # CHECK:           %[[RES:.*]] = torch.prim.If %[[B]] -> (i64) {
     # CHECK:             %[[ADD:.*]] = torch.aten.add.int %[[I]], %[[I]]
-    # CHECK:             scf.yield %[[ADD]] : i64
+    # CHECK:             torch.prim.If.yield %[[ADD]] : i64
     # CHECK:           } else {
     # CHECK:             %[[MUL:.*]] = torch.aten.mul.int %[[I]], %[[I]]
-    # CHECK:             scf.yield %[[MUL]] : i64
+    # CHECK:             torch.prim.If.yield %[[MUL]] : i64
     # CHECK:           }
     # CHECK:           return %[[RES:.*]] : i64
     if b:
         return i + i
     else:
         return i * i
-    # elif is modeled as a nested if, so no need to specially test it here.
 
 # CHECK-LABEL:   func @__torch__.prim_If_derefine(
 # CHECK-SAME:                           %[[B:.*]]: !torch.bool,
 # CHECK-SAME:                           %[[I:.*]]: i64) -> !torch.optional<i64> {
 # CHECK:           %[[NONE:.*]] = torch.constant.none
-# CHECK:           %[[PRED:.*]] = torch.to_i1 %[[B]]
-# CHECK:           %[[RES:.*]] = scf.if %[[PRED]] -> (!torch.optional<i64>) {
+# CHECK:           %[[RES:.*]] = torch.prim.If %[[B]] -> (!torch.optional<i64>) {
 # CHECK:             %[[NONE_DEREFINED:.*]] = torch.derefine %[[NONE]] : !torch.none to !torch.optional<i64>
-# CHECK:             scf.yield %[[NONE_DEREFINED]] : !torch.optional<i64>
+# CHECK:             torch.prim.If.yield %[[NONE_DEREFINED]] : !torch.optional<i64>
 # CHECK:           } else {
 # CHECK:             %[[I_DEREFINED:.*]] = torch.derefine %[[I]] : i64 to !torch.optional<i64>
-# CHECK:             scf.yield %[[I_DEREFINED]] : !torch.optional<i64>
+# CHECK:             torch.prim.If.yield %[[I_DEREFINED]] : !torch.optional<i64>
 # CHECK:           }
 # CHECK:           return %[[RES:.*]] : !torch.optional<i64>
 @mb.import_function

--- a/frontends/pytorch/test/node_import/prim.py
+++ b/frontends/pytorch/test/node_import/prim.py
@@ -49,12 +49,11 @@ def prim_RaiseException():
 # CHECK:           %[[NONE:.*]] = torch.constant.none
 # CHECK:           %[[C3:.*]] = torch.constant.int 3 : i64
 # CHECK:           %[[IS_NONE:.*]] = torch.aten.__is__ %[[ARG]], %[[NONE]] : !torch.optional<i64>, !torch.none -> !torch.bool
-# CHECK:           %[[COND:.*]] = torch.to_i1 %[[IS_NONE]]
-# CHECK:           %[[RESULT:.*]] = scf.if %[[COND]] -> (i64) {
-# CHECK:             scf.yield %[[C3]] : i64
+# CHECK:           %[[RESULT:.*]] = torch.prim.If %[[IS_NONE]] -> (i64) {
+# CHECK:             torch.prim.If.yield %[[C3]] : i64
 # CHECK:           } else {
 # CHECK:             %[[CASTED:.*]] = torch.prim.unchecked_cast %[[ARG]] : !torch.optional<i64> -> i64
-# CHECK:             scf.yield %[[CASTED]] : i64
+# CHECK:             torch.prim.If.yield %[[CASTED]] : i64
 # CHECK:           }
 # CHECK:           return %[[RESULT:.*]] : i64
 @mb.import_function

--- a/include/npcomp/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/npcomp/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -268,6 +268,7 @@ def Torch_AtenGtIntOp : Torch_Op<"aten.gt.int", [
     Torch_BoolType:$result
   );
   let assemblyFormat = "$a `,` $b attr-dict `:` type($a) `,` type($b) `->` type($result)";
+  let hasFolder = 1;
 }
 
 def Torch_AtenNeIntOp : Torch_Op<"aten.ne.int", [
@@ -283,6 +284,7 @@ def Torch_AtenNeIntOp : Torch_Op<"aten.ne.int", [
     Torch_BoolType:$result
   );
   let assemblyFormat = "$a `,` $b attr-dict `:` type($a) `,` type($b) `->` type($result)";
+  let hasFolder = 1;
 }
 
 def Torch_AtenAddIntOp : Torch_Op<"aten.add.int", [

--- a/include/npcomp/Dialect/Torch/IR/TorchOps.td
+++ b/include/npcomp/Dialect/Torch/IR/TorchOps.td
@@ -453,6 +453,51 @@ def Torch_PrimLoopConditionOp : Torch_Op<"prim.Loop.condition", [
   }];
 }
 
+def Torch_PrimIfOp : Torch_Op<"prim.If", [
+  DeclareOpInterfaceMethods<RegionBranchOpInterface>]> {
+  let summary = "TorchScript prim::If op";
+  let description = [{
+    This op (together with prim.If.yield) define a conditional control flow
+    construct. It is analogous to `scf.if` for MLIR folks that are familiar
+    with that. The main differences from that op are:
+
+    - `!torch.bool` condition value.
+    - The "else" region is always present. This is reflective of invariants of
+      the TorchScript IR.
+    - No special prettiness for the "no yielded values" case. These are
+      interesting for modeling mostly-non-SSA programs, but TorchScript IR
+      is already in SSA form.
+
+    See: https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/OVERVIEW.md#if
+  }];
+
+  let arguments = (ins Torch_BoolType:$condition);
+  let results = (outs Variadic<AnyTorchType>:$results);
+  let regions = (region SizedRegion<1>:$thenRegion, SizedRegion<1>:$elseRegion);
+  let printer = [{ return ::print(p, *this); }];
+  let parser = [{ return ::parsePrimIfOp(parser, result); }];
+  let verifier = [{ return RegionBranchOpInterface::verifyTypes(*this); }];
+  let hasCanonicalizer = 1;
+}
+
+def Torch_PrimIfYieldOp : Torch_Op<"prim.If.yield", [
+    Terminator,
+    HasParent<"::mlir::NPCOMP::Torch::PrimIfOp">]> {
+  let summary = "yield-like terminator for torch.prim.If";
+  let description = [{
+    Does not correspond to any torch prim op directly (the way that they model
+    blocks has a built-in notion of yield-like terminator).
+  }];
+
+  let arguments = (ins
+    Variadic<AnyTorchType>:$results
+  );
+  let results = (outs);
+
+  let assemblyFormat = [{
+    attr-dict ($results^ `:` type($results))?
+  }];
+}
 
 //===----------------------------------------------------------------------===//
 // Ops corresponding to prim::Constant

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -412,6 +412,36 @@ void AtenSizeOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 }
 
 //===----------------------------------------------------------------------===//
+// AtenGtIntOp
+//===----------------------------------------------------------------------===//
+
+static IntegerAttr getI1IntegerAttr(MLIRContext *context, bool value) {
+  return IntegerAttr::get(IntegerType::get(context, 1),
+                          static_cast<int64_t>(value));
+}
+
+OpFoldResult AtenGtIntOp::fold(ArrayRef<Attribute> operands) {
+  auto lhs = operands[0].dyn_cast_or_null<IntegerAttr>();
+  auto rhs = operands[1].dyn_cast_or_null<IntegerAttr>();
+  if (lhs && rhs) {
+    if (lhs.getValue().getSExtValue() > rhs.getValue().getSExtValue())
+      return getI1IntegerAttr(getContext(), true);
+  }
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// AtenNeIntOp
+//===----------------------------------------------------------------------===//
+
+OpFoldResult AtenNeIntOp::fold(ArrayRef<Attribute> operands) {
+  // `torch.aten.ne.int %x, %x` -> `false`
+  if (getOperand(0) == getOperand(1))
+    return getI1IntegerAttr(getContext(), false);
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
 // TensorOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -30,6 +30,25 @@ func @torch.aten.size$unknown_size(%arg0: !torch.vtensor<[?,3],f32>) -> !torch.l
   return %0 : !torch.list<i64>
 }
 
+// CHECK-LABEL:   func @torch.aten.gt.int$evaluate() -> !torch.bool {
+// CHECK-NEXT:       %[[T:.*]] = torch.constant.bool true
+// CHECK-NEXT:       return %[[T]] : !torch.bool
+func @torch.aten.gt.int$evaluate() -> !torch.bool {
+  %int2 = torch.constant.int 2
+  %int4 = torch.constant.int 4
+  %0 = torch.aten.gt.int %int4, %int2 : i64, i64 -> !torch.bool
+  return %0 : !torch.bool
+}
+
+// CHECK-LABEL:   func @torch.aten.ne.int$same_value(
+// CHECK-SAME:                                       %{{.*}}: i64) -> !torch.bool {
+// CHECK-NEXT:       %[[F:.*]] = torch.constant.bool false
+// CHECK-NEXT:       return %[[F]] : !torch.bool
+func @torch.aten.ne.int$same_value(%arg0: i64) -> !torch.bool {
+  %0 = torch.aten.ne.int %arg0, %arg0 : i64, i64 -> !torch.bool
+  return %0 : !torch.bool
+}
+
 // CHECK-LABEL:   func @torch.aten.len.t$of_size(
 // CHECK-SAME:                                   %[[ARG:.*]]: !torch.vtensor<*,f32>) -> i64 {
 // CHECK:           %[[DIM:.*]] = torch.aten.dim %[[ARG]] : !torch.vtensor<*,f32> -> i64

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -144,3 +144,19 @@ func @torch.constant.bool$constantlike() -> (!torch.bool, !torch.bool, !torch.bo
   %2 = torch.constant.bool false
   return %0, %1, %2 : !torch.bool, !torch.bool, !torch.bool
 }
+
+// CHECK-LABEL:   func @torch.prim.If$erase_dead_branch(
+// CHECK-SAME:                                          %[[ARG:.*]]: i64) -> i64 {
+// CHECK-NEXT:       %[[RET:.*]] = torch.aten.add.int %[[ARG]], %[[ARG]] : i64, i64 -> i64
+// CHECK-NEXT:       return %[[RET]] : i64
+func @torch.prim.If$erase_dead_branch(%arg0: i64) -> i64 {
+  %true = torch.constant.bool true
+  %0 = torch.prim.If %true -> (i64) {
+    %1 = torch.aten.add.int %arg0, %arg0 : i64, i64 -> i64
+    torch.prim.If.yield %1 : i64
+  } else {
+    %1 = torch.aten.mul.int %arg0, %arg0 : i64, i64 -> i64
+    torch.prim.If.yield %1 : i64
+  }
+  return %0 : i64
+}

--- a/test/Dialect/Torch/ops.mlir
+++ b/test/Dialect/Torch/ops.mlir
@@ -62,6 +62,17 @@ func @derefine(%arg0: !torch.tensor) -> !torch.optional<!torch.tensor> {
   return %0 : !torch.optional<!torch.tensor>
 }
 
+func @torch.prim.If(%arg0: !torch.bool, %arg1: i64) -> i64 {
+  %0 = torch.prim.If %arg0 -> (i64) {
+    %1 = torch.aten.add.int %arg1, %arg1 : i64, i64 -> i64
+    torch.prim.If.yield %1 : i64
+  } else {
+    %1 = torch.aten.mul.int %arg1, %arg1 : i64, i64 -> i64
+    torch.prim.If.yield %1 : i64
+  }
+  return %0 : i64
+}
+
 // CHECK: %true = torch.constant.bool true
 %true = torch.constant.bool true
 // CHECK: %false = torch.constant.bool false


### PR DESCRIPTION
This removes the use of `scf.if`, which required laundering back and
forth between `i1` and `!torch.bool` in the frontend. We will eventually
lower this op to `scf.if`, but this results in a cleaner IR and layering
at the frontend.

I also put in another commit for fixing a constant folding issue.

Recommended review order: commit by commit
