### PR TITLE
Bring CI back to life.

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -44,12 +44,11 @@ jobs:
           -DPython3_EXECUTABLE=$(which python) \
           -DLLVM_ENABLE_ASSERTIONS=ON \
           -DLLVM_TARGETS_TO_BUILD=host
-        ninja
-        ninja check-npcomp check-frontends-pytorch
+        ninja check-npcomp-all
     - name: Refbackend integration tests
       run: |
         cd $GITHUB_WORKSPACE
-        export PYTHONPATH="$GITHUB_WORKSPACE/build/python_packages/npcomp_core:$GITHUB_WORKSPACE/build/python_packages/npcomp_torch"
+        export PYTHONPATH="$GITHUB_WORKSPACE/build/python_packages/npcomp_core:$GITHUB_WORKSPACE/build/python_packages/npcomp_torch:$GITHUB_WORKSPACE/build/python_packages/torch_mlir:$GITHUB_WORKSPACE/build/python_packages/torch_mlir_dialects"
         python -m frontends.pytorch.e2e_testing.torchscript.main --config=refbackend
 
 #   build_wheels:

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -113,3 +113,5 @@ add_mlir_python_modules(NPCOMPPythonModules
   COMMON_CAPI_LINK_LIBS
     NPCOMPPythonCAPI
 )
+
+add_dependencies(NPCOMPPythonModules NPCOMPPythonResources)


### PR DESCRIPTION
This brings back `check-npcomp-all` and the refbackend e2e tests
coverage.