### PR TITLE
Bump llvm-project to a085c23aa3c8f91866d7f4588d4f683407dc775d.

### DIFF
--- a/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
+++ b/lib/Conversion/TorchToLinalg/TorchToLinalg.cpp
@@ -236,6 +236,9 @@ public:
       return rewriter.notifyMatchFailure(op, "only support stride [1, 1]");
     if (!isConstantIntListMatching(dilation, expects))
       return rewriter.notifyMatchFailure(op, "only support dilation [1, 1]");
+    // Unit strides and dilations.
+    auto linalgStrides = rewriter.getI64VectorAttr({1, 1});
+    auto linalgDilations = rewriter.getI64VectorAttr({1, 1});
 
     if (!op.bias().getType().isa<Torch::NoneType>())
       return rewriter.notifyMatchFailure(op, "only support None bias");
@@ -288,9 +291,9 @@ public:
 
     Value conv2d =
         rewriter
-            .create<linalg::ConvNCHWOp>(loc, ranked4DTensorType,
-                                        ValueRange{paddedInput, weight},
-                                        ValueRange{initTensor0})
+            .create<linalg::Conv2DNchwOp>(
+                loc, ranked4DTensorType, ValueRange{paddedInput, weight},
+                ValueRange{initTensor0}, linalgStrides, linalgDilations)
             .getResult(0);
     Type newResultType = getTypeConverter()->convertType(op.getType());
     rewriter.replaceOpWithNewOp<tensor::CastOp>(op, newResultType, conv2d);

--- a/lib/RefBackend/CMakeLists.txt
+++ b/lib/RefBackend/CMakeLists.txt
@@ -19,6 +19,8 @@ add_npcomp_library(NPCOMPRefBackend
   MLIRIR
   MLIRLinalg
   MLIRLinalgToLLVM
+  MLIRMathToLLVM
+  MLIRMemRefToLLVM
   MLIRSCFToStandard
   MLIRSCFTransforms
   MLIRShapeToStandard

--- a/lib/RefBackend/LowerToLLVM.cpp
+++ b/lib/RefBackend/LowerToLLVM.cpp
@@ -9,7 +9,11 @@
 #include "PassDetail.h"
 #include "npcomp/RefBackend/RefBackend.h"
 
+#include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Conversion/LinalgToLLVM/LinalgToLLVM.h"
+#include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
+#include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVM.h"
 #include "mlir/Conversion/StandardToLLVM/ConvertStandardToLLVMPass.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -702,6 +706,8 @@ class LowerToLLVM : public LowerToLLVMBase<LowerToLLVM> {
     populateCompilerRuntimePatterns(module, patterns, converter);
     target.addLegalOp<ModuleOp>();
     populateStdToLLVMConversionPatterns(converter, patterns);
+    populateMathToLLVMConversionPatterns(converter, patterns);
+    populateMemRefToLLVMConversionPatterns(converter, patterns);
     patterns.add<LowerModuleMetadata>(context);
 
     // TODO: Move these "std to std" legalizations to their own pass if we grow

--- a/lib/RefBackend/RefBackend.cpp
+++ b/lib/RefBackend/RefBackend.cpp
@@ -207,7 +207,7 @@ void mlir::NPCOMP::createRefBackendLoweringPipeline(
   pm.addNestedPass<FuncOp>(createConvertElementwiseToLinalgPass());
 
   if (options.optimize) {
-    pm.addNestedPass<FuncOp>(createLinalgFusionOfTensorOpsPass());
+    pm.addNestedPass<FuncOp>(createLinalgElementwiseOpFusionPass());
     pm.addNestedPass<FuncOp>(createCanonicalizerPass());
     pm.addNestedPass<FuncOp>(createCSEPass());
   }

--- a/test/Conversion/TCFToLinalg/basic.mlir
+++ b/test/Conversion/TCFToLinalg/basic.mlir
@@ -62,7 +62,7 @@ func @tcf_matmul(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf
 // CHECK:             %[[OUTWIDTH:.*]] = addi %[[WIDTHV0M1]], %[[C1]] : index
 // CHECK:             %[[SHAPE:.*]] = tensor.from_elements %[[BATCH]], %[[OUTCHANNELS]], %[[OUTHEIGHT]], %[[OUTWIDTH]] : tensor<4xindex>
 // CHECK:             %[[INIT_TENSOR:.*]] = tcp.splatted %[[C0F32]], %[[SHAPE]] : (f32, tensor<4xindex>) -> tensor<?x?x?x?xf32>
-// CHECK:             %[[CONVNCHW:.*]] = linalg.conv_2d_nchw ins(%[[IN]], %[[FILTER]] : tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) outs(%[[INIT_TENSOR]] : tensor<?x?x?x?xf32>)  -> tensor<?x?x?x?xf32>
+// CHECK:             %[[CONVNCHW:.*]] = linalg.conv_2d_nchw {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%[[IN]], %[[FILTER]] : tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) outs(%[[INIT_TENSOR]] : tensor<?x?x?x?xf32>)  -> tensor<?x?x?x?xf32>
 // CHECK:             shape.assuming_yield %[[CONVNCHW]] : tensor<?x?x?x?xf32>
 // CHECK:           }
 // CHECK:           return %[[RET:.*]] : tensor<?x?x?x?xf32>

--- a/tools/npcomp-shlib/CMakeLists.txt
+++ b/tools/npcomp-shlib/CMakeLists.txt
@@ -42,7 +42,7 @@ llvm_add_library(
   ${_OBJECTS}
   LINK_LIBS PUBLIC
   # Public dependencies on the MLIR public API and impl shared libraries.
-  MLIRPublicAPI
+  MLIRPythonCAPI
   MLIR
   ${_DEPS}
 )


### PR DESCRIPTION
* Added additional *ToLLVM conversion patterns (they were disaggregated from standard).
* Misc renames.
* Spelling change on ConvNCHW op, and it now expects strides and dilations attributes.