### PR TITLE
Add a !torch.float type.

### DIFF
--- a/frontends/pytorch/csrc/builder/func_builder.cpp
+++ b/frontends/pytorch/csrc/builder/func_builder.cpp
@@ -107,8 +107,9 @@ MlirValue FuncBuilder::getScalarConstant(MlirLocation loc, at::Scalar s) {
     return mlirOperationGetResult(op, 0);
   }
   if (s.isFloatingPoint()) {
-    MlirType t = mlirF64TypeGet(context);
-    MlirAttribute value = mlirFloatAttrDoubleGet(context, t, s.to<double>());
+    MlirType t = npcompTorchFloatTypeGet(context);
+    MlirAttribute value = mlirFloatAttrDoubleGet(
+        context, mlirF64TypeGet(context), s.to<double>());
     MlirOperation op = createMlirOperation(
         "torch.constant.float", loc, t, toMlirNamedAttribute("value", value));
     insertConstantOp(op);

--- a/frontends/pytorch/csrc/builder/ivalue_importer.cpp
+++ b/frontends/pytorch/csrc/builder/ivalue_importer.cpp
@@ -248,11 +248,12 @@ MlirValue IValueImporter::rawImportIValue(c10::IValue ivalue) {
     return mlirOperationGetResult(operation, 0);
   }
   if (ivalue.isDouble()) {
-    MlirType type = mlirF64TypeGet(context);
+    MlirType type = npcompTorchFloatTypeGet(context);
     MlirOperation operation = createMlirOperationAtEnd(
         importBlock, "torch.constant.float", loc, type,
         toMlirNamedAttribute(
-            "value", mlirFloatAttrDoubleGet(context, type, ivalue.toDouble())));
+            "value", mlirFloatAttrDoubleGet(context, mlirF64TypeGet(context),
+                                            ivalue.toDouble())));
     return mlirOperationGetResult(operation, 0);
   }
   if (ivalue.isInt()) {

--- a/frontends/pytorch/csrc/builder/torch_to_mlir_utils.cpp
+++ b/frontends/pytorch/csrc/builder/torch_to_mlir_utils.cpp
@@ -166,7 +166,7 @@ MlirType TypeMapper::mapFromTorchType(MlirLocation loc,
     return npcompTorchNnModuleTypeGet(context, toMlirStringRef(name));
   }
   case TypeKind::FloatType: {
-    return mlirF64TypeGet(context);
+    return npcompTorchFloatTypeGet(context);
   }
   case TypeKind::OptionalType: {
     return npcompTorchOptionalTypeGet(mapFromTorchType(

--- a/frontends/pytorch/python/torch_mlir_utils/codegen/torch_ods_gen.py
+++ b/frontends/pytorch/python/torch_mlir_utils/codegen/torch_ods_gen.py
@@ -223,7 +223,7 @@ TORCH_TYPE_TO_ODS_TYPE = {
     "int[]": "AnyTorchIntListType",
     "bool": "Torch_BoolType",
     "bool[]": "AnyTorchBoolListType",
-    "float": "AnyTorchFloatType",
+    "float": "Torch_FloatType",
     "t[]": "AnyTorchListType",
     "t": "AnyTorchType",
     "t1": "AnyTorchType",

--- a/frontends/pytorch/test/ivalue_import/primitives.py
+++ b/frontends/pytorch/test/ivalue_import/primitives.py
@@ -20,7 +20,7 @@ class TestModule(torch.nn.Module):
 # CHECK: torch.class_type @[[CLASSTYPE:.*]] {
 # CHECK:   torch.attr "training" : !torch.bool
 # CHECK:   torch.attr "i" : !torch.int
-# CHECK:   torch.attr "f" : f64
+# CHECK:   torch.attr "f" : !torch.float
 # CHECK: }
 # CHECK: %[[TRUE:.*]] = torch.constant.bool true
 # CHECK: %[[N3:.*]] = torch.constant.int 3
@@ -29,7 +29,7 @@ class TestModule(torch.nn.Module):
 # Note: for some reason, Torch always adds a "training" property to all modules.
 # CHECK:   torch.slot "training", %[[TRUE]] : !torch.bool
 # CHECK:   torch.slot "i", %[[N3]] : !torch.int
-# CHECK:   torch.slot "f", %[[N42]] : f64
+# CHECK:   torch.slot "f", %[[N42]] : !torch.float
 # CHECK: } : !torch.nn.Module<"[[CLASSTYPE:.*]]">
 
 

--- a/frontends/pytorch/test/ivalue_import/quantization.py
+++ b/frontends/pytorch/test/ivalue_import/quantization.py
@@ -22,7 +22,7 @@ class TestModule(torch.nn.Module):
     # CHECK: %[[SCALE:.*]] = torch.constant.float
     # CHECK: %[[ZERO_POINT:.*]] = torch.constant.int 0
     # CHECK: %[[INT_REPR:.*]] = torch.tensor({{.*}}) : !torch.tensor<[2,5],si8>
-    # CHECK: %[[WEIGHTS:.*]] = torch.per_tensor_affine.create %[[INT_REPR]], %[[SCALE]], %[[ZERO_POINT]] : !torch.tensor<[2,5],si8>, f64, !torch.int -> !torch.tensor<[2,5],!torch.qint8>
+    # CHECK: %[[WEIGHTS:.*]] = torch.per_tensor_affine.create %[[INT_REPR]], %[[SCALE]], %[[ZERO_POINT]] : !torch.tensor<[2,5],si8>, !torch.float, !torch.int -> !torch.tensor<[2,5],!torch.qint8>
     # CHECK: %[[BIAS:.*]] = torch.tensor({{.*}}) : !torch.tensor<[2],f32>
     # CHECK: %[[LINEAR_PARAMS:.*]] = torch.linear_params.create %[[WEIGHTS]], %[[BIAS]] : !torch.tensor<[2,5],!torch.qint8>, !torch.tensor<[2],f32>
     @torch.jit.export

--- a/frontends/pytorch/test/node_import/loop.py
+++ b/frontends/pytorch/test/node_import/loop.py
@@ -12,15 +12,15 @@ import typing
 mb = torch_mlir.ModuleBuilder()
 
 # CHECK-LABEL:   func @__torch__.prim_Loop_forlike(
-# CHECK-SAME:                            %[[MAX_ITERATIONS:.*]]: !torch.int) -> f64 {
+# CHECK-SAME:                            %[[MAX_ITERATIONS:.*]]: !torch.int) -> !torch.float {
 # CHECK:           %[[BOOL_TRUE:.*]] = torch.constant.bool true
 # CHECK:           %[[F_INIT:.*]] = torch.constant.float 0.000000e+00
 # CHECK:           %[[RESULTS:.*]] = torch.prim.Loop %[[MAX_ITERATIONS]], %[[BOOL_TRUE]], init(%[[F_INIT]])  {
-# CHECK:           ^bb0(%[[IV:.*]]: !torch.int, %[[F_ITER:.*]]: f64):
-# CHECK:             %[[F_NEXT:.*]] = torch.aten.add.float_int %[[F_ITER]], %[[IV]] : f64, !torch.int -> f64
-# CHECK:             torch.prim.Loop.condition %[[BOOL_TRUE]], iter(%[[F_NEXT]] : f64)
-# CHECK:           } : (!torch.int, !torch.bool, f64) -> f64
-# CHECK:           return %[[RESULTS:.*]] : f64
+# CHECK:           ^bb0(%[[IV:.*]]: !torch.int, %[[F_ITER:.*]]: !torch.float):
+# CHECK:             %[[F_NEXT:.*]] = torch.aten.add.float_int %[[F_ITER]], %[[IV]] : !torch.float, !torch.int -> !torch.float
+# CHECK:             torch.prim.Loop.condition %[[BOOL_TRUE]], iter(%[[F_NEXT]] : !torch.float)
+# CHECK:           } : (!torch.int, !torch.bool, !torch.float) -> !torch.float
+# CHECK:           return %[[RESULTS:.*]] : !torch.float
 @mb.import_function
 @torch.jit.script
 def prim_Loop_forlike(n: int):
@@ -30,17 +30,17 @@ def prim_Loop_forlike(n: int):
     return f
 
 # CHECK-LABEL:   func @__torch__.prim_Loop_whilelike(
-# CHECK-SAME:                              %[[VAL_0:.*]]: !torch.int) -> f64 {
+# CHECK-SAME:                              %[[VAL_0:.*]]: !torch.int) -> !torch.float {
 # CHECK:           %[[F_INIT:.*]] = torch.constant.float 3.200000e+00
 # CHECK:           %[[MAX_ITERATIONS:.*]] = torch.constant.int 9223372036854775807
-# CHECK:           %[[COND_INIT:.*]] = torch.aten.lt.float_int %[[F_INIT]], %[[VAL_0]] : f64, !torch.int -> !torch.bool
+# CHECK:           %[[COND_INIT:.*]] = torch.aten.lt.float_int %[[F_INIT]], %[[VAL_0]] : !torch.float, !torch.int -> !torch.bool
 # CHECK:           %[[RET:.*]] = torch.prim.Loop %[[MAX_ITERATIONS]], %[[COND_INIT]], init(%[[F_INIT]])  {
-# CHECK:           ^bb0(%[[F_ITER:.*]]: !torch.int, %[[F_ITER:.*]]: f64):
-# CHECK:             %[[F_NEXT:.*]] = torch.aten.mul.float %[[F_ITER]], %[[F_ITER]] : f64, f64 -> f64
-# CHECK:             %[[COND_ITER:.*]] = torch.aten.lt.float_int %[[F_NEXT]], %[[VAL_0]] : f64, !torch.int -> !torch.bool
-# CHECK:             torch.prim.Loop.condition %[[COND_ITER]], iter(%[[F_NEXT]] : f64)
-# CHECK:           } : (!torch.int, !torch.bool, f64) -> f64
-# CHECK:           return %[[RET:.*]] : f64
+# CHECK:           ^bb0(%[[F_ITER:.*]]: !torch.int, %[[F_ITER:.*]]: !torch.float):
+# CHECK:             %[[F_NEXT:.*]] = torch.aten.mul.float %[[F_ITER]], %[[F_ITER]] : !torch.float, !torch.float -> !torch.float
+# CHECK:             %[[COND_ITER:.*]] = torch.aten.lt.float_int %[[F_NEXT]], %[[VAL_0]] : !torch.float, !torch.int -> !torch.bool
+# CHECK:             torch.prim.Loop.condition %[[COND_ITER]], iter(%[[F_NEXT]] : !torch.float)
+# CHECK:           } : (!torch.int, !torch.bool, !torch.float) -> !torch.float
+# CHECK:           return %[[RET:.*]] : !torch.float
 @mb.import_function
 @torch.jit.script
 def prim_Loop_whilelike(n: int):

--- a/include/npcomp-c/TorchTypes.h
+++ b/include/npcomp-c/TorchTypes.h
@@ -90,6 +90,16 @@ bool npcompTypeIsATorchInt(MlirType t);
 MlirType npcompTorchIntTypeGet(MlirContext context);
 
 //===----------------------------------------------------------------------===//
+// torch.float type.
+//===----------------------------------------------------------------------===//
+
+/// Checks whether the given type is a !torch.float type
+bool npcompTypeIsATorchFloat(MlirType t);
+
+/// Gets the !torch.float type.
+MlirType npcompTorchFloatTypeGet(MlirContext context);
+
+//===----------------------------------------------------------------------===//
 // torch.LinearParams type.
 //===----------------------------------------------------------------------===//
 

--- a/include/npcomp/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/npcomp/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -166,8 +166,8 @@ def Torch_AtenBatchNormOp : Torch_Op<"aten.batch_norm", [
     AnyTorchOptionalTensor:$running_mean,
     AnyTorchOptionalTensor:$running_var,
     Torch_BoolType:$training,
-    AnyTorchFloatType:$momentum,
-    AnyTorchFloatType:$eps,
+    Torch_FloatType:$momentum,
+    Torch_FloatType:$eps,
     Torch_BoolType:$cudnn_enabled
   );
   let results = (outs
@@ -323,11 +323,11 @@ def Torch_AtenAddFloatIntOp : Torch_Op<"aten.add.float_int", [
   ]> {
   let summary = "Generated op for `aten::add.float_int : (float, int) -> (float)`";
   let arguments = (ins
-    AnyTorchFloatType:$a,
+    Torch_FloatType:$a,
     Torch_IntType:$b
   );
   let results = (outs
-    AnyTorchFloatType:$result
+    Torch_FloatType:$result
   );
   let assemblyFormat = "$a `,` $b attr-dict `:` type($a) `,` type($b) `->` type($result)";
 }
@@ -338,11 +338,11 @@ def Torch_AtenMulFloatOp : Torch_Op<"aten.mul.float", [
   ]> {
   let summary = "Generated op for `aten::mul.float : (float, float) -> (float)`";
   let arguments = (ins
-    AnyTorchFloatType:$a,
-    AnyTorchFloatType:$b
+    Torch_FloatType:$a,
+    Torch_FloatType:$b
   );
   let results = (outs
-    AnyTorchFloatType:$result
+    Torch_FloatType:$result
   );
   let assemblyFormat = "$a `,` $b attr-dict `:` type($a) `,` type($b) `->` type($result)";
 }
@@ -353,7 +353,7 @@ def Torch_AtenLtFloatIntOp : Torch_Op<"aten.lt.float_int", [
   ]> {
   let summary = "Generated op for `aten::lt.float_int : (float, int) -> (bool)`";
   let arguments = (ins
-    AnyTorchFloatType:$a,
+    Torch_FloatType:$a,
     Torch_IntType:$b
   );
   let results = (outs
@@ -423,3 +423,4 @@ def Torch_Aten_SetItemTOp : Torch_Op<"aten._set_item.t", [
   );
   let assemblyFormat = "$l `,` $idx `,` $el attr-dict `:` type($l) `,` type($idx) `,` type($el) `->` type($result)";
 }
+

--- a/include/npcomp/Dialect/Torch/IR/GeneratedPrimOps.td
+++ b/include/npcomp/Dialect/Torch/IR/GeneratedPrimOps.td
@@ -208,3 +208,4 @@ def Torch_PrimPrintOp : Torch_Op<"prim.Print", [
   );
   let assemblyFormat = "`(` $operands `)` attr-dict `:` type($operands)";
 }
+

--- a/include/npcomp/Dialect/Torch/IR/GeneratedQuantizedOps.td
+++ b/include/npcomp/Dialect/Torch/IR/GeneratedQuantizedOps.td
@@ -24,7 +24,7 @@ def Torch_QuantizedLinearOp : Torch_Op<"quantized.linear", [
   let arguments = (ins
     AnyTorchTensorType:$X,
     Torch_LinearParamsType:$W_prepack,
-    AnyTorchFloatType:$Y_scale_i,
+    Torch_FloatType:$Y_scale_i,
     Torch_IntType:$Y_zero_point_i
   );
   let results = (outs
@@ -32,3 +32,4 @@ def Torch_QuantizedLinearOp : Torch_Op<"quantized.linear", [
   );
   let assemblyFormat = "$X `,` $W_prepack `,` $Y_scale_i `,` $Y_zero_point_i attr-dict `:` type($X) `,` type($W_prepack) `,` type($Y_scale_i) `,` type($Y_zero_point_i) `->` type($Y)";
 }
+

--- a/include/npcomp/Dialect/Torch/IR/TorchOps.td
+++ b/include/npcomp/Dialect/Torch/IR/TorchOps.td
@@ -47,7 +47,7 @@ def Torch_NnModuleOp : Torch_Op<"nn_module", [
     %2 = torch.nn_module {
       torch.slot "b", %bool_true : !torch.bool
       torch.slot "i", %int3 : !torch.int
-      torch.slot "f", %float : f64
+      torch.slot "f", %float : !torch.float
       torch.slot "t", %t : !torch.tensor
       torch.slot "submodule", %1 : !torch.nn.Module
     } : !torch.nn.Module<"my_class_name">
@@ -127,7 +127,7 @@ def Torch_ClassTypeOp : Torch_Op<"class_type", [
     torch.class_type @test {
       torch.attr "b" : !torch.bool
       torch.attr "i" : !torch.int
-      torch.attr "f" : f64
+      torch.attr "f" : !torch.float
       torch.attr "t" : !torch.tensor
       torch.attr "submodule" : !torch.nn.Module<"empty">
       torch.method "method", @f
@@ -136,7 +136,7 @@ def Torch_ClassTypeOp : Torch_Op<"class_type", [
       // These must match the order and names in the `torch.class_type`.
       torch.slot "b", %bool_true : !torch.bool
       torch.slot "i", %int3 : !torch.int
-      torch.slot "f", %float : f64
+      torch.slot "f", %float : !torch.float
       torch.slot "t", %t : !torch.tensor
       torch.slot "submodule", %submodule : !torch.nn.Module<"empty">
     } : !torch.nn.Module<"test">
@@ -562,7 +562,7 @@ def Torch_ConstantFloatOp : Torch_Op<"constant.float",
     F64Attr:$value
   );
   let results = (outs
-    AnyTorchFloatType:$result
+    Torch_FloatType:$result
   );
   let assemblyFormat = "$value attr-dict";
   let hasFolder = 1;
@@ -697,6 +697,42 @@ def Torch_FromI64Op : Torch_Op<"from_i64", [
   }];
 }
 
+def Torch_ToF64Op : Torch_Op<"to_f64", [
+    DeclareOpInterfaceMethods<InferTypeOpInterface>
+  ]> {
+  let summary = "Convert a `!torch.float` to an `f64`";
+  let description = [{
+    This op is primarily useful as a materialization during dialect conversion.
+  }];
+  let arguments = (ins
+    Torch_FloatType:$operand
+  );
+  let results = (outs
+    F64:$result
+  );
+  let assemblyFormat = [{
+    $operand attr-dict
+  }];
+}
+
+def Torch_FromF64Op : Torch_Op<"from_f64", [
+    DeclareOpInterfaceMethods<InferTypeOpInterface>
+  ]> {
+  let summary = "Convert an `f64` to a `!torch.float`";
+  let description = [{
+    This op is primarily useful as a materialization during dialect conversion.
+  }];
+  let arguments = (ins
+    F64:$operand
+  );
+  let results = (outs
+    Torch_FloatType:$result
+  );
+  let assemblyFormat = [{
+    $operand attr-dict
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Additional ops used to model TorchScript's Graph's / Node's.
 //===----------------------------------------------------------------------===//
@@ -784,7 +820,7 @@ def Torch_PerTensorAffineCreateOp : Torch_Op<"per_tensor_affine.create", [
   }];
   let arguments = (ins
     AnyTorchTensorType:$int_repr,
-    AnyFloat:$scale,
+    Torch_FloatType:$scale,
     Torch_IntType:$offset
   );
   // TODO: Limit to quantized dtypes (e.g. !torch.qint8).

--- a/include/npcomp/Dialect/Torch/IR/TorchTypes.td
+++ b/include/npcomp/Dialect/Torch/IR/TorchTypes.td
@@ -258,6 +258,18 @@ def Torch_IntType : Torch_Type<"Int", "int"> {
   let description = [{
     The integer type used to model the Python `int` type in TorchScript.
     TorchScript itself models this type as a 64-bit signed integer.
+
+    Note: This type is not used for modeling tensor dtypes.
+  }];
+}
+
+def Torch_FloatType : Torch_Type<"Float", "float"> {
+  let summary = "Torch FloatType";
+  let description = [{
+    The float type is used to model the Python `float` type in TorchScript.
+    Python and TorchScript use 64-bit floating point for this type at runtime.
+
+    Note: This type is not used for modeling tensor dtypes.
   }];
 }
 
@@ -328,14 +340,11 @@ class ListOf<list<Type> allowedTypes, string descr> :
 
 def AnyTorchBoolListType : ListOf<[Torch_BoolType], "Any bool list type (bool[])">;
 
-def AnyTorchFloatType : TypeAlias<F64,
-    "Any type usable for representing the `float` Python type">;
-
 def AnyTorchIntListType : ListOf<[Torch_IntType], "Any int list type (int[])">;
 
 def AnyTorchScalarType : AnyTypeOf<[
   Torch_IntType,
-  AnyTorchFloatType,
+  Torch_FloatType,
   Torch_BoolType,
 ], "Any Python numeric type compatible with being the scalar type of a tensor (`Scalar`)">;
 

--- a/lib/CAPI/TorchTypes.cpp
+++ b/lib/CAPI/TorchTypes.cpp
@@ -108,6 +108,18 @@ MlirType npcompTorchIntTypeGet(MlirContext context) {
 }
 
 //===----------------------------------------------------------------------===//
+// torch.float type.
+//===----------------------------------------------------------------------===//
+
+bool npcompTypeIsATorchFloat(MlirType t) {
+  return unwrap(t).isa<Torch::FloatType>();
+}
+
+MlirType npcompTorchFloatTypeGet(MlirContext context) {
+  return wrap(Torch::FloatType::get(unwrap(context)));
+}
+
+//===----------------------------------------------------------------------===//
 // torch.LinearParams type.
 //===----------------------------------------------------------------------===//
 

--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -55,7 +55,7 @@ static LogicalResult verifyLinalgCompatibleTypes(Operation *op,
           return true;
       }
     }
-    if (type.isa<FloatType, IntegerType, IndexType>())
+    if (type.isa<mlir::FloatType, IntegerType, IndexType>())
       return true;
     return false;
   };

--- a/lib/Dialect/Torch/IR/TorchDialect.cpp
+++ b/lib/Dialect/Torch/IR/TorchDialect.cpp
@@ -122,11 +122,7 @@ Operation *TorchDialect::materializeConstant(OpBuilder &builder,
   if (auto integerType = type.dyn_cast<Torch::IntType>())
     return builder.create<Torch::ConstantIntOp>(loc, value.cast<IntegerAttr>());
 
-  // We currently use the builtin `f64` type to model the Python `float` type.
-  // This semantically matches how TorchScript represents it, but is still
-  // a little bit ugly.
-  // TODO: We should have a !torch.float type to model this.
-  if (auto floatType = type.dyn_cast<Float64Type>())
+  if (auto floatType = type.dyn_cast<Torch::FloatType>())
     return builder.create<Torch::ConstantFloatOp>(loc, value.cast<FloatAttr>());
 
   if (type.isa<Torch::BoolType>()) {

--- a/lib/Dialect/Torch/Transforms/GlobalizeObjectGraph.cpp
+++ b/lib/Dialect/Torch/Transforms/GlobalizeObjectGraph.cpp
@@ -46,7 +46,7 @@ static FailureOr<NnModuleOp> findRootNnModule(ModuleOp module) {
 }
 
 static bool hasMeaningfulObjectIdentity(Type type) {
-  return !type.isa<Torch::IntType, FloatType, Torch::BoolType,
+  return !type.isa<Torch::IntType, Torch::FloatType, Torch::BoolType,
                    Torch::StringType, Torch::NoneType,
                    Torch::ValueTensorType>();
 }

--- a/test/Dialect/Torch/GlobalizeObjectGraph/basic.mlir
+++ b/test/Dialect/Torch/GlobalizeObjectGraph/basic.mlir
@@ -12,9 +12,9 @@
 // CHECK:           torch.global_slot.init %[[INIT]] : !torch.int
 // CHECK:         }
 
-// CHECK-LABEL:   torch.global_slot @f : f64  {
+// CHECK-LABEL:   torch.global_slot @f : !torch.float  {
 // CHECK:           %[[INIT:.*]] = torch.constant.float 4.250000e+01
-// CHECK:           torch.global_slot.init %[[INIT]] : f64
+// CHECK:           torch.global_slot.init %[[INIT]] : !torch.float
 // CHECK:         }
 
 // CHECK-LABEL:   torch.global_slot @t : !torch.tensor  {
@@ -25,7 +25,7 @@
 torch.class_type @c {
   torch.attr "b" : !torch.bool
   torch.attr "i" : !torch.int
-  torch.attr "f" : f64
+  torch.attr "f" : !torch.float
   torch.attr "t" : !torch.tensor
 }
 
@@ -36,6 +36,6 @@ torch.class_type @c {
 torch.nn_module {
   torch.slot "b", %bool_true : !torch.bool
   torch.slot "i", %i : !torch.int
-  torch.slot "f", %f : f64
+  torch.slot "f", %f : !torch.float
   torch.slot "t", %t : !torch.tensor
 } : !torch.nn.Module<"c">

--- a/test/Dialect/Torch/GlobalizeObjectGraph/error.mlir
+++ b/test/Dialect/Torch/GlobalizeObjectGraph/error.mlir
@@ -11,7 +11,7 @@ torch.nn_module {} : !torch.nn.Module<"c2">
 // -----
 
 torch.class_type @child {
-  torch.attr "float" : f64
+  torch.attr "float" : !torch.float
 }
 torch.class_type @parent {
   torch.attr "m" : !torch.nn.Module<"child">
@@ -19,10 +19,10 @@ torch.class_type @parent {
 
 }
 
-%c42 = std.constant 42.0 : f64
+%c42 = torch.constant.float 42.0
 // expected-error @+1 {{reachable by multiple paths from root object: '<root>.m' and '<root>.m2'}}
 %child = torch.nn_module {
-  torch.slot "float", %c42 : f64
+  torch.slot "float", %c42 : !torch.float
 } : !torch.nn.Module<"child">
 %parent = torch.nn_module {
   torch.slot "m", %child : !torch.nn.Module<"child">

--- a/test/Dialect/Torch/GlobalizeObjectGraph/free-functions.mlir
+++ b/test/Dialect/Torch/GlobalizeObjectGraph/free-functions.mlir
@@ -1,41 +1,41 @@
 // RUN: npcomp-opt -torch-globalize-object-graph -split-input-file %s | FileCheck %s
 
 torch.class_type @c {
-  torch.attr "float" : f64
+  torch.attr "float" : !torch.float
   torch.method "calls_free_function", @calls_free_function
 }
 // CHECK-LABEL:   func private
 // CHECK-SAME:        @free_function$[[$MONOMORPHIZE_TAG0:.*]](
-// CHECK-SAME:                                                 %[[F:.*]]: f64) -> f64 {
-// CHECK:           return %[[F]] : f64
+// CHECK-SAME:                                                 %[[F:.*]]: !torch.float) -> !torch.float {
+// CHECK:           return %[[F]] : !torch.float
 // CHECK:         }
-func private @free_function(%arg0: f64, %arg1: !torch.nn.Module<"c">) -> f64 {
-  return %arg0 : f64
+func private @free_function(%arg0: !torch.float, %arg1: !torch.nn.Module<"c">) -> !torch.float {
+  return %arg0 : !torch.float
 }
 
 // CHECK-LABEL:   func private
 // CHECK-SAME:        @free_function_no_module_args$[[$MONOMORPHIZE_TAG1:.*]](
-// CHECK-SAME:                                                 %[[F:.*]]: f64) -> f64 {
-// CHECK:           return %[[F]] : f64
+// CHECK-SAME:                                                 %[[F:.*]]: !torch.float) -> !torch.float {
+// CHECK:           return %[[F]] : !torch.float
 // CHECK:         }
-func private @free_function_no_module_args(%arg0: f64) -> f64 {
-  return %arg0 : f64
+func private @free_function_no_module_args(%arg0: !torch.float) -> !torch.float {
+  return %arg0 : !torch.float
 }
 
-// CHECK-LABEL:   func @calls_free_function() -> f64 {
-// CHECK:           %[[F1:.*]] = torch.global_slot.get @float : f64
-// CHECK:           %[[F2:.*]] = call @free_function$[[$MONOMORPHIZE_TAG0]](%[[F1]]) : (f64) -> f64
-// CHECK:           %[[RET:.*]] = call @free_function_no_module_args$[[$MONOMORPHIZE_TAG1]](%[[F2]]) : (f64) -> f64
-// CHECK:           return %[[RET]] : f64
+// CHECK-LABEL:   func @calls_free_function() -> !torch.float {
+// CHECK:           %[[F1:.*]] = torch.global_slot.get @float : !torch.float
+// CHECK:           %[[F2:.*]] = call @free_function$[[$MONOMORPHIZE_TAG0]](%[[F1]]) : (!torch.float) -> !torch.float
+// CHECK:           %[[RET:.*]] = call @free_function_no_module_args$[[$MONOMORPHIZE_TAG1]](%[[F2]]) : (!torch.float) -> !torch.float
+// CHECK:           return %[[RET]] : !torch.float
 // CHECK:         }
-func private @calls_free_function(%arg0: !torch.nn.Module<"c">) -> f64 {
-  %0 = torch.prim.GetAttr %arg0["float"] : !torch.nn.Module<"c"> -> f64
-  %1 = call @free_function(%0, %arg0) : (f64, !torch.nn.Module<"c">) -> f64
-  %2 = call @free_function_no_module_args(%1) : (f64) -> f64
-  return %2 : f64
+func private @calls_free_function(%arg0: !torch.nn.Module<"c">) -> !torch.float {
+  %0 = torch.prim.GetAttr %arg0["float"] : !torch.nn.Module<"c"> -> !torch.float
+  %1 = call @free_function(%0, %arg0) : (!torch.float, !torch.nn.Module<"c">) -> !torch.float
+  %2 = call @free_function_no_module_args(%1) : (!torch.float) -> !torch.float
+  return %2 : !torch.float
 }
 
-%c42 = std.constant 42.0 : f64
+%c42 = torch.constant.float 42.0
 torch.nn_module {
-  torch.slot "float", %c42 : f64
+  torch.slot "float", %c42 : !torch.float
 } : !torch.nn.Module<"c">

--- a/test/Dialect/Torch/GlobalizeObjectGraph/methods.mlir
+++ b/test/Dialect/Torch/GlobalizeObjectGraph/methods.mlir
@@ -1,39 +1,39 @@
 // RUN: npcomp-opt -torch-globalize-object-graph -split-input-file %s | FileCheck %s
 
 torch.class_type @c {
-  torch.attr "float" : f64
+  torch.attr "float" : !torch.float
   torch.method "test_get", @test_get
   torch.method "test_set", @test_set
   torch.method "test_call", @test_call
 }
 
-// CHECK-LABEL:   func @test_get() -> f64 {
-// CHECK:           %[[V:.*]] = torch.global_slot.get @float : f64
-// CHECK:           return %[[V]] : f64
-func private @test_get(%arg0: !torch.nn.Module<"c">) -> f64 {
-  %0 = torch.prim.GetAttr %arg0["float"] : !torch.nn.Module<"c"> -> f64
-  return %0 : f64
+// CHECK-LABEL:   func @test_get() -> !torch.float {
+// CHECK:           %[[V:.*]] = torch.global_slot.get @float : !torch.float
+// CHECK:           return %[[V]] : !torch.float
+func private @test_get(%arg0: !torch.nn.Module<"c">) -> !torch.float {
+  %0 = torch.prim.GetAttr %arg0["float"] : !torch.nn.Module<"c"> -> !torch.float
+  return %0 : !torch.float
 }
 
 // CHECK-LABEL:   func @test_set(
-// CHECK-SAME:                   %[[A:.*]]: f64) {
-// CHECK:           torch.global_slot.set @float = %[[A]] : f64
+// CHECK-SAME:                   %[[A:.*]]: !torch.float) {
+// CHECK:           torch.global_slot.set @float = %[[A]] : !torch.float
 // CHECK:           return
-func private @test_set(%arg0: !torch.nn.Module<"c">, %arg1: f64) {
-  torch.prim.SetAttr %arg0["float"] = %arg1 : !torch.nn.Module<"c">, f64
+func private @test_set(%arg0: !torch.nn.Module<"c">, %arg1: !torch.float) {
+  torch.prim.SetAttr %arg0["float"] = %arg1 : !torch.nn.Module<"c">, !torch.float
   return
 }
 
 // CHECK-LABEL:   func @test_call(
-// CHECK-SAME:                    %[[A:.*]]: f64) -> f64 {
-// CHECK:           %[[V:.*]] = call @test_call(%[[A]]) : (f64) -> f64
-// CHECK:           return %[[V]] : f64
-func private @test_call(%arg0: !torch.nn.Module<"c">, %arg1: f64) -> f64 {
-  %0 = call @test_call(%arg0, %arg1) : (!torch.nn.Module<"c">, f64) -> f64
-  return %0 : f64
+// CHECK-SAME:                    %[[A:.*]]: !torch.float) -> !torch.float {
+// CHECK:           %[[V:.*]] = call @test_call(%[[A]]) : (!torch.float) -> !torch.float
+// CHECK:           return %[[V]] : !torch.float
+func private @test_call(%arg0: !torch.nn.Module<"c">, %arg1: !torch.float) -> !torch.float {
+  %0 = call @test_call(%arg0, %arg1) : (!torch.nn.Module<"c">, !torch.float) -> !torch.float
+  return %0 : !torch.float
 }
 
-%c42 = std.constant 42.0 : f64
+%c42 = torch.constant.float 42.0
 torch.nn_module {
-  torch.slot "float", %c42 : f64
+  torch.slot "float", %c42 : !torch.float
 } : !torch.nn.Module<"c">

--- a/test/Dialect/Torch/GlobalizeObjectGraph/submodules.mlir
+++ b/test/Dialect/Torch/GlobalizeObjectGraph/submodules.mlir
@@ -2,14 +2,14 @@
 
 // Check that linkage names consist of the dotted path from the root. 
 
-// CHECK-LABEL:   torch.global_slot @m.float : f64  {
+// CHECK-LABEL:   torch.global_slot @m.float : !torch.float  {
 // CHECK:           %[[INIT:.*]] = torch.constant.float 4.200000e+01
-// CHECK:           torch.global_slot.init %[[INIT]] : f64
+// CHECK:           torch.global_slot.init %[[INIT]] : !torch.float
 // CHECK:         }
 
 
 torch.class_type @child {
-  torch.attr "float" : f64
+  torch.attr "float" : !torch.float
 }
 torch.class_type @parent {
   torch.attr "m" : !torch.nn.Module<"child">
@@ -17,7 +17,7 @@ torch.class_type @parent {
 
 %c42 = torch.constant.float 42.0
 %child = torch.nn_module {
-  torch.slot "float", %c42 : f64
+  torch.slot "float", %c42 : !torch.float
 } : !torch.nn.Module<"child">
 %parent = torch.nn_module {
   torch.slot "m", %child : !torch.nn.Module<"child">

--- a/test/Dialect/Torch/GlobalizeObjectGraph/visibility.mlir
+++ b/test/Dialect/Torch/GlobalizeObjectGraph/visibility.mlir
@@ -1,8 +1,8 @@
 // RUN: npcomp-opt -torch-globalize-object-graph -split-input-file %s | FileCheck %s
 
 torch.class_type @c {
-  // CHECK: torch.global_slot "private" @float : f64
-  torch.attr private "float" : f64
+  // CHECK: torch.global_slot "private" @float : !torch.float
+  torch.attr private "float" : !torch.float
   torch.method private "forward", @method
 }
 
@@ -11,7 +11,7 @@ func private @method(%arg0: !torch.nn.Module<"c">) {
   return
 }
 
-%c42 = std.constant 42.0 : f64
+%c42 = torch.constant.float 42.0
 torch.nn_module {
-  torch.slot "float", %c42 : f64
+  torch.slot "float", %c42 : !torch.float
 } : !torch.nn.Module<"c">

--- a/test/Dialect/Torch/finalizing-backend-type-conversion.mlir
+++ b/test/Dialect/Torch/finalizing-backend-type-conversion.mlir
@@ -33,6 +33,15 @@ func @eliminate_materializations$torch.int(%arg0: i64) -> i64 {
   return %1 : i64
 }
 
+// CHECK-LABEL:   func @eliminate_materializations$torch.float(
+// CHECK-SAME:                                                 %[[ARG:.*]]: f64) -> f64 {
+// CHECK:           return %[[ARG]] : f64
+func @eliminate_materializations$torch.float(%arg0: f64) -> f64 {
+  %0 = torch.from_f64 %arg0
+  %1 = torch.to_f64 %0
+  return %1 : f64
+}
+
 // -----
 
 func @unable_to_convert_lone_buffer_cast() -> tensor<f32> {

--- a/test/Dialect/Torch/func-backend-type-conversion.mlir
+++ b/test/Dialect/Torch/func-backend-type-conversion.mlir
@@ -113,3 +113,12 @@ func @identity$torch.bool(%arg0: !torch.bool) -> !torch.bool {
 func @identity$torch.int(%arg0: !torch.int) -> !torch.int {
   return %arg0 : !torch.int
 }
+
+// CHECK-LABEL:   func @identity$torch.float(
+// CHECK-SAME:                               %[[ARG:.*]]: f64) -> f64 {
+// CHECK:           %[[TORCH_FLOAT:.*]] = torch.from_f64 %[[ARG]]
+// CHECK:           %[[F64:.*]] = torch.to_f64 %[[TORCH_FLOAT]]
+// CHECK:           return %[[F64]] : f64
+func @identity$torch.float(%arg0: !torch.float) -> !torch.float {
+  return %arg0 : !torch.float
+}

--- a/test/Dialect/Torch/ops.mlir
+++ b/test/Dialect/Torch/ops.mlir
@@ -96,7 +96,7 @@ torch.class_type @empty {}
 torch.class_type @test {
   torch.attr "b" : !torch.bool
   torch.attr "i" : !torch.int
-  torch.attr "f" : f64
+  torch.attr "f" : !torch.float
   torch.attr "t" : !torch.tensor
   torch.attr "submodule" : !torch.nn.Module<"empty">
   torch.attr "ob" : !torch.optional<!torch.bool>
@@ -106,7 +106,7 @@ torch.class_type @test {
 torch.nn_module {
   torch.slot "b", %true : !torch.bool
   torch.slot "i", %int3 : !torch.int
-  torch.slot "f", %float : f64
+  torch.slot "f", %float : !torch.float
   torch.slot "t", %tensor : !torch.tensor
   torch.slot "submodule", %submodule : !torch.nn.Module<"empty">
   torch.slot "ob", %none : !torch.none

--- a/test/Dialect/Torch/prepare-for-globalize-object-graph.mlir
+++ b/test/Dialect/Torch/prepare-for-globalize-object-graph.mlir
@@ -8,24 +8,24 @@ torch.class_type @c {
 
 // CHECK-LABEL:   func private @test_call_method(
 // CHECK-SAME:                            %[[RECEIVER:.*]]: !torch.nn.Module<"c">,
-// CHECK-SAME:                            %[[F:.*]]: f64) -> f64 {
-// CHECK:           %[[RET:.*]] = call @test_call_method(%[[RECEIVER]], %[[F]]) : (!torch.nn.Module<"c">, f64) -> f64
-// CHECK:           return %[[RET]] : f64
-func private @test_call_method(%arg0: !torch.nn.Module<"c">, %arg1: f64) -> f64 {
-  %0 = torch.prim.CallMethod %arg0["test_call_method"] (%arg1) : !torch.nn.Module<"c">, (f64) -> f64
-  return %0 : f64
+// CHECK-SAME:                            %[[F:.*]]: !torch.float) -> !torch.float {
+// CHECK:           %[[RET:.*]] = call @test_call_method(%[[RECEIVER]], %[[F]]) : (!torch.nn.Module<"c">, !torch.float) -> !torch.float
+// CHECK:           return %[[RET]] : !torch.float
+func private @test_call_method(%arg0: !torch.nn.Module<"c">, %arg1: !torch.float) -> !torch.float {
+  %0 = torch.prim.CallMethod %arg0["test_call_method"] (%arg1) : !torch.nn.Module<"c">, (!torch.float) -> !torch.float
+  return %0 : !torch.float
 }
 
 // CHECK-LABEL:   func private @test_call_indirect(
 // CHECK-SAME:                                     %[[RECEIVER:.*]]: !torch.nn.Module<"c">,
-// CHECK-SAME:                                     %[[F:.*]]: f64) -> f64 {
+// CHECK-SAME:                                     %[[F:.*]]: !torch.float) -> !torch.float {
 // Ensure no std.constant.
-// CHECK-NEXT:      %[[VAL_2:.*]] = call @test_call_method(%[[RECEIVER]], %[[F]]) : (!torch.nn.Module<"c">, f64) -> f64
-// CHECK-NEXT:      return %[[VAL_2]] : f64
-func private @test_call_indirect(%arg0: !torch.nn.Module<"c">, %arg1: f64) -> f64 {
-  %0 = constant @test_call_method : (!torch.nn.Module<"c">, f64) -> f64
-  %1 = call_indirect %0(%arg0, %arg1) : (!torch.nn.Module<"c">, f64) -> f64
-  return %1 : f64
+// CHECK-NEXT:      %[[VAL_2:.*]] = call @test_call_method(%[[RECEIVER]], %[[F]]) : (!torch.nn.Module<"c">, !torch.float) -> !torch.float
+// CHECK-NEXT:      return %[[VAL_2]] : !torch.float
+func private @test_call_indirect(%arg0: !torch.nn.Module<"c">, %arg1: !torch.float) -> !torch.float {
+  %0 = constant @test_call_method : (!torch.nn.Module<"c">, !torch.float) -> !torch.float
+  %1 = call_indirect %0(%arg0, %arg1) : (!torch.nn.Module<"c">, !torch.float) -> !torch.float
+  return %1 : !torch.float
 }
 
 torch.nn_module {


### PR DESCRIPTION
This removes the dependence of the `torch` dialect on the low-level
builtin types.
Now the `torch` dialect is a standalone layer, suitable for targeting
from higher-level Python abstractions without any premature lowering to
primitive types.