### PR TITLE
Rename npcomp-run-mlir to refback-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The project is roughly split into the following areas of code:
     infra from Python
   * [backend_test](backend_test): Lit test suites conditionally enabled for
     each backend
-* [tools](tools): Scripts and binaries (npcomp-opt, npcomp-run-mlir, etc)
+* [tools](tools): Scripts and binaries (npcomp-opt, refback-run, etc)
 
 ## Interactive Use
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@ set(NPCOMP_TEST_DEPENDS
         FileCheck count not
         npcomp-capi-ir-test
         npcomp-opt
-        npcomp-run-mlir
+        refback-run
         NPCOMPPythonModules
         NPCOMPMLIRPythonModules
 )

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -67,7 +67,7 @@ tool_dirs = [
 ]
 tools = [
     'npcomp-opt',
-    'npcomp-run-mlir',
+    'refback-run',
     'npcomp-capi-ir-test',
     ToolSubst('%npcomp_runtime_shlib', config.npcomp_runtime_shlib),
 ]

--- a/test/refback-run/basic.mlir
+++ b/test/refback-run/basic.mlir
@@ -1,4 +1,4 @@
-// RUN: npcomp-run-mlir %s \
+// RUN: refback-run %s \
 // RUN:   -invoke forward \
 // RUN:   -arg-value="dense<[[1.0, 2.0], [3.0, 4.0]]> : tensor<2x2xf32>" \
 // RUN:   -arg-value="dense<[10.0, 20.0]> : tensor<2xf32>" \

--- a/test/refback-run/constant.mlir
+++ b/test/refback-run/constant.mlir
@@ -1,4 +1,4 @@
-// RUN: npcomp-run-mlir %s \
+// RUN: refback-run %s \
 // RUN:   -invoke constant \
 // RUN:   -shared-libs=%npcomp_runtime_shlib 2>&1 \
 // RUN:   | FileCheck %s

--- a/test/refback-run/identity.mlir
+++ b/test/refback-run/identity.mlir
@@ -1,4 +1,4 @@
-// RUN: npcomp-run-mlir %s \
+// RUN: refback-run %s \
 // RUN:   -invoke identity \
 // RUN:   -arg-value="dense<1.0> : tensor<f32>" \
 // RUN:   -shared-libs=%npcomp_runtime_shlib 2>&1 \

--- a/test/refback-run/invalid-input-types.mlir
+++ b/test/refback-run/invalid-input-types.mlir
@@ -1,4 +1,4 @@
-// RUN: not npcomp-run-mlir %s \
+// RUN: not refback-run %s \
 // RUN:   -invoke expects_one_tensor \
 // RUN:   -arg-value="1.0 : f32" \
 // RUN:   -shared-libs=%npcomp_runtime_shlib 2>&1 \

--- a/test/refback-run/invalid-num-inputs.mlir
+++ b/test/refback-run/invalid-num-inputs.mlir
@@ -1,4 +1,4 @@
-// RUN: not npcomp-run-mlir %s \
+// RUN: not refback-run %s \
 // RUN:   -invoke requires_one_input \
 // RUN:   -shared-libs=%npcomp_runtime_shlib 2>&1 \
 // RUN:   | FileCheck %s

--- a/test/refback-run/multi-output.mlir
+++ b/test/refback-run/multi-output.mlir
@@ -1,4 +1,4 @@
-// RUN: npcomp-run-mlir %s \
+// RUN: refback-run %s \
 // RUN:   -invoke multi_output \
 // RUN:   -arg-value="dense<1.0> : tensor<1xf32>" \
 // RUN:   -shared-libs=%npcomp_runtime_shlib 2>&1 \

--- a/test/refback-run/scalar.mlir
+++ b/test/refback-run/scalar.mlir
@@ -1,4 +1,4 @@
-// RUN: npcomp-run-mlir %s \
+// RUN: refback-run %s \
 // RUN:   -invoke scalar_arg \
 // RUN:   -arg-value="2.5 : f32" \
 // RUN:   -shared-libs=%npcomp_runtime_shlib 2>&1 \

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_subdirectory(npcomp-opt)
-add_subdirectory(npcomp-run-mlir)
+add_subdirectory(refback-run)

--- a/tools/bash_helpers.sh
+++ b/tools/bash_helpers.sh
@@ -18,16 +18,16 @@ npcomp-opt() {
     "$@"
 }
 
-npcomp-run-mlir() {
-  # Helper for building and invoking npcomp-run-mlir.
+refback-run() {
+  # Helper for building and invoking refback-run.
   #
   # This also automatically builds and adds the npcomp runtime shared
   # library.
   #
   # Usage:
-  # $ npcomp-run-mlir <regular npcomp-run-mlir options>
-  ninja -C "$build_dir" npcomp-run-mlir NPCOMPCompilerRuntimeShlib 1>&2 || return 1
-  "$build_dir/bin/npcomp-run-mlir" \
+  # $ refback-run <regular refback-run options>
+  ninja -C "$build_dir" refback-run NPCOMPCompilerRuntimeShlib 1>&2 || return 1
+  "$build_dir/bin/refback-run" \
     -shared-libs="${build_dir}/lib/libNPCOMPCompilerRuntimeShlib.so" "$@"
 }
 

--- a/tools/refback-run/CMakeLists.txt
+++ b/tools/refback-run/CMakeLists.txt
@@ -1,15 +1,15 @@
-# npcomp-run-mlir is always linked dynamically as we want to distribute the
+# refback-run is always linked dynamically as we want to distribute the
 # binaries with the python packages for hacking/debugging.
 
 get_property(dialect_libs GLOBAL PROPERTY NPCOMP_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY NPCOMP_CONVERSION_LIBS)
 
-add_npcomp_executable(npcomp-run-mlir
-  npcomp-run-mlir.cpp
+add_npcomp_executable(refback-run
+  refback-run.cpp
   )
 
-llvm_update_compile_flags(npcomp-run-mlir)
-target_link_libraries(npcomp-run-mlir PRIVATE
+llvm_update_compile_flags(refback-run)
+target_link_libraries(refback-run PRIVATE
   NPCOMPCAPI
   NPCOMPInitAll
   MLIRAnalysis
@@ -24,6 +24,6 @@ target_link_libraries(npcomp-run-mlir PRIVATE
   ${conversion_libs}
   ${dialect_libs}
 )
-add_dependencies(npcomp-run-mlir
+add_dependencies(refback-run
   NPCOMPCompilerRuntimeShlib
   )

--- a/tools/refback-run/refback-run.cpp
+++ b/tools/refback-run/refback-run.cpp
@@ -7,7 +7,8 @@
 //===----------------------------------------------------------------------===//
 //
 // Utility binary for compiling and running code through the npcomp
-// compiler/runtime stack.
+// RefBackend. The accepted input is the npcomp backend contract
+// (roughly, linalg-on-tensors + std).
 //
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
This better represents its limited scope. This was causing confusion --
people were feeding it higher level ops that require frontend lowering.