### PR TITLE
Clean up `memref.dim` ops better.

### DIFF
--- a/lib/Dialect/Torch/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Torch/Transforms/CMakeLists.txt
@@ -25,4 +25,5 @@ add_npcomp_conversion_library(NPCOMPTorchPasses
   NPCOMPTorchDialect
   NPCOMPTorchToLinalg
   NPCOMPInterfaces
+  MLIRMemRefTransforms
 )


### PR DESCRIPTION
Recent changes in MLIR have changed the canonicalization for the `memref.dim` op. To clean it up, we now need the createResolveShapedTypeResultDimsPass().

This results in cleaner IR. In particular, Mlp2LayerModule e2e test has
a dim op that is eliminated by this change:
https://gist.github.com/silvasean/734f11a291ae6236c955f65cffae285f