### PR TITLE
MT model compilation minor changes

### DIFF
--- a/frontends/pytorch/python/torch_mlir_utils/codegen/torch_ods_gen.py
+++ b/frontends/pytorch/python/torch_mlir_utils/codegen/torch_ods_gen.py
@@ -398,7 +398,7 @@ def emit_prim_ops(torch_ir_dir: str, registry: Registry):
         emit("prim::layout : (Tensor) -> (int)")
         emit("prim::TupleIndex : (Any, int) -> (Any)")
         emit("prim::device : (Tensor) -> (Device)")
-        emit("prim::dtype : (Tensor) -> (int)")
+        emit("prim::dtype : (Tensor) -> (int)", has_folder=True)
         emit("prim::TupleUnpack : (Any) -> (...)", has_canonicalizer=True)
         emit("prim::NumToTensor.Scalar : (Scalar) -> (Tensor)")
         emit("prim::min.self_int : (int[]) -> (int)")

--- a/include/npcomp/Dialect/Torch/IR/GeneratedAtenOps.td
+++ b/include/npcomp/Dialect/Torch/IR/GeneratedAtenOps.td
@@ -791,6 +791,40 @@ def Torch_AtenTriu_Op : Torch_Op<"aten.triu_", [
   let assemblyFormat = "$self `,` $diagonal attr-dict `:` type($self) `,` type($diagonal) `->` type($result)";
 }
 
+def Torch_AtenIndexPutOp : Torch_Op<"aten.index_put", [
+    AllowsTypeRefinement,
+    HasValueSemantics
+  ]> {
+  let summary = "Generated op for `aten::index_put : (Tensor, Tensor?[], Tensor, bool) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchOptionalTensorListType:$indices,
+    AnyTorchTensorType:$values,
+    Torch_BoolType:$accumulate
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $indices `,` $values `,` $accumulate attr-dict `:` type($self) `,` type($indices) `,` type($values) `,` type($accumulate) `->` type($result)";
+}
+
+def Torch_AtenIndexPut_Op : Torch_Op<"aten.index_put_", [
+    IsTrailingUnderscoreInplaceVariant,
+    AllowsTypeRefinement
+  ]> {
+  let summary = "Generated op for `aten::index_put_ : (Tensor, Tensor?[], Tensor, bool) -> (Tensor)`";
+  let arguments = (ins
+    AnyTorchTensorType:$self,
+    AnyTorchOptionalTensorListType:$indices,
+    AnyTorchTensorType:$values,
+    Torch_BoolType:$accumulate
+  );
+  let results = (outs
+    AnyTorchTensorType:$result
+  );
+  let assemblyFormat = "$self `,` $indices `,` $values `,` $accumulate attr-dict `:` type($self) `,` type($indices) `,` type($values) `,` type($accumulate) `->` type($result)";
+}
+
 def Torch_AtenLinearOp : Torch_Op<"aten.linear", [
     AllowsTypeRefinement,
     HasValueSemantics
@@ -1402,22 +1436,6 @@ def Torch_AtenIndexTensorOp : Torch_Op<"aten.index.Tensor", [
     AnyTorchTensorType:$result
   );
   let assemblyFormat = "$self `,` $indices attr-dict `:` type($self) `,` type($indices) `->` type($result)";
-}
-
-def Torch_AtenIndexPut_Op : Torch_Op<"aten.index_put_", [
-    AllowsTypeRefinement
-  ]> {
-  let summary = "Generated op for `aten::index_put_ : (Tensor, Tensor?[], Tensor, bool) -> (Tensor)`";
-  let arguments = (ins
-    AnyTorchTensorType:$self,
-    AnyTorchOptionalTensorListType:$indices,
-    AnyTorchTensorType:$values,
-    Torch_BoolType:$accumulate
-  );
-  let results = (outs
-    AnyTorchTensorType:$result
-  );
-  let assemblyFormat = "$self `,` $indices `,` $values `,` $accumulate attr-dict `:` type($self) `,` type($indices) `,` type($values) `,` type($accumulate) `->` type($result)";
 }
 
 def Torch_AtenIndexSelectOp : Torch_Op<"aten.index_select", [

--- a/include/npcomp/Dialect/Torch/IR/GeneratedPrimOps.td
+++ b/include/npcomp/Dialect/Torch/IR/GeneratedPrimOps.td
@@ -70,6 +70,7 @@ def Torch_PrimDtypeOp : Torch_Op<"prim.dtype", [
     Torch_IntType:$result
   );
   let assemblyFormat = "$a attr-dict `:` type($a) `->` type($result)";
+  let hasFolder = 1;
 }
 
 def Torch_PrimTupleUnpackOp : Torch_Op<"prim.TupleUnpack", [

--- a/test/Dialect/Torch/canonicalize.mlir
+++ b/test/Dialect/Torch/canonicalize.mlir
@@ -406,7 +406,6 @@ func @torch.aten.__getitem__.Dict_str(%k0 : !torch.str, %v0: !torch.tensor, %k1:
 // CHECK-LABEL:   func @torch.aten.add.int() -> !torch.int {
 // CHECK:           %[[CST9:.*]] = torch.constant.int 9
 // CHECK:           return %[[CST9]] : !torch.int
-// CHECK:         }
 func @torch.aten.add.int() -> !torch.int {
     %cst4 = torch.constant.int 4
     %cst5 = torch.constant.int 5
@@ -417,7 +416,6 @@ func @torch.aten.add.int() -> !torch.int {
 // CHECK-LABEL:   func @torch.aten.sub.int() -> !torch.int {
 // CHECK:           %[[CST1:.*]] = torch.constant.int 1
 // CHECK:           return %[[CST1]] : !torch.int
-// CHECK:         }
 func @torch.aten.sub.int() -> !torch.int {
     %cst6 = torch.constant.int 6
     %cst5 = torch.constant.int 5
@@ -428,7 +426,6 @@ func @torch.aten.sub.int() -> !torch.int {
 // CHECK-LABEL:   func @torch.aten.mul.int() -> !torch.int {
 // CHECK:           %[[CST30:.*]] = torch.constant.int 30
 // CHECK:           return %[[CST30]] : !torch.int
-// CHECK:         }
 func @torch.aten.mul.int() -> !torch.int {
     %cst6 = torch.constant.int 6
     %cst5 = torch.constant.int 5
@@ -439,7 +436,6 @@ func @torch.aten.mul.int() -> !torch.int {
 // CHECK-LABEL:   func @torch.aten.mul.int$with_zero() -> !torch.int {
 // CHECK:           %[[CST0:.*]] = torch.constant.int 0
 // CHECK:           return %[[CST0]] : !torch.int
-// CHECK:         }
 func @torch.aten.mul.int$with_zero() -> !torch.int {
     %cst6 = torch.constant.int 6
     %cst0 = torch.constant.int 0
@@ -450,7 +446,6 @@ func @torch.aten.mul.int$with_zero() -> !torch.int {
 // CHECK-LABEL:   func @torch.aten.floordiv.int() -> !torch.int {
 // CHECK:           %[[CST3:.*]] = torch.constant.int 3
 // CHECK:           return %[[CST3]] : !torch.int
-// CHECK:         }
 func @torch.aten.floordiv.int() -> !torch.int {
     %cst18 = torch.constant.int 18
     %cst5 = torch.constant.int 5
@@ -461,10 +456,36 @@ func @torch.aten.floordiv.int() -> !torch.int {
 // CHECK-LABEL:   func @torch.aten.remainder.int() -> !torch.int {
 // CHECK:           %[[CST3:.*]] = torch.constant.int 3
 // CHECK:           return %[[CST3]] : !torch.int
-// CHECK:         }
 func @torch.aten.remainder.int() -> !torch.int {
     %cst18 = torch.constant.int 18
     %cst5 = torch.constant.int 5
     %ret = torch.aten.remainder.int %cst18, %cst5: !torch.int, !torch.int -> !torch.int
+    return %ret : !torch.int
+}
+
+// CHECK-LABEL:   func @torch.prim.dtype$float(
+// CHECK-SAME:             %[[T:.*]]: !torch.tensor<*,f32>) -> !torch.int {
+// CHECK:           %[[CST:.*]] = torch.constant.int 6
+// CHECK:           return %[[CST]] : !torch.int
+func @torch.prim.dtype$float(%t : !torch.tensor<*,f32>) -> !torch.int {
+    %ret = torch.prim.dtype %t: !torch.tensor<*,f32> -> !torch.int
+    return %ret : !torch.int
+}
+
+// CHECK-LABEL:   func @torch.prim.dtype$bool(
+// CHECK-SAME:              %[[T:.*]]: !torch.tensor<*,i1>) -> !torch.int {
+// CHECK:           %[[CST:.*]] = torch.constant.int 11
+// CHECK:           return %[[CST]] : !torch.int
+func @torch.prim.dtype$bool(%t : !torch.tensor<*,i1>) -> !torch.int {
+    %ret = torch.prim.dtype %t: !torch.tensor<*,i1> -> !torch.int
+    return %ret : !torch.int
+}
+
+// CHECK-LABEL:   func @torch.prim.dtype$int64(
+// CHECK-SAME:            %[[T:.*]]: !torch.tensor<*,si64>) -> !torch.int {
+// CHECK:           %[[CST:.*]] = torch.constant.int 4
+// CHECK:           return %[[CST]] : !torch.int
+func @torch.prim.dtype$int64(%t : !torch.tensor<*,si64>) -> !torch.int {
+    %ret = torch.prim.dtype %t: !torch.tensor<*,si64> -> !torch.int
     return %ret : !torch.int
 }


### PR DESCRIPTION
This contains the following changes:
 - Fix optional knowledge propagation. The initial knowledge should
 always be NotNone for the operations we implemented.
 - Add Folder for `prim.dtype`