### PR TITLE
Add basic support for lists.

### DIFF
--- a/frontends/pytorch/e2e_testing/torchscript/list_programs.py
+++ b/frontends/pytorch/e2e_testing/torchscript/list_programs.py
@@ -16,10 +16,10 @@ class ListLiteralModule(torch.nn.Module):
         super().__init__()
 
     @export
-    def forward(self, x: float):
+    def forward(self, x: int):
         return [x, x]
 
 
 @register_test_case(module_factory=lambda: ListLiteralModule())
 def ListLiteralModule_basic(module, tu: TestUtils):
-    module.forward(3.0)
+    module.forward(3)

--- a/frontends/pytorch/e2e_testing/torchscript/xfail_sets.py
+++ b/frontends/pytorch/e2e_testing/torchscript/xfail_sets.py
@@ -16,10 +16,16 @@ XFAIL_SETS = {}
 # to the backend contract.
 _common_npcomp_lowering_xfails = {
     'QuantizedMLP_basic',
+}
+
+# Any test expected to fail on backends that don't support non-tensor types
+# should be listed here.
+_common_non_tensor_type_xfails = {
     'ListLiteralModule_basic',
 }
 
-XFAIL_SETS['refbackend'] = _common_npcomp_lowering_xfails
+XFAIL_SETS['refbackend'] = (_common_npcomp_lowering_xfails
+                            | _common_non_tensor_type_xfails)
 
 XFAIL_SETS['iree'] = _common_npcomp_lowering_xfails
 

--- a/frontends/pytorch/python/torch_mlir_torchscript_e2e_test_configs/npcomp_backend.py
+++ b/frontends/pytorch/python/torch_mlir_torchscript_e2e_test_configs/npcomp_backend.py
@@ -18,18 +18,41 @@ from npcomp.compiler.pytorch.backend.abc import NpcompBackend
 from torch_mlir_torchscript.e2e_test.framework import TestConfig, Trace, TraceItem
 from torch_mlir.torchscript_annotations import extract_annotations
 
-class PrettyErrorReportForIrOperation(object):
-    def __init__(self, module, module_name_for_ir_dump: str):
-        sys.stderr = StringIO()
-        self.filename_for_ir_dump = os.path.join(tempfile.gettempdir(),
-                                module_name_for_ir_dump + '.mlir')
-        self.asm_for_error_report = module.get_asm(
-            large_elements_limit=10, enable_debug_info=True)
-    def __enter__(self):
-        pass
-    def __exit__(self, type, value, traceback):
-        with open(self.filename_for_ir_dump, 'w') as f:
-            f.write(self.asm_for_error_report)
+def _recursively_convert_to_numpy(o: Any):
+    if isinstance(o, torch.Tensor):
+        return o.numpy()
+    if isinstance(o, tuple):
+        return tuple(_recursively_convert_to_numpy(x) for x in o)
+    if isinstance(o, list):
+        return [_recursively_convert_to_numpy(x) for x in o]
+    if isinstance(o, dict):
+        return {k: _recursively_convert_to_numpy(v) for k, v in o.items()}
+    # No-op cases. Explicitly enumerated to avoid things sneaking through.
+    if isinstance(o, str):
+        return o
+    if isinstance(o, float):
+        return o
+    if isinstance(o, int):
+        return o
+    raise Exception(f"Unexpected Python function input: {o}")
+
+def _recursively_convert_from_numpy(o: Any):
+    if isinstance(o, np.ndarray):
+        return torch.from_numpy(o)
+    if isinstance(o, tuple):
+        return tuple(_recursively_convert_from_numpy(x) for x in o)
+    if isinstance(o, list):
+        return [_recursively_convert_from_numpy(x) for x in o]
+    if isinstance(o, dict):
+        return {k: _recursively_convert_from_numpy(v) for k, v in o.items()}
+    # No-op cases. Explicitly enumerated to avoid things sneaking through.
+    if isinstance(o, str):
+        return o
+    if isinstance(o, float):
+        return o
+    if isinstance(o, int):
+        return o
+    raise Exception(f"Unexpected Python function output: {o}")
 
 class NpcompBackendTestConfig(TestConfig):
     """Base class for TestConfig's that are implemented with npcomp.
@@ -124,16 +147,9 @@ NPCOMP Backend lowering for {self.backend.__class__.__name__} failed with the fo
         backend_module = self.backend.load(artifact)
         result: Trace = []
         for item in trace:
-            numpy_inputs = [t.numpy() for t in item.inputs]
+            numpy_inputs = _recursively_convert_to_numpy(item.inputs)
             outputs = getattr(backend_module, item.symbol)(*numpy_inputs)
-            # TODO: Properly handle recursively nested objects.
-            # We probably want to push this kind of unpacking/normalizing
-            # back to true Python values further down into the backends
-            # themselves.
-            if isinstance(outputs, list):
-                output = [torch.tensor(ndarray) for ndarray in outputs]
-            else:
-                output = torch.tensor(outputs)
+            output = _recursively_convert_from_numpy(outputs)
             result.append(
                 TraceItem(symbol=item.symbol,
                           inputs=item.inputs,

--- a/include/npcomp/Backend/Common/Passes.h
+++ b/include/npcomp/Backend/Common/Passes.h
@@ -20,6 +20,8 @@ void registerCommonBackendPasses();
 
 std::unique_ptr<OperationPass<ModuleOp>> createVerifyBackendContractPass();
 
+std::unique_ptr<OperationPass<FuncOp>> createDeleteDeadIREEListsPass();
+
 } // namespace CommonBackend
 } // namespace NPCOMP
 } // namespace mlir

--- a/include/npcomp/Backend/Common/Passes.td
+++ b/include/npcomp/Backend/Common/Passes.td
@@ -16,4 +16,17 @@ def VerifyBackendContract : Pass<"npcomp-verify-backend-contract", "ModuleOp"> {
   let constructor = "mlir::NPCOMP::CommonBackend::createVerifyBackendContractPass()";
 }
 
+def DeleteDeadIREELists : Pass<"delete-dead-iree-lists", "FuncOp"> {
+  let summary = "Deletes dead `!iree.list` values";
+  let description = [{
+    Some backends cannot handle `!iree.list` values which might be incidentally
+    created during type conversion. This pass deletes them so those backends
+    can still run programs that don't use lists in an essential way.
+
+    For example, list arguments to convolution ops (such as strides) turn into
+    dead lists with our current lowerings.
+  }];
+  let constructor = "mlir::NPCOMP::CommonBackend::createDeleteDeadIREEListsPass()";
+}
+
 #endif // NPCOMP_BACKEND_COMMON_PASSES

--- a/include/npcomp/Dialect/TorchConversion/Transforms/Passes.h
+++ b/include/npcomp/Dialect/TorchConversion/Transforms/Passes.h
@@ -31,7 +31,8 @@ std::unique_ptr<OperationPass<ModuleOp>> createFuncBackendTypeConversionPass();
 std::unique_ptr<OperationPass<FuncOp>>
 createFinalizingBackendTypeConversionPass();
 
-std::unique_ptr<OperationPass<FuncOp>> createTmpDeleteDeadIREEListsPass();
+std::unique_ptr<OperationPass<ModuleOp>> createAnnotateABIPass();
+
 
 } // namespace TorchConversion
 

--- a/include/npcomp/Dialect/TorchConversion/Transforms/Passes.td
+++ b/include/npcomp/Dialect/TorchConversion/Transforms/Passes.td
@@ -52,24 +52,25 @@ def FinalizingBackendTypeConversion
   }];
 }
 
-
-def TmpDeleteDeadIREELists
-    : Pass<"torch-tmp-delete-dead-lists", "FuncOp"> {
-  let summary = "Delete dead !iree.list ops";
-  let constructor =
-    "mlir::NPCOMP::TorchConversion::createTmpDeleteDeadIREEListsPass()";
+def AnnotateABI : Pass<"torch-annotate-abi", "ModuleOp"> {
+  let summary = "Annotate `torch` types before lowering to backend types";
   let description = [{
-    Runs a few patterns to delete dead !iree.list ops until IREE can support
-    running them. Currently, these will get materialized as part of conversions
-    for ops like AtenConv2dOp that have list operands, even though they are dead
-    (for those ops, we pattern match a specific case of static constant lists).
-    Currently, this will break execution of those tests because the IREE
-    side of these ops still doesn't work (nor is IREE able to delete them
-    itself).
+    Populates `iree.abi` metadata to allow runtime reflection of
+    arguments and results.
 
-    TODO: Add support to IREE to run these ops E2E.
-    TODO: Remove this pass once IREE can run them e2e.
+    See IREE's `docs/developers/design_docs/function_abi.md` for information
+    about this annotation format.
+
+    This information must be annotated before we lower types to the backend
+    contract, since that lowering is not generally reversible to recover the
+    correct Python signature.
+
+    TODO: Reconsider the passes in the Torch lowering pipeline in light of this.
+    We want to provide a faithful ABI up to the user, so the None handling (and
+    unimplemented tuple handling) in AdjustCallingConventions and the ClassType
+    handling in GlobalizeObjectGraph will need to be considered.
   }];
+  let constructor = "mlir::NPCOMP::TorchConversion::createAnnotateABIPass()";
 }
 
 

--- a/lib/Backend/Common/CMakeLists.txt
+++ b/lib/Backend/Common/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_npcomp_library(NPCOMPCommonBackend
+  DeleteDeadIREELists.cpp
   VerifyBackendContract.cpp
   Passes.cpp
 

--- a/lib/Backend/Common/DeleteDeadIREELists.cpp
+++ b/lib/Backend/Common/DeleteDeadIREELists.cpp
@@ -1,4 +1,4 @@
-//===- TmpDeleteDeadIREELists.cpp --------------------------------*- C++-*-===//
+//===- DeleteDeadIREELists.cpp -----------------------------------*- C++-*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -11,17 +11,15 @@
 #include "iree-dialects/Dialect/IREE/IREEOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
-#include "npcomp/Dialect/Torch/IR/TorchOps.h"
-#include "npcomp/Dialect/TorchConversion/IR/TorchConversionOps.h"
-#include "npcomp/Dialect/TorchConversion/Transforms/Passes.h"
+#include "npcomp/Backend/Common/Passes.h"
 
 using namespace mlir;
 using namespace mlir::NPCOMP;
-using namespace mlir::NPCOMP::TorchConversion;
+using namespace mlir::NPCOMP::CommonBackend;
 
 namespace {
-class TmpDeleteDeadIREEListsPass
-    : public TmpDeleteDeadIREEListsBase<TmpDeleteDeadIREEListsPass> {
+class DeleteDeadIREEListsPass
+    : public DeleteDeadIREEListsBase<DeleteDeadIREEListsPass> {
   void runOnOperation() override {
     SmallVector<Operation *> toErase;
     // Delete lists that are only set (but not read from).
@@ -51,6 +49,6 @@ class TmpDeleteDeadIREEListsPass
 } // namespace
 
 std::unique_ptr<OperationPass<FuncOp>>
-mlir::NPCOMP::TorchConversion::createTmpDeleteDeadIREEListsPass() {
-  return std::make_unique<TmpDeleteDeadIREEListsPass>();
+mlir::NPCOMP::CommonBackend::createDeleteDeadIREEListsPass() {
+  return std::make_unique<DeleteDeadIREEListsPass>();
 }

--- a/lib/Dialect/TorchConversion/Transforms/AnnotateABI.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/AnnotateABI.cpp
@@ -1,0 +1,131 @@
+//===- AnnotateABI.cpp -------------------------------------------*- C++-*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+
+#include "iree-dialects/Dialect/IREE/IREEOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "npcomp/Dialect/Torch/IR/TorchOps.h"
+#include "npcomp/Dialect/TorchConversion/IR/TorchConversionOps.h"
+#include "npcomp/Dialect/TorchConversion/Transforms/Passes.h"
+#include "llvm/Support/JSON.h"
+
+using namespace mlir;
+using namespace mlir::NPCOMP;
+using namespace mlir::NPCOMP::TorchConversion;
+namespace json = llvm::json;
+
+static json::Value
+convertTypeToIREEABIJSON(Type type,
+                         llvm::function_ref<InFlightDiagnostic()> emitError) {
+  if (auto tensorType = type.dyn_cast<Torch::BaseTensorType>()) {
+    // TODO: Support unranked and unknown dtype when we actually have examples
+    // that need it.
+    if (tensorType.hasSizes() && tensorType.hasDtype()) {
+      json::Array typeRecord{"ndarray"};
+      typeRecord.push_back(
+          convertTypeToIREEABIJSON(tensorType.getDtype(), emitError));
+      typeRecord.push_back(json::Value(tensorType.getSizes().size()));
+      for (auto size : tensorType.getSizes()) {
+        if (size == Torch::kUnknownSize)
+          typeRecord.push_back(json::Value(nullptr));
+        else
+          typeRecord.push_back(json::Value(size));
+      }
+      return typeRecord;
+    }
+  } else if (auto boolType = type.dyn_cast<Torch::BoolType>()) {
+    return json::Value("i1");
+  } else if (auto intType = type.dyn_cast<Torch::IntType>()) {
+    return json::Value("i64");
+  } else if (auto floatType = type.dyn_cast<Torch::FloatType>()) {
+    return json::Value("f64");
+  } else if (auto listType = type.dyn_cast<Torch::ListType>()) {
+    return json::Array{
+        json::Value("py_uniform_list"),
+        convertTypeToIREEABIJSON(listType.getContainedType(), emitError)};
+  } else if (auto dictType = type.dyn_cast<Torch::DictType>()) {
+    return json::Array{
+        json::Value("py_uniform_dict"),
+        convertTypeToIREEABIJSON(dictType.getKeyType(), emitError),
+        convertTypeToIREEABIJSON(dictType.getValueType(), emitError)};
+  } else if (auto tupleType = type.dyn_cast<Torch::TupleType>()) {
+    auto typeRecord = json::Array{"pytuple"};
+    for (auto containedType : tupleType.getContainedTypes())
+      typeRecord.push_back(convertTypeToIREEABIJSON(containedType, emitError));
+    return typeRecord;
+  } else if (auto strType = type.dyn_cast<Torch::StringType>()) {
+    return json::Value("pystr");
+  } else if (auto integerType = type.dyn_cast<mlir::IntegerType>()) {
+    // Only used in recursive calls for tensor dtypes.
+    return json::Value(("i" + Twine(integerType.getWidth())).str());
+  } else if (auto floatType = type.dyn_cast<mlir::FloatType>()) {
+    // Only used in recursive calls for tensor dtypes.
+    if (floatType.isa<BFloat16Type>())
+      return json::Value("bf16");
+    return json::Value(("f" + Twine(floatType.getWidth())).str());
+  }
+
+  emitError() << "unimplemented: ABI annotation for type " << type;
+  return json::Value("error: unimplemented type");
+}
+
+namespace {
+class AnnotateABIPass : public AnnotateABIBase<AnnotateABIPass> {
+  void runOnOperation() override {
+    auto module = getOperation();
+
+    bool hadError = false;
+    module.walk([&](FuncOp func) {
+      if (func.getVisibility() != SymbolTable::Visibility::Public)
+        return;
+      func.getArgumentTypes();
+      json::Array abiArgs;
+      json::Array abiResults;
+      for (auto type : llvm::enumerate(func.getArgumentTypes())) {
+        auto emitError = [&]() {
+          hadError = true;
+          return func.emitError()
+                 << "at function argument " << type.index() << ": ";
+        };
+        abiArgs.push_back(convertTypeToIREEABIJSON(type.value(), emitError));
+      }
+      for (auto type : llvm::enumerate(func.getCallableResults())) {
+        auto emitError = [&]() {
+          hadError = true;
+          return func.emitError()
+                 << "at function result " << type.index() << ": ";
+        };
+        abiResults.push_back(convertTypeToIREEABIJSON(type.value(), emitError));
+      }
+
+      if (hadError)
+        return;
+
+      json::Object abiDict;
+      abiDict["v"] = json::Value(1);
+      abiDict["a"] = json::Value(std::move(abiArgs));
+      abiDict["r"] = json::Value(std::move(abiResults));
+
+      std::string buf;
+      llvm::raw_string_ostream os(buf);
+      os << json::Value(std::move(abiDict));
+      func->setAttr("iree.abi", Builder(func).getStringAttr(os.str()));
+    });
+
+    if (hadError)
+      return signalPassFailure();
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::NPCOMP::TorchConversion::createAnnotateABIPass() {
+  return std::make_unique<AnnotateABIPass>();
+}

--- a/lib/Dialect/TorchConversion/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TorchConversion/Transforms/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_npcomp_conversion_library(NPCOMPTorchConversionPasses
+  AnnotateABI.cpp
   BackendTypeConversion.cpp
   Passes.cpp
-  TmpDeleteDeadIREELists.cpp
   VerifyInvariantsBeforeBackendLowering.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/lib/Dialect/TorchConversion/Transforms/Passes.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/Passes.cpp
@@ -46,6 +46,10 @@ void mlir::NPCOMP::TorchConversion::createTorchScriptToNpcompBackendPipeline(
   // contract.
   Torch::createTorchScriptToTorchBackendPipeline(pm, options);
 
+  // Annotate the ABI of the original Torch functions before we lower them and
+  // lose information.
+  pm.addPass(TorchConversion::createAnnotateABIPass());
+
   // Check some invariants to catch errors in a clear way.
   pm.addPass(
       TorchConversion::createVerifyInvariantsBeforeBackendLoweringPass());
@@ -84,11 +88,6 @@ void mlir::NPCOMP::TorchConversion::createTorchScriptToNpcompBackendPipeline(
   pm.addPass(TorchConversion::createFuncBackendTypeConversionPass());
   pm.addNestedPass<FuncOp>(
       TorchConversion::createFinalizingBackendTypeConversionPass());
-
-  // Temporarily delete dead list ops until IREE can run them e2e.
-  // TODO: Remove this pass once IREE can run them e2e.
-  // TODO: Add support to IREE to run these ops E2E.
-  pm.addNestedPass<FuncOp>(TorchConversion::createTmpDeleteDeadIREEListsPass());
 
   // Verify that we have lowered to the form that npcomp backends expect.
   // This fails compilation (signalPassFailure) if the IR is not in the

--- a/lib/RefBackend/RefBackend.cpp
+++ b/lib/RefBackend/RefBackend.cpp
@@ -38,6 +38,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
+#include "npcomp/Backend/Common/Passes.h"
 #include "npcomp/Dialect/Refback/IR/RefbackOps.h"
 
 using namespace mlir;
@@ -122,6 +123,11 @@ mlir::NPCOMP::createLowerAllocMemRefOpsPass() {
 
 void mlir::NPCOMP::createRefBackendLoweringPipeline(
     OpPassManager &pm, const RefBackendLoweringPipelineOptions &options) {
+
+  // Delete dead lists. RefBackend doesn't support lists, but in some cases
+  // we can get by if all the lists are dead.
+  pm.addNestedPass<FuncOp>(
+      NPCOMP::CommonBackend::createDeleteDeadIREEListsPass());
 
   // Convert all elementwise ops to linalg.
   //

--- a/python/npcomp/compiler/pytorch/backend/iree.py
+++ b/python/npcomp/compiler/pytorch/backend/iree.py
@@ -34,13 +34,7 @@ class IreeModuleInvoker:
 
     def invoke(*args):
       results = self._iree_module[function_name](*args)
-      if isinstance(results, np.ndarray):
-        return results
-      if len(results) == 1:
-        # De-tuple.
-        return results[0]
-      else:
-        return tuple(results)
+      return results
 
     invoke.__isnpcomp__ = True
     return invoke

--- a/test/Dialect/TorchConversion/annotate-abi.mlir
+++ b/test/Dialect/TorchConversion/annotate-abi.mlir
@@ -1,0 +1,48 @@
+// RUN: npcomp-opt -split-input-file -verify-diagnostics %s -torch-annotate-abi
+
+// -----
+
+// CHECK-LABEL:   builtin.func @basic_arg_and_ret(
+// CHECK-SAME:    attributes {iree.abi = "{\22a\22:[\22f64\22,\22i64\22,\22i1\22],\22r\22:[\22f64\22,\22i64\22,\22i1\22],\22v\22:1}"} {
+builtin.func @basic_arg_and_ret(%arg0: !torch.float, %arg1: !torch.int, %arg2: !torch.bool) -> (!torch.float, !torch.int, !torch.bool) {
+  return %arg0, %arg1, %arg2 : !torch.float, !torch.int, !torch.bool
+}
+
+// -----
+
+// CHECK-LABEL:   builtin.func @list(
+// CHECK-SAME:    attributes {iree.abi = "{\22a\22:{{\[\[}}\22py_uniform_list\22,\22f64\22]],\22r\22:[],\22v\22:1}"} {
+builtin.func @list(%arg0: !torch.list<!torch.float>) {
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   builtin.func @tuple(
+// CHECK-SAME:    attributes {iree.abi = "{\22a\22:{{\[\[}}\22pytuple\22,\22f64\22,\22i64\22]],\22r\22:[],\22v\22:1}"} {
+builtin.func @tuple(%arg0: !torch.tuple<!torch.float, !torch.int>) {
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   builtin.func @dict(
+// CHECK-SAME:    attributes {iree.abi = "{\22a\22:{{\[\[}}\22py_uniform_dict\22,\22pystr\22,\22f64\22]],\22r\22:[],\22v\22:1}"} {
+builtin.func @dict(%arg0: !torch.dict<!torch.str, !torch.float>) {
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   builtin.func @tensor(
+// CHECK-SAME:    attributes {iree.abi = "{\22a\22:{{\[\[}}\22ndarray\22,\22f32\22,2,null,3]],\22r\22:[],\22v\22:1}"} {
+builtin.func @tensor(%arg0: !torch.tensor<[?,3],f32>) {
+  return
+}
+
+// -----
+
+// expected-error @+1 {{at function argument 0: unimplemented: ABI annotation for type '!torch.any'}}
+builtin.func @unsupported(%arg0: !torch.any) {
+  return
+}


### PR DESCRIPTION
This plumbs through a vertical slice of support for lists.

The main chunk of new code here is AnnotateABIPass which captures the
program signature at the Torch backend contract layer, right before we
start `TorchConversion`. The `TorchConversion` lowering process is lossy
w.r.t. types, so it's necessary to do this for all targets in general.
Like using `!iree.list` directly, we use IREE's ABI annotation
representation for this, although there is nothing very IREE-specific
about it (see
https://github.com/google/iree/blob/main/docs/developers/design_docs/function_abi.md)

We change `ListLiteralModule_basic` to use `!torch.int` because IREE
doesn't support f64 yet (and we don't yet have a way for users to say
that they want `!torch.float` to lower as f32).

Recommended review order:
- AnnotateABIPass and tests
- Arg marshaling in npcomp_backend.py and `iree.py`
- Updates to `list_programs.py` / `xfail_sets.py`
- Moving DeleteDeadIREEListsPass to Backend/Common, so that backends
  that don't support lists can use it. RefBackend uses that pass, for
  example.