### PR TITLE
Make `torch.copy.tensor` canonicalization a bit smarter.

### DIFF
--- a/frontends/pytorch/e2e_testing/torchscript/basic.py
+++ b/frontends/pytorch/e2e_testing/torchscript/basic.py
@@ -33,6 +33,25 @@ def MmModule_chained(module, tu: TestUtils):
 
 # ==============================================================================
 
+# A subgraph with multiple mm ops.
+class MmDagModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+    @export
+    @annotate_args([
+        None,
+        ([4, 4], torch.float32, True),
+        ([4, 4], torch.float32, True),
+    ])
+    def forward(self, lhs, rhs):
+        return torch.mm(lhs, torch.mm(lhs, rhs))
+
+@register_test_case(module_factory=lambda: MmDagModule())
+def MmDagModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(4, 4), tu.rand(4, 4))
+
+# ==============================================================================
+
 class TanhModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/include/npcomp/Dialect/Torch/IR/TorchOps.td
+++ b/include/npcomp/Dialect/Torch/IR/TorchOps.td
@@ -922,7 +922,9 @@ def Torch_TensorStaticInfoCastOp : Torch_Op<"tensor_static_info_cast", [
   }];
 }
 
-def Torch_CopyTensorOp : Torch_Op<"copy.tensor", []> {
+def Torch_CopyTensorOp : Torch_Op<"copy.tensor", [
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+  ]> {
   let summary = "Makes a copy of a tensor.";
   let description = [{
     Changes to the original tensor will not be reflected in the copy.

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -179,3 +179,13 @@ func @torch.prim.If$erase_dead_branch(%arg0: !torch.int) -> !torch.int {
   }
   return %0 : !torch.int
 }
+
+// CHECK-LABEL:   func @torch.copy.tensor$untouched_nonval(
+// CHECK-SAME:                                             %[[ARG:.*]]: !torch.vtensor) -> (!torch.vtensor, !torch.vtensor) {
+// CHECK-NEXT:      return %[[ARG]], %[[ARG]] : !torch.vtensor, !torch.vtensor
+func @torch.copy.tensor$untouched_nonval(%arg0: !torch.vtensor) -> (!torch.vtensor, !torch.vtensor) {
+  %0 = torch.copy.tensor %arg0 : !torch.vtensor -> !torch.tensor
+  %1 = torch.copy.tensor %0 : !torch.tensor -> !torch.vtensor
+  %2 = torch.copy.tensor %0 : !torch.tensor -> !torch.vtensor
+  return %1, %2 : !torch.vtensor, !torch.vtensor
+}


### PR DESCRIPTION
This removes most of the trivial cases that MaximizeValueSemantics needs
to handle, making it easier to see the nontrivial cases.