### PR TITLE
Torch.sum lowering to Linalg

### DIFF
--- a/frontends/pytorch/e2e_testing/torchscript/elementwise.py
+++ b/frontends/pytorch/e2e_testing/torchscript/elementwise.py
@@ -189,3 +189,5 @@ class ElementwiseSigmoidModule(torch.nn.Module):
 def ElementwiseSigmoidModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 5))
 
+# ==============================================================================
+

--- a/frontends/pytorch/e2e_testing/torchscript/main.py
+++ b/frontends/pytorch/e2e_testing/torchscript/main.py
@@ -36,6 +36,7 @@ from . import batchnorm
 from . import quantized_models
 from . import elementwise
 from . import list_programs
+from . import reduction
 
 def _get_argparse():
     config_choices = ['native_torch', 'torchscript', 'refbackend']

--- a/frontends/pytorch/e2e_testing/torchscript/reduction.py
+++ b/frontends/pytorch/e2e_testing/torchscript/reduction.py
@@ -1,0 +1,66 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import torch
+
+from torch_mlir_torchscript.e2e_test.framework import TestUtils
+from torch_mlir_torchscript.e2e_test.registry import register_test_case
+from torch_mlir_torchscript.annotations import annotate_args, export
+
+# ==============================================================================
+
+class ReduceSumModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.sum(a)
+
+
+@register_test_case(module_factory=lambda: ReduceSumModule())
+def ReduceSumModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+
+class ReduceSumDimIntListModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.sum(a, (0, 1))
+
+
+@register_test_case(module_factory=lambda: ReduceSumDimIntListModule())
+def ReduceSumDimIntListModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5))
+
+# ==============================================================================
+
+class ReduceSumDimIntListKeepDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, a):
+        return torch.sum(a, (1, 2), keepdim=True)
+
+
+@register_test_case(module_factory=lambda: ReduceSumDimIntListKeepDimModule())
+def ReduceSumDimIntListKeepDimModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5))

--- a/frontends/pytorch/python/torch_mlir_utils/codegen/torch_ods_gen.py
+++ b/frontends/pytorch/python/torch_mlir_utils/codegen/torch_ods_gen.py
@@ -521,6 +521,7 @@ def emit_aten_ops(torch_ir_dir: str, registry: Registry):
         emit("aten::select.int : (Tensor, int, int) -> (Tensor)")
         emit("aten::size.int : (Tensor, int) -> (int)")
         emit("aten::stack : (Tensor[], int) -> (Tensor)")
+        emit("aten::sum : (Tensor, int?) -> (Tensor)")
         emit("aten::sum.dim_IntList : (Tensor, int[], bool, int?) -> (Tensor)")
         emit("aten::to.dtype : (Tensor, int, bool, bool, int?) -> (Tensor)")
         emit("aten::to.other : (Tensor, Tensor, bool, bool, int?) -> (Tensor)")

--- a/include/npcomp/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/npcomp/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -1554,6 +1554,21 @@ def Torch_AtenStackOp : Torch_Op<"aten.stack", [
   let assemblyFormat = "$tensors `,` $dim attr-dict `:` type($tensors) `,` type($dim) `->` type($result)";
 }
 
+def Torch_AtenSumOp : Torch_Op<"aten.sum", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::sum : (Tensor, int?) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    TorchOptionalIntType:$dtype
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $dtype attr-dict `:` type($self) `,` type($dtype) `->` type($result)";
+}
+
 def Torch_AtenSumDimIntListOp : Torch_Op<"aten.sum.dim_IntList", [
     AllowsTypeRefinement,
     HasValueSemantics


### PR DESCRIPTION
Adds a lowering for the two versions of `torch.sum` (with and without dimensions specified). The lowering is based on the one used for `Tosa->Linalg` in `MLIR`.

In addition, this PR also includes a general `ConversionPattern` (`ConvertReduceOp`) that can be easily extended to include any other `torch` operations that result in a reduction of tensors.

## Issues

### Problem with `ResNet` test

The only problem I am having at the moment is that when I run the tests I wrote at the same time as the test for `ResNet18Module_basic` in https://github.com/llvm/mlir-npcomp/blob/main/frontends/pytorch/e2e_testing/torchscript/elementwise.py, at least one of the `sum` tests fails non-deterministically. If I run the test suite without the `ResNet18Module_basic`, my tests pass every single time.

### Broken invariant

In order to implement the version of `torch.sum` that reduces along every dimension, I had to refine the type in https://github.com/llvm/mlir-npcomp/blob/main/lib/Dialect/Torch/Transforms/RefineTypes.cpp by saying that `knowledge.hasSizes = true` while keeping the `knowledge.sizes` vector empty. This is needed because the result is supposed to be a zero ranked tensor. The problem is that this breaks the assert statement in the `ValueKnowledge` constructor:

```c++
assert(sizes.size() == 0 || hasSizes);
```

This does not prevent my code from running correctly, but I think this assert statement should be revisited, since zero-rank tensors are possible in `torch`.