### PR TITLE
Fix lowering of reduce ops

### DIFF
--- a/frontends/pytorch/python/torch_mlir_torchscript/e2e_test/reporting.py
+++ b/frontends/pytorch/python/torch_mlir_torchscript/e2e_test/reporting.py
@@ -22,9 +22,10 @@ class TensorSummary:
         self.min = torch.min(tensor)
         self.max = torch.max(tensor)
         self.mean = torch.mean(tensor)
+        self.shape = list(tensor.shape)
 
     def __str__(self):
-        return f'Tensor with min={self.min:+0.4}, max={self.max:+0.4}, mean={self.mean:+0.4f}'
+        return f'Tensor with shape={self.shape} min={self.min:+0.4}, max={self.max:+0.4}, mean={self.mean:+0.4}'
 
 
 class ErrorContext:

--- a/frontends/pytorch/test/torchscript_e2e_test/error_reports.py
+++ b/frontends/pytorch/test/torchscript_e2e_test/error_reports.py
@@ -116,7 +116,7 @@ class ErroneousModule(torch.nn.Module):
 
     # CHECK-NEXT: @ trace item #8 - call to "test_tensor_value_mismatch"
     # CHECK-NEXT: @ output of call to "test_tensor_value_mismatch"
-    # CHECK-NEXT: ERROR: value (Tensor with min=+1.0, max=+3.0, mean=+2.0000) is not close to golden value (Tensor with min=+1.5, max=+3.5, mean=+2.5000)
+    # CHECK-NEXT: ERROR: value (Tensor with shape=[3] min=+1.0, max=+3.0, mean=+2.0) is not close to golden value (Tensor with shape=[3] min=+1.5, max=+3.5, mean=+2.5)
     @torch.jit.export
     def test_tensor_value_mismatch(self):
         if torch.jit.is_scripting():


### PR DESCRIPTION
We were not filling the `outs` with the neutral element of the
reduction, which resulted in reading uninitialized values (we were
getting lucky that sometimes the uninitialized buffers were all zero's).

Also,
- Slight tweak to error messages in the e2e framework.