### PR TITLE
Remove "refjit" terminology.

### DIFF
--- a/e2e_testing/torchscript/main.py
+++ b/e2e_testing/torchscript/main.py
@@ -21,7 +21,7 @@ from npcomp.compiler.pytorch.backend import is_iree_enabled
 IREE_ENABLED = is_iree_enabled()
 if IREE_ENABLED:
     from npcomp.compiler.pytorch.backend.iree import IreeNpcompBackend
-from npcomp.compiler.pytorch.backend.refjit import RefjitNpcompBackend
+from npcomp.compiler.pytorch.backend.refbackend import RefBackendNpcompBackend
 
 from .xfail_sets import XFAIL_SETS
 
@@ -75,7 +75,7 @@ def main():
 
     # Find the selected config.
     if args.config == 'refbackend':
-        config = NpcompBackendTestConfig(RefjitNpcompBackend())
+        config = NpcompBackendTestConfig(RefBackendNpcompBackend())
     elif args.config == 'iree':
         config = NpcompBackendTestConfig(IreeNpcompBackend())
     elif args.config == 'native_torch':

--- a/examples/torchfx/examples/example_add_tanh_sigmoid.py
+++ b/examples/torchfx/examples/example_add_tanh_sigmoid.py
@@ -5,7 +5,7 @@
 import torch
 from torch.fx.experimental.fx_acc import acc_tracer
 import npcomp
-from npcomp.compiler.pytorch.backend import refjit
+from npcomp.compiler.pytorch.backend import refbackend
 from npcomp.passmanager import PassManager
 
 from torchfx2iree.builder import build_module
@@ -43,7 +43,7 @@ pm.run(lowered_mlir_module)
 print("\n\nLOWERED MLIR")
 lowered_mlir_module.dump()
 
-backend = refjit.RefjitNpcompBackend()
+backend = refbackend.RefBackendNpcompBackend()
 compiled = backend.compile(lowered_mlir_module)
 jit_module = backend.load(compiled)
 

--- a/examples/torchscript_resnet18_e2e.py
+++ b/examples/torchscript_resnet18_e2e.py
@@ -13,7 +13,7 @@ import torch_mlir
 
 import npcomp
 from npcomp.passmanager import PassManager
-from npcomp.compiler.pytorch.backend import refjit, iree
+from npcomp.compiler.pytorch.backend import refbackend, iree
 from npcomp.compiler.utils import logging
 
 mb = torch_mlir.ModuleBuilder()
@@ -109,7 +109,7 @@ class_annotator.annotateArgs(
 # TODO: Automatically handle unpacking Python class RecursiveScriptModule into the underlying ScriptModule.
 mb.import_module(recursivescriptmodule._c, class_annotator)
 
-backend = refjit.RefjitNpcompBackend()
+backend = refbackend.RefBackendNpcompBackend()
 PassManager.parse("torchscript-to-npcomp-backend-pipeline").run(mb.module)
 compiled = backend.compile(mb.module)
 jit_module = backend.load(compiled)

--- a/python/NpcompModule.h
+++ b/python/NpcompModule.h
@@ -14,8 +14,8 @@
 namespace npcomp {
 namespace python {
 
-/// Defines an "refjit" module with backend support definitions.
-void defineBackendRefJitModule(py::module &m);
+/// Defines an "refbackend" module with backend support definitions.
+void defineBackendrefbackendModule(py::module &m);
 
 } // namespace python
 } // namespace npcomp

--- a/python/npcomp/compiler/pytorch/backend/refbackend.py
+++ b/python/npcomp/compiler/pytorch/backend/refbackend.py
@@ -16,7 +16,7 @@ import torch_mlir.dialects.torch
 from .abc import NpcompBackend
 
 __all__ = [
-    "RefjitNpcompBackend",
+    "RefBackendNpcompBackend",
 ]
 
 
@@ -74,7 +74,7 @@ LOWERING_PIPELINE = ",".join([
 ])
 
 
-class RefjitNpcompBackend(NpcompBackend):
+class RefBackendNpcompBackend(NpcompBackend):
     """Main entry-point for the backend."""
 
     def __init__(self):

--- a/python/torch_support/npcomp_torchscript_e2e_test_configs/npcomp_backend.py
+++ b/python/torch_support/npcomp_torchscript_e2e_test_configs/npcomp_backend.py
@@ -15,7 +15,7 @@ from torch_mlir.dialects.torch.importer.jit_ir import ClassAnnotator, ModuleBuil
 from torch_mlir.dialects.torch.importer.jit_ir.torchscript_annotations import extract_annotations
 import npcomp
 from npcomp.passmanager import PassManager
-from npcomp.compiler.pytorch.backend import refjit
+from npcomp.compiler.pytorch.backend import refbackend
 from npcomp.compiler.pytorch.backend.abc import NpcompBackend
 from npcomp_torchscript.e2e_test.framework import TestConfig, Trace, TraceItem
 


### PR DESCRIPTION
We now use RefBackend/refbackend consistently.