### PR TITLE
Triage e2e IREE failures for npcetest.

### DIFF
--- a/frontends/pytorch/e2e_testing/torchscript/main.py
+++ b/frontends/pytorch/e2e_testing/torchscript/main.py
@@ -41,7 +41,7 @@ def _get_argparse():
     if IREE_ENABLED:
         config_choices += ['iree']
     parser = argparse.ArgumentParser(description='Run torchscript e2e tests.')
-    parser.add_argument('--config',
+    parser.add_argument('-c', '--config',
         choices=config_choices,
         default='refbackend',
         help=f'''

--- a/frontends/pytorch/e2e_testing/torchscript/xfail_sets.py
+++ b/frontends/pytorch/e2e_testing/torchscript/xfail_sets.py
@@ -21,10 +21,9 @@ _common_npcomp_lowering_xfails = {
 XFAIL_SETS['refbackend'] = _common_npcomp_lowering_xfails
 
 XFAIL_SETS['iree'] = _common_npcomp_lowering_xfails | {
-    #https://reviews.llvm.org/D106658 to reach iree release
-    'MaxPool2dModule_basic',
+    # https://github.com/google/iree/issues/6629
+    'Conv2dWithPaddingModule_basic',
     'Conv2dWithPaddingDilationStrideModule_basic',
-    #https://github.com/google/iree/issues/6420
-    'FlattenDynamicModule_basic',
-    'ResNet18Module_basic'
+    'ResNet18Module_basic',
+    'MaxPool2dModule_basic',
 }


### PR DESCRIPTION
ResNet works with static shapes. (our test is not static though).

All tests blocked on https://github.com/google/iree/issues/6629