### PR TITLE
Sigmoid lowering to linalg

### DIFF
--- a/frontends/pytorch/e2e_testing/torchscript/elementwise.py
+++ b/frontends/pytorch/e2e_testing/torchscript/elementwise.py
@@ -149,7 +149,6 @@ class ElementwiseFlattenBroadcastModule(torch.nn.Module):
 def ElementwiseFlattenBroadcastModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(6), tu.rand())
 
-
 # ==============================================================================
 
 
@@ -169,3 +168,24 @@ class ElementwiseReluModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: ElementwiseReluModule())
 def ElementwiseReluModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(4, 2) - 0.5)
+
+# ==============================================================================
+
+
+class ElementwiseSigmoidModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.sigmoid(x)
+
+
+@register_test_case(module_factory=lambda: ElementwiseSigmoidModule())
+def ElementwiseSigmoidModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 5))
+

--- a/frontends/pytorch/python/torch_mlir_utils/codegen/torch_ods_gen.py
+++ b/frontends/pytorch/python/torch_mlir_utils/codegen/torch_ods_gen.py
@@ -436,6 +436,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         for key in [
                 "aten::tanh : (Tensor) -> (Tensor)",
                 "aten::relu : (Tensor) -> (Tensor)",
+                "aten::sigmoid : (Tensor) -> (Tensor)",
                 "aten::sin : (Tensor) -> (Tensor)",
                 "aten::exp : (Tensor) -> (Tensor)",
                 "aten::cos : (Tensor) -> (Tensor)",

--- a/include/npcomp/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/npcomp/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -71,6 +71,34 @@ def Torch_AtenRelu_Op : Torch_Op<"aten.relu_", [
   let assemblyFormat = "$self attr-dict `:` type($self) `->` type($result)";
 }
 
+def Torch_AtenSigmoidOp : Torch_Op<"aten.sigmoid", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::sigmoid : (Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self attr-dict `:` type($self) `->` type($result)";
+}
+
+def Torch_AtenSigmoid_Op : Torch_Op<"aten.sigmoid_", [
+    IsTrailingUnderscoreInplaceVariant,
+    AllowsTypeRefinement
+  ]> {
+  let summary = "Generated op for `aten::sigmoid_ : (Tensor) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self attr-dict `:` type($self) `->` type($result)";
+}
+
 def Torch_AtenSinOp : Torch_Op<"aten.sin", [
     AllowsTypeRefinement,
     HasValueSemantics

--- a/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -175,7 +175,7 @@ public:
             AtenSubScalarOp, AtenMulScalarOp, AtenDivScalarOp, AtenFmodScalarOp,
             AtenFloorDivideScalarOp, AtenEqScalarOp, AtenGeScalarOp,
             AtenNeScalarOp, AtenBitwiseNotOp, AtenToDtypeOp, AtenExpOp,
-            AtenSinOp, AtenCosOp, DerefineOp>(op)) {
+            AtenSinOp, AtenCosOp, AtenSigmoidOp, DerefineOp>(op)) {
       return getLatticeElement(op->getResult(0)).join(*operands[0]);
     }
 


### PR DESCRIPTION
Adds a pretty straightforward lowering for Sigmoid following the existing conventions for relu and tanh. 

Would it be appropriate to mirror the lit tests for tanh in ./test/Conversion/TorchToLinalg/elementwise.mlir and /test/Dialect/Torch/refine-types.mlir? Any other tests required for this kind of patch? 