### PR TITLE
Add npcomp-lsp-server.

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,2 +1,3 @@
+add_subdirectory(npcomp-lsp-server)
 add_subdirectory(npcomp-opt)
 add_subdirectory(npcomp-run-mlir)

--- a/tools/npcomp-lsp-server/CMakeLists.txt
+++ b/tools/npcomp-lsp-server/CMakeLists.txt
@@ -1,0 +1,17 @@
+# npcomp-lsp-server is always linked dynamically as we want to distribute the
+# binaries with the python packages for hacking/debugging.
+add_npcomp_executable(npcomp-lsp-server npcomp-lsp-server.cpp)
+
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+
+target_link_libraries(npcomp-lsp-server PRIVATE
+  MLIRLspServerLib
+  NPCOMPInitAll
+
+  # TODO: Remove these in favor of interface deps.
+  ${dialect_libs}
+  ${conversion_libs}
+)
+
+mlir_check_all_link_libraries(npcomp-lsp-server)

--- a/tools/npcomp-lsp-server/npcomp-lsp-server.cpp
+++ b/tools/npcomp-lsp-server/npcomp-lsp-server.cpp
@@ -1,0 +1,22 @@
+//===- npcomp-lsp-server.cpp - MLIR Language Server -------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/InitAllDialects.h"
+#include "mlir/Tools/mlir-lsp-server/MlirLspServerMain.h"
+#include "npcomp/InitAll.h"
+
+using namespace mlir;
+
+int main(int argc, char **argv) {
+  DialectRegistry registry;
+  registerAllDialects(registry);
+  mlir::NPCOMP::registerAllDialects(registry);
+  return failed(MlirLspServerMain(argc, argv, registry));
+}


### PR DESCRIPTION
To use, do `ninja npcomp-lsp-server`, copy `build/bin/npcomp-lsp-server`
into your PATH somewhere, and then add
```
"mlir.server_path": "npcomp-lsp-server",
```
to your settings.json.

Also bump llvm-project to 2d9759c7902c5cbc9a7e3ab623321d5578d51687 to
bring in latest `mlir-lsp-server` changes.