### PR TITLE
E2e implementation for `aten.cat`,`aten.gather`, `aten.bmm`

### DIFF
--- a/e2e_testing/torchscript/basic.py
+++ b/e2e_testing/torchscript/basic.py
@@ -41,6 +41,28 @@ def MmModule_basic(module, tu: TestUtils):
 #     res = module.forward(tu.rand(4, 4), tu.rand(4, 4))
 #     module.forward(res, res)
 
+# ==============================================================================
+
+
+class BmmModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, lhs, rhs):
+        return torch.bmm(lhs, rhs)
+
+
+@register_test_case(module_factory=lambda: BmmModule())
+def BmmModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3, 4, 5), tu.rand(3, 5, 4))
+
+
 
 # ==============================================================================
 
@@ -203,3 +225,41 @@ class TransposeIntModule(torch.nn.Module):
 @register_test_case(module_factory=lambda: TransposeIntModule())
 def TransposeIntModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3, 4, 2))
+
+
+class TensorsConcatModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x, y, z):
+        return torch.cat([x, y, z], 1)
+
+
+@register_test_case(module_factory=lambda: TensorsConcatModule())
+def TensorsConcatModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 2, 4), tu.rand(2, 1, 4), tu.rand(2, 3, 4))
+
+class GatherModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1], torch.float32, True),
+        ([-1, -1, -1], torch.int64, True),
+    ])
+    def forward(self, tensor, indices):
+        return torch.gather(tensor, 2, indices)
+
+
+#@register_test_case(module_factory=lambda: GatherModule())
+#def GatherModule_basic(module, tu: TestUtils):
+#    module.forward(tu.rand(2, 3, 4), torch.tensor([[[1,2,3],[1,2,3]]]))

--- a/external/torch-mlir/include/torch-mlir-c/TorchTypes.h
+++ b/external/torch-mlir/include/torch-mlir-c/TorchTypes.h
@@ -144,9 +144,9 @@ MLIR_CAPI_EXPORTED MlirType
 torchMlirTorchNonValueTensorTypeGetWithLeastStaticInformation(
     MlirContext context);
 
-/// Gets a !torch.tensor type, taking shape/dtype from a ShapedType `type`.
+/// Gets the !torch.tensor type with the tensor attribute.
 MLIR_CAPI_EXPORTED MlirType
-torchMlirTorchNonValueTensorTypeGetFromShaped(MlirType type);
+torchMlirTorchNonValueTensorTypeGetFromAttribute(MlirAttribute attr);
 
 //===----------------------------------------------------------------------===//
 // torch.vtensor type.
@@ -168,10 +168,6 @@ MLIR_CAPI_EXPORTED MlirType torchMlirTorchValueTensorTypeGet(
 /// Gets the !torch.tensor type with the least static information.
 MLIR_CAPI_EXPORTED MlirType
 torchMlirTorchValueTensorTypeGetWithLeastStaticInformation(MlirContext context);
-
-/// Gets a !torch.tensor type, taking shape/dtype from a ShapedType `type`.
-MLIR_CAPI_EXPORTED MlirType
-torchMlirTorchValueTensorTypeGetFromShaped(MlirType type);
 
 //===----------------------------------------------------------------------===//
 // !torch.none type.

--- a/external/torch-mlir/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
+++ b/external/torch-mlir/include/torch-mlir/Dialect/Torch/IR/TorchOps.td
@@ -647,8 +647,6 @@ def Torch_DerefineOp : Torch_Op<"derefine", [
   let assemblyFormat = [{
     $operand attr-dict `:` type($operand) `to` type($result)
   }];
-
-  let hasCanonicalizer = 1;
 }
 
 def Torch_OperatorOp : Torch_Op<"operator", [

--- a/external/torch-mlir/include/torch-mlir/Dialect/Torch/IR/TorchTypes.td
+++ b/external/torch-mlir/include/torch-mlir/Dialect/Torch/IR/TorchTypes.td
@@ -189,8 +189,6 @@ def Torch_NonValueTensorType : AnyTorchTensorType<"NonValueTensor", "tensor"> {
     ValueTensorType getWithValueSemantics() const;
     // Get the !torch.tensor type with the least static information.
     static NonValueTensorType getWithLeastStaticInformation(MLIRContext *context);
-    // Get a NonValueTensorType with shape/dtype matching `type`.
-    static NonValueTensorType getFromShaped(ShapedType type);
   }];
 }
 
@@ -200,8 +198,6 @@ def Torch_ValueTensorType : AnyTorchTensorType<"ValueTensor", "vtensor"> {
     NonValueTensorType getWithoutValueSemantics() const;
     // Get the !torch.tensor type with the least static information.
     static ValueTensorType getWithLeastStaticInformation(MLIRContext *context);
-    // Get a NonValueTensorType with shape/dtype matching `type`.
-    static ValueTensorType getFromShaped(ShapedType type);
     // Get the builtin tensor type with the same static information as this one,
     // or nullptr if that is not possible (i.e. when the dtype is unknown).
     TensorType toBuiltinTensor() const;

--- a/external/torch-mlir/lib/CAPI/TorchTypes.cpp
+++ b/external/torch-mlir/lib/CAPI/TorchTypes.cpp
@@ -168,9 +168,11 @@ MlirType torchMlirTorchNonValueTensorTypeGetWithLeastStaticInformation(
       unwrap(context)));
 }
 
-MlirType torchMlirTorchNonValueTensorTypeGetFromShaped(MlirType type) {
-  return wrap(Torch::NonValueTensorType::getFromShaped(
-      unwrap(type).cast<ShapedType>()));
+MlirType torchMlirTorchNonValueTensorTypeGetFromAttribute(MlirAttribute attr) {
+  auto attrTensorType = unwrap(attr).getType().cast<RankedTensorType>();
+  return wrap(Torch::NonValueTensorType::get(attrTensorType.getContext(),
+                                             attrTensorType.getShape(),
+                                             attrTensorType.getElementType()));
 }
 
 //===----------------------------------------------------------------------===//
@@ -196,11 +198,6 @@ MlirType torchMlirTorchValueTensorTypeGetWithLeastStaticInformation(
     MlirContext context) {
   return wrap(
       Torch::ValueTensorType::getWithLeastStaticInformation(unwrap(context)));
-}
-
-MlirType torchMlirTorchValueTensorTypeGetFromShaped(MlirType type) {
-  return wrap(
-      Torch::ValueTensorType::getFromShaped(unwrap(type).cast<ShapedType>()));
 }
 
 //===----------------------------------------------------------------------===//

--- a/external/torch-mlir/lib/Dialect/Torch/Transforms/RefineTypes.cpp
+++ b/external/torch-mlir/lib/Dialect/Torch/Transforms/RefineTypes.cpp
@@ -1057,6 +1057,7 @@ ChangeResult TypeAnalyzer::visitAtenBmmOp(
   auto mat2 = operands[1]->getValue();
   knowledge.sizes.resize(3, kUnknownSize);
   knowledge.dtype = joinElementTypes(self.dtype, mat2.dtype);
+  knowledge.hasSizes = true;
   return getLatticeElement(op->getResult(0)).join(knowledge);
 }
 

--- a/external/torch-mlir/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/ivalue_importer.cpp
+++ b/external/torch-mlir/python/torch_mlir/dialects/torch/importer/jit_ir/csrc/ivalue_importer.cpp
@@ -363,11 +363,11 @@ MlirValue IValueImporter::importTensor(c10::IValue ivalue) {
   // Import the bulk tensor representation.
   at::Tensor tensor = ivalue.toTensor().contiguous();
   MlirAttribute denseElements = convertTensorToMlirElementsAttr(tensor, loc);
-  MlirOperation tensorOp =
-      createMlirOperationAtEnd(importBlock, "torch.tensor.literal", loc,
-                               torchMlirTorchNonValueTensorTypeGetFromShaped(
-                                   mlirAttributeGetType(denseElements)),
-                               toMlirNamedAttribute("value", denseElements));
+
+  MlirOperation tensorOp = createMlirOperationAtEnd(
+      importBlock, "torch.tensor.literal", loc,
+      torchMlirTorchNonValueTensorTypeGetFromAttribute(denseElements),
+      toMlirNamedAttribute("value", denseElements));
   MlirValue tensorReprValue = mlirOperationGetResult(tensorOp, 0);
 
   // Construct the complete tensor value. This is trivial for most tensors, but

--- a/external/torch-mlir/test/Dialect/Torch/reduce-op-variants-error.mlir
+++ b/external/torch-mlir/test/Dialect/Torch/reduce-op-variants-error.mlir
@@ -1,0 +1,26 @@
+// RUN: torch-mlir-opt -torch-reduce-op-variants  -verify-diagnostics -split-input-file %s
+
+// -----
+
+func @convert_to_value_semantic_tensors_list( %list: !torch.list<!torch.tensor>) -> !torch.tensor {
+  %int1 = torch.constant.int 1
+  // expected-error@+1 {{failed to legalize operation 'torch.aten.cat' that was explicitly marked illegal}}
+  %ret = torch.aten.cat %list, %int1 : !torch.list<!torch.tensor>, !torch.int -> !torch.tensor
+  return %ret : !torch.tensor
+}
+
+// -----
+
+func @convert_to_value_semantic_tensors_optional(%tensor_optional: !torch.optional<!torch.tensor>,
+                                                 %t: !torch.tensor,
+                                                 %training: !torch.bool,
+                                                 %cudnn_enable: !torch.bool,
+                                                 %f : !torch.float) -> !torch.tensor {
+    // expected-error@+1 {{failed to legalize operation 'torch.aten.batch_norm' that was explicitly marked illegal}}
+    %ret = torch.aten.batch_norm %t, %tensor_optional, %tensor_optional, %tensor_optional,
+              %tensor_optional, %training, %f, %f, %cudnn_enable:
+              !torch.tensor, !torch.optional<!torch.tensor>, !torch.optional<!torch.tensor>,
+              !torch.optional<!torch.tensor>, !torch.optional<!torch.tensor>,
+              !torch.bool, !torch.float, !torch.float, !torch.bool -> !torch.tensor
+    return %ret: !torch.tensor
+}

--- a/external/torch-mlir/test/Dialect/Torch/reduce-op-variants.mlir
+++ b/external/torch-mlir/test/Dialect/Torch/reduce-op-variants.mlir
@@ -11,6 +11,77 @@ func @convert_to_value_semantic_tensors(%arg0: !torch.tensor<[],f32>) -> !torch.
   return %0 : !torch.tensor<[],f32>
 }
 
+// CHECK-LABEL:   func @convert_to_value_semantic_tensors_list(
+// CHECK-SAME:                  %[[VT0:.*]]: !torch.vtensor, %[[VT1:.*]]: !torch.vtensor,
+// CHECK-SAME:                  %[[VT2:.*]]: !torch.vtensor) -> !torch.tensor {
+// CHECK:           %[[T0:.*]] = torch.copy.to_tensor %[[VT0]] : !torch.tensor
+// CHECK:           %[[T1:.*]] = torch.copy.to_tensor %[[VT1]] : !torch.tensor
+// CHECK:           %[[T2:.*]] = torch.copy.to_tensor %[[VT2]] : !torch.tensor
+// CHECK:           %[[DIM:.*]] = torch.constant.int 1
+// CHECK:           %[[LIST_ORIG:.*]] = torch.prim.ListConstruct %[[T0]], %[[T1]], %[[T2]] :
+// CHECK-SAME:          (!torch.tensor, !torch.tensor, !torch.tensor) -> !torch.list<!torch.tensor>
+// CHECK:           %[[VT0_COPY:.*]] = torch.copy.to_vtensor %[[T0]] : !torch.vtensor
+// CHECK:           %[[VT1_COPY:.*]] = torch.copy.to_vtensor %[[T1]] : !torch.vtensor
+// CHECK:           %[[VT2_COPY:.*]] = torch.copy.to_vtensor %[[T2]] : !torch.vtensor
+// CHECK:           %[[LIST_NEW:.*]] = torch.prim.ListConstruct
+// CHECK-SAME:          %[[VT0_COPY]], %[[VT1_COPY]], %[[VT2_COPY]] :
+// CHECK-SAME:          (!torch.vtensor, !torch.vtensor, !torch.vtensor) -> !torch.list<!torch.vtensor>
+// CHECK:           %[[VRET:.*]] = torch.aten.cat %[[LIST_NEW]], %[[DIM]] :
+// CHECK-SAME:          !torch.list<!torch.vtensor>, !torch.int -> !torch.vtensor
+// CHECK:           %[[RET:.*]] = torch.copy.to_tensor %[[VRET]] : !torch.tensor
+// CHECK:           return %[[RET]] : !torch.tensor
+func @convert_to_value_semantic_tensors_list(%vt0: !torch.vtensor, %vt1: !torch.vtensor, %vt2: !torch.vtensor) -> !torch.tensor {
+  %t0 = torch.copy.to_tensor %vt0 : !torch.tensor
+  %t1 = torch.copy.to_tensor %vt1 : !torch.tensor
+  %t2 = torch.copy.to_tensor %vt2 : !torch.tensor
+  %int1 = torch.constant.int 1
+  %list = torch.prim.ListConstruct %t0, %t1, %t2 : (!torch.tensor, !torch.tensor, !torch.tensor) -> !torch.list<!torch.tensor>
+  %ret = torch.aten.cat %list, %int1 : !torch.list<!torch.tensor>, !torch.int -> !torch.tensor
+  return %ret : !torch.tensor
+}
+
+// CHECK-LABEL:   func @convert_to_value_semantic_tensors_optional(
+// CHECK-SAME:         %[[INPUT:.*]]: !torch.tensor, %[[FLOAT_TENSOR:.*]]: !torch.tensor<[4],f32>,
+// CHECK-SAME:         %[[TRAINING:.*]]: !torch.bool, %[[CUDNN_ENABLE:.*]]: !torch.bool,
+// CHECK-SAME:         %[[FLOAT:.*]]: !torch.float) -> !torch.tensor {
+// CHECK:           %[[NONE:.*]] = torch.constant.none
+// CHECK:           %[[FLOAT_TENSOR_OPTIONAL:.*]] = torch.derefine %[[FLOAT_TENSOR]] :
+// CHECK-SAME:         !torch.tensor<[4],f32> to !torch.optional<!torch.tensor>
+// CHECK:           %[[BIAS_NONE_OPTIONAL:.*]] = torch.derefine %[[NONE]] : !torch.none to !torch.optional<!torch.tensor>
+// CHECK:           %[[VINPUT:.*]] = torch.copy.to_vtensor %[[INPUT]] : !torch.vtensor
+// CHECK:           %[[FLOAT_VTENSOR:.*]] = torch.copy.to_vtensor %[[FLOAT_TENSOR]] : !torch.vtensor<[4],f32>
+// CHECK:           %[[WEIGHTS_TENSOR_OPTIONAL:.*]] = torch.derefine %[[FLOAT_VTENSOR]] :
+// CHECK-SAME:         !torch.vtensor<[4],f32> to !torch.optional<!torch.vtensor<[4],f32>>
+// CHECK:           %[[FLOAT_VTENSOR:.*]] = torch.copy.to_vtensor %[[FLOAT_TENSOR]] : !torch.vtensor<[4],f32>
+// CHECK:           %[[MEAN_VTENSOR_OPTIONAL:.*]] = torch.derefine %[[FLOAT_VTENSOR]] :
+// CHECK-SAME:         !torch.vtensor<[4],f32> to !torch.optional<!torch.vtensor<[4],f32>>
+// CHECK:           %[[FLOAT_VTENSOR:.*]] = torch.copy.to_vtensor %[[FLOAT_TENSOR]] : !torch.vtensor<[4],f32>
+// CHECK:           %[[VAR_VTENSOR_OPTIONAL:.*]] = torch.derefine %[[FLOAT_VTENSOR]] :
+// CHECK-SAME:         !torch.vtensor<[4],f32> to !torch.optional<!torch.vtensor<[4],f32>>
+// CHECK:           %[[VRET:.*]] = torch.aten.batch_norm %[[VINPUT]], %[[WEIGHTS_TENSOR_OPTIONAL]],
+// CHECK-SAME:         %[[BIAS_NONE_OPTIONAL]], %[[MEAN_VTENSOR_OPTIONAL]], %[[VAR_VTENSOR_OPTIONAL]],
+// CHECK-SAME:         %[[TRAINING]], %[[FLOAT]], %[[FLOAT]], %[[CUDNN_ENABLE]] :
+// CHECK-SAME:         !torch.vtensor, !torch.optional<!torch.vtensor<[4],f32>>, !torch.optional<!torch.tensor>,
+// CHECK-SAME:         !torch.optional<!torch.vtensor<[4],f32>>, !torch.optional<!torch.vtensor<[4],f32>>,
+// CHECK-SAME:         !torch.bool, !torch.float, !torch.float, !torch.bool -> !torch.vtensor
+// CHECK:           %[[RET:.*]] = torch.copy.to_tensor %[[VRET]] : !torch.tensor
+// CHECK:           return %[[RET]] : !torch.tensor
+// CHECK:         }
+func @convert_to_value_semantic_tensors_optional(%t: !torch.tensor,
+                                                 %ft: !torch.tensor<[4],f32>,
+                                                 %training: !torch.bool,
+                                                 %cudnn_enable: !torch.bool,
+                                                 %f : !torch.float) -> !torch.tensor {
+    %none = torch.constant.none
+    %tensor_optional = torch.derefine %ft: !torch.tensor<[4],f32> to !torch.optional<!torch.tensor>
+    %none_optional = torch.derefine %none : !torch.none to !torch.optional<!torch.tensor>
+    %ret = torch.aten.batch_norm %t, %tensor_optional, %none_optional, %tensor_optional,
+              %tensor_optional, %training, %f, %f, %cudnn_enable:
+              !torch.tensor, !torch.optional<!torch.tensor>, !torch.optional<!torch.tensor>,
+              !torch.optional<!torch.tensor>, !torch.optional<!torch.tensor>,
+              !torch.bool, !torch.float, !torch.float, !torch.bool -> !torch.tensor
+    return %ret: !torch.tensor
+}
 
 // CHECK-LABEL:   func @reduce_trailing_underscore_inplace_variant(
 // CHECK-SAME:                          %[[ARG0:.*]]: !torch.tensor<[2,2],f32>,

--- a/include/npcomp/Dialect/TorchConversion/IR/TorchConversionOps.td
+++ b/include/npcomp/Dialect/TorchConversion/IR/TorchConversionOps.td
@@ -44,9 +44,8 @@ def TorchConversion_ToBuiltinTensorOp : TorchConversion_Op<"to_builtin_tensor", 
   }];
 }
 
-def TorchConversion_FromBuiltinTensorOp : TorchConversion_Op<"from_builtin_tensor", [
-    DeclareOpInterfaceMethods<InferTypeOpInterface>
-  ]> {
+def TorchConversion_FromBuiltinTensorOp : TorchConversion_Op<"from_builtin_tensor">
+ {
   let summary = "Convert a `tensor` to a `!torch.vtensor`";
   let description = [{
     This op only operates on ValueTensorType, to avoid conflating conversions

--- a/lib/Dialect/TorchConversion/IR/TorchConversionOps.cpp
+++ b/lib/Dialect/TorchConversion/IR/TorchConversionOps.cpp
@@ -36,18 +36,5 @@ LogicalResult ToBuiltinTensorOp::inferReturnTypes(
   return success();
 }
 
-//===----------------------------------------------------------------------===//
-// FromBuiltinTensorOp
-//===----------------------------------------------------------------------===//
-
-LogicalResult FromBuiltinTensorOp::inferReturnTypes(
-    MLIRContext *context, Optional<Location> location, ValueRange operands,
-    DictionaryAttr attributes, RegionRange regions,
-    SmallVectorImpl<Type> &inferredReturnTypes) {
-  inferredReturnTypes.push_back(Torch::ValueTensorType::getFromShaped(
-      operands[0].getType().cast<TensorType>()));
-  return success();
-}
-
 #define GET_OP_CLASSES
 #include "npcomp/Dialect/TorchConversion/IR/TorchConversionOps.cpp.inc"

--- a/lib/Dialect/TorchConversion/Transforms/BackendTypeConversion.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/BackendTypeConversion.cpp
@@ -55,7 +55,7 @@ setupValueTensorToBuiltinTensorConversion(ConversionTarget &target,
                                   ValueRange inputs, Location loc) -> Value {
     assert(inputs.size() == 1);
     assert(inputs[0].getType().isa<TensorType>());
-    return builder.create<FromBuiltinTensorOp>(loc, inputs[0]);
+    return builder.create<FromBuiltinTensorOp>(loc, type, inputs[0]);
   };
   typeConverter.addSourceMaterialization(sourceMaterialization);
   typeConverter.addArgumentMaterialization(sourceMaterialization);

--- a/test/Dialect/TorchConversion/ops.mlir
+++ b/test/Dialect/TorchConversion/ops.mlir
@@ -1,14 +1,16 @@
 // RUN: npcomp-opt %s | npcomp-opt | FileCheck %s
 
 // CHECK-LABEL: func @builtin_tensor_interop(
-func @builtin_tensor_interop(%arg0: tensor<*xf32>, %arg1: tensor<3x?xsi8>, %arg2: !torch.vtensor<*,f32>, %arg3: !torch.vtensor<[3,?],si8>) {
+func @builtin_tensor_interop(%arg0: tensor<*xf32>, %arg1: tensor<3x?xi8>, %arg2: !torch.vtensor<*,f32>, %arg3: !torch.vtensor<[3,?],si8>) {
   // CHECK: torch_c.from_builtin_tensor %arg0 : tensor<*xf32> -> !torch.vtensor<*,f32>
   %0 = torch_c.from_builtin_tensor %arg0 : tensor<*xf32> -> !torch.vtensor<*,f32>
-  // CHECK: torch_c.from_builtin_tensor %arg1 : tensor<3x?xsi8> -> !torch.vtensor<[3,?],si8>
-  %1 = torch_c.from_builtin_tensor %arg1 : tensor<3x?xsi8> -> !torch.vtensor<[3,?],si8>
+  // CHECK: torch_c.from_builtin_tensor %arg1 : tensor<3x?xi8> -> !torch.vtensor<[3,?],si8>
+  %1 = torch_c.from_builtin_tensor %arg1 : tensor<3x?xi8> -> !torch.vtensor<[3,?],si8>
+  // CHECK: torch_c.from_builtin_tensor %arg1 : tensor<3x?xi8> -> !torch.vtensor<[3,?],ui8>
+  %2 = torch_c.from_builtin_tensor %arg1 : tensor<3x?xi8> -> !torch.vtensor<[3,?],ui8>
   // CHECK: torch_c.to_builtin_tensor %arg2 : !torch.vtensor<*,f32> -> tensor<*xf32>
-  %2 = torch_c.to_builtin_tensor %arg2 : !torch.vtensor<*,f32> -> tensor<*xf32>
-  // CHECK: torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[3,?],si8> -> tensor<3x?xsi8>
-  %3 = torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[3,?],si8> -> tensor<3x?xsi8>
+  %3 = torch_c.to_builtin_tensor %arg2 : !torch.vtensor<*,f32> -> tensor<*xf32>
+  // CHECK: torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[3,?],si8> -> tensor<3x?xi8>
+  %4 = torch_c.to_builtin_tensor %arg3 : !torch.vtensor<[3,?],si8> -> tensor<3x?xi8>
   return
 }


### PR DESCRIPTION
Also contain the following changes:
- Remove derefineOp canonicalizer because it's not safe.
- i64 dtype tensor arguement support for refbackend.
- Support for optional tensor and list tensors in reduceOpVariant. This
only works for some special detected and easy to handle cases. For list,
it covers the case list is got from a `ListConstruct`. For optional, it
covers the case optional is constructed from a `DerefineOp`.
- Remove the `inferReturnTypes` for `FromBuiltinTensorOp` because it's
not safe to deduce types from the input. For example, a built-in tensor
of i8 could be converted to si8 or ui8. It's better to let the user
specify the return type explicitly. Also, delete the `getFromShaped` from
{Non,}ValueTensorType. 